### PR TITLE
Fix the use of IAEA phase space files

### DIFF
--- a/source/general/include/GateIAEAConfig.h
+++ b/source/general/include/GateIAEAConfig.h
@@ -25,7 +25,10 @@ typedef float  IAEA_Float;
 #endif
 
 typedef short IAEA_I16;
-typedef long  IAEA_I32; // RCN changed to long to allow storage of EGS LATCH, Dec. 2006 
+//typedef long  IAEA_I32; // RCN changed to long to allow storage of EGS LATCH, Dec. 2006 
+typedef  int  IAEA_I32;    // Changed back on April 2011, following Daniel OBrien's comments
+                           // It also corresponds to EGSnrc definition (see egs_config1.h file)
+
 #ifdef WIN32
 typedef __int64 IAEA_I64;
 #else

--- a/source/physics/src/GateSourcePhaseSpace.cc
+++ b/source/physics/src/GateSourcePhaseSpace.cc
@@ -256,8 +256,7 @@ void GateSourcePhaseSpace::GenerateIAEAVertex( G4Event* /*aEvent*/ )
 
   dx = pIAEARecordType->u;
   dy = pIAEARecordType->v;
-  dz = sqrt(1. - dx*dx - dy*dy );
-  dz *= pIAEARecordType->w;
+  dz = pIAEARecordType->w;
 
   mParticleMomentum = G4ThreeVector(dx*mMomentum, dy*mMomentum, dz*mMomentum);
 
@@ -506,9 +505,9 @@ G4int GateSourcePhaseSpace::OpenIAEAFile(G4String file)
   if( pIAEAheader->read_header() ) GateError("Error reading phase space file header: " + IAEAFileName + IAEAHeaderExt);
 
   pIAEARecordType= (iaea_record_type *) calloc(1, sizeof(iaea_record_type));
-  pIAEAheader->get_record_contents(pIAEARecordType);
   pIAEARecordType->p_file = pIAEAFile;
   pIAEARecordType->initialize();
+  pIAEAheader->get_record_contents(pIAEARecordType);
 
   return pIAEAheader->nParticles;
 }


### PR DESCRIPTION
I recently tried to use as source an IAEA phase space, specifically the
one named "VarianClinaciX_6MV_10x10_w1.IAEAphsp" (downloadable
from https://www-nds.iaea.org/phsp/photon1/), via the "/gate/source/[Source
name]/addPhaseSpaceFile" macro command.

The simulation (Gate 7.0) run smoothly, however I got meaningless results.
Digging into the related Gate source code, I believe I found 3 bugs
for which I propose a correction in the 'fixIAEAphspSource' branch.

   1) In the function 'GateSourcePhaseSpace::OpenIAEAFile()' the call
'pIAEARecordType->initialize()' is placed after
'pIAEAReader->getRecordContents(pIAEARecordType)'. These two lines shall be
swapped, otherwise the record contents information extracted form the IAEA
header and stored in the the object pointed by pIAEARecordType is cleared
by the initialisation operation.

   2) The "GateIAEA*" source files appear to be based on an old C++
implementation for handling phase spaces distributed by the IAEA. Some
things seem to be outdated, for instance in the "GateIAEAConfig.h" the
definition 'typedef long IAEA_I32' must be replaced with 'typedef int
IAEA_I32' in order to conform to the current "*.IAEAphsp" file format.

   3) In the function 'GateSourcePhaseSpace::GenerateIAEAVertex()' the
'pIAEARecordType->w' variable seems to be misused in the expression 'dz *=
pIAEARecordType->w'. The 'pIAEARecordType->w' variable contains the Z
direction cosine of the particle, not just its sign. So it should rather be
'dz = pIAEARecordType->w'. Since the 'pIAEARecordType->w' variable is
slightly smaller than 1, this mistake causes small errors in the
normalisation of the momentum (and hence of the kinetic energy).

After having applied these correction, I was able to obtain an output dose distribution for the 10x10 cm field quite close to the experimental data reported in the documentation distributed by IAEA along with the IAEAphsp and IAEAheader files ("https://www-nds.iaea.org/phsp/photon1/VarianClinaciX_6MV_PHSPdoc_Gothenburg.pdf").

![comparisonpdd](https://cloud.githubusercontent.com/assets/8522577/8030667/fed03d40-0dc8-11e5-8a51-90eae801a36d.png)

![comparisonxprofiles](https://cloud.githubusercontent.com/assets/8522577/8030686/28bccb3c-0dc9-11e5-9075-8756f6952043.png)

![comparisonyprofiles](https://cloud.githubusercontent.com/assets/8522577/8030692/2e0595f6-0dc9-11e5-8da2-ed4992dd8c9b.png)
