### PR TITLE
replace 'and' with '&&' and 'or' with '||' in C++

### DIFF
--- a/source/digits_hits/include/GateTrajectory.hh
+++ b/source/digits_hits/include/GateTrajectory.hh
@@ -71,7 +71,7 @@ class GateTrajectory : public G4VTrajectory
    virtual G4ThreeVector GetInitialMomentum() const = 0;
 
    virtual void ShowTrajectory(std::ostream&) const;
-#if (G4VERSION_MAJOR == 10 and G4VERSION_MINOR == 0)
+#if (G4VERSION_MAJOR == 10 && G4VERSION_MINOR == 0)
    virtual void DrawTrajectory(G4int i_mode =0) const;
 #else
   virtual void DrawTrajectory() const;

--- a/source/digits_hits/src/GateActorManager.cc
+++ b/source/digits_hits/src/GateActorManager.cc
@@ -77,7 +77,7 @@ GateVActor*  GateActorManager::GetActor(const G4String &actorType, const G4Strin
 {
   for (std::vector<GateVActor*>::const_iterator iter=theListOfActors.begin(); iter!=theListOfActors.end(); iter++) {
     GateVActor *actor = *iter;
-    if (actor->GetName()==actorName and actor->GetTypeName()==actorType) return actor;
+    if (actor->GetName()==actorName && actor->GetTypeName()==actorType) return actor;
   }
   return NULL;
 }

--- a/source/digits_hits/src/GateMaterialMuHandler.cc
+++ b/source/digits_hits/src/GateMaterialMuHandler.cc
@@ -117,7 +117,7 @@ void GateMaterialMuHandler::Initialize()
   {
     SimulateMaterialTable();
   }
-  else if(mDatabaseName == "NIST" or mDatabaseName == "EPDL")
+  else if(mDatabaseName == "NIST" || mDatabaseName == "EPDL")
   {
     InitElementTable();
     
@@ -431,7 +431,7 @@ void GateMaterialMuHandler::SimulateMaterialTable()
 	int initialShotNumberPE = int(initialShotNumber / 2);
 
 	int variableShotNumberPE = 0;
-	if(modelPE and isFluoActive) { variableShotNumberPE = initialShotNumberPE; }
+	if(modelPE && isFluoActive) { variableShotNumberPE = initialShotNumberPE; }
 
 	int variableShotNumberCS = 0;
 	if(modelCS) { variableShotNumberCS = initialShotNumber - variableShotNumberPE; }
@@ -479,7 +479,7 @@ void GateMaterialMuHandler::SimulateMaterialTable()
 	  squaredSigmaMuen = (squaredSigmaPE + squaredSigmaCS) / (incidentEnergy * incidentEnergy);
 	  precision = sqrt(squaredSigmaMuen) / muen;
 
-	  if(modelPE and isFluoActive) {
+	  if(modelPE && isFluoActive) {
 	    if(squaredSigmaPE > 0) { variableShotNumberPE = (int)floor(0.5 + double(initialShotNumber) * sqrt(squaredSigmaPE / (squaredSigmaPE + squaredSigmaCS))); }
 	    else { variableShotNumberPE = initialShotNumberPE; }
 	  }
@@ -572,7 +572,7 @@ void GateMaterialMuHandler::ConstructEnergyList(std::vector<MuStorageStruct> *mu
 	unsigned int elementToErase = -1;
 	for(unsigned int e=0; e<muStorage->size(); e++)
 	{
-	  if(((*muStorage)[e].energy > infEnergy) and ((*muStorage)[e].energy < supEnergy))
+	  if(((*muStorage)[e].energy > infEnergy) && ((*muStorage)[e].energy < supEnergy))
 	  {
 	    elementToErase = e;
 	    break;
@@ -598,7 +598,7 @@ void GateMaterialMuHandler::MergeAtomicShell(std::vector<MuStorageStruct> *muSto
     if(isAtomicShell != 0)
     {
       int neighbourIndex = e + isAtomicShell;
-      if((neighbourIndex > -1) and (neighbourIndex < (int)muStorage->size()))
+      if((neighbourIndex > -1) && (neighbourIndex < (int)muStorage->size()))
       {
 	double mu = interpolation((*muStorage)[neighbourIndex].energy,
 				  (*muStorage)[e].energy,

--- a/source/digits_hits/src/GateSETLEDoseActor.cc
+++ b/source/digits_hits/src/GateSETLEDoseActor.cc
@@ -608,7 +608,7 @@ bool GateSETLEDoseActor::IntersectionBox(G4ThreeVector p, G4ThreeVector m)
   for(int i=0; i<3; i++)
   {
     if(mRayDirection[i] == 0.0) {
-      if(mRayOrigin[i]<mBoxMin[i] or mRayOrigin[i]>mBoxMax[i]) { return false; }
+      if(mRayOrigin[i]<mBoxMin[i] || mRayOrigin[i]>mBoxMax[i]) { return false; }
     }
 
     T1 = (mBoxMin[i] - mRayOrigin[i]) / mRayDirection[i];

--- a/source/digits_hits/src/GateSETLEMultiplicityActor.cc
+++ b/source/digits_hits/src/GateSETLEMultiplicityActor.cc
@@ -65,7 +65,7 @@ void GateSETLEMultiplicityActor::Construct()
   EnablePostUserTrackingAction(true);
   EnableUserSteppingAction(true);
     
-  if((mDefaultPrimaryMultiplicity<0) or (mDefaultSecondaryMultiplicity<0)) {
+  if((mDefaultPrimaryMultiplicity<0) || (mDefaultSecondaryMultiplicity<0)) {
     GateError("Multiplicity cannot be inferior to 0 (Mprim = " << mDefaultPrimaryMultiplicity << ", Msec = " << mDefaultSecondaryMultiplicity << ")");
   }
 }

--- a/source/digits_hits/src/GateTrajectory.cc
+++ b/source/digits_hits/src/GateTrajectory.cc
@@ -98,7 +98,7 @@ void GateTrajectory::ShowTrajectory(std::ostream& os) const
    }
 }
 
-#if (G4VERSION_MAJOR == 10 and G4VERSION_MINOR == 0)
+#if (G4VERSION_MAJOR == 10 && G4VERSION_MINOR == 0)
   void GateTrajectory::DrawTrajectory(G4int /*i_mode =0*/) const
 #else
   void GateTrajectory::DrawTrajectory() const

--- a/source/geometry/src/GateDMapdt_sedt.cc
+++ b/source/geometry/src/GateDMapdt_sedt.cc
@@ -64,9 +64,9 @@ inline void phaseSaitoX_1D(const Vol &V, Longvol &sdt_x, const bool isMultiregio
   //TORIC Case We look for a min index
   index = 0;
 
-  if (not(isMultiregion))
+  if (!(isMultiregion))
     {
-      while ((int)index < V.sizeX() and (V(index,y,z) != 0))
+      while ((int)index < V.sizeX() && (V(index,y,z) != 0))
         {
 	  sdt_x(index,y,z)=INFTY;
 	  index++;
@@ -88,7 +88,7 @@ inline void phaseSaitoX_1D(const Vol &V, Longvol &sdt_x, const bool isMultiregio
 
       for (unsigned int x = 1; x < bound; x++)
         {
-	  if (not (isMultiregion))
+	  if (!(isMultiregion))
             {
 	      if (V(cpt,y,z) == 0)
 		sdt_x(cpt,y,z) = 0;
@@ -114,7 +114,7 @@ inline void phaseSaitoX_1D(const Vol &V, Longvol &sdt_x, const bool isMultiregio
 	sdt_x(V.sizeX()-1,y,z) = 0;
 
       //Backward scan
-      if (not(isToric))
+      if (!(isToric))
 	cpt = V.sizeX()-2;
       else
 	cpt = (index + V.sizeX()-1) % V.sizeX();

--- a/source/physics/src/GateVSource.cc
+++ b/source/physics/src/GateVSource.cc
@@ -454,7 +454,7 @@ G4int GateVSource::GeneratePrimaries( G4Event* event )
     {
       if (GetType() == G4String("backtoback"))    { GeneratePrimariesForBackToBackSource(event); }
       else if (GetType() == G4String("fastI124")) { GeneratePrimariesForFastI124Source(event); }
-      else if ((GetType() == G4String("")) or (GetType() == G4String("gps"))) {
+      else if ((GetType() == G4String("")) || (GetType() == G4String("gps"))) {
         // decay time for ions inside the timeSlice controlled here and not by RDM
         // NB: temporary: secondary ions of the decay chain not properly treated
         SetParticleTime( m_time );


### PR DESCRIPTION
Gate uses some weird C++ code for boolean operations that doesn't compile with Visual Studio. I would like to request changing the code to use '!', '&&', '||' as opposed to 'not', 'and', 'or'. 