### PR TITLE
typo fixes etc

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@
 - For a complete installation of GATE, user needs to read the Installation Guide
   http://wiki.opengatecollaboration.org/index.php/InstallationGuideV7.1
 
-- The installation of this GATE V7.1 version is supported, tested and recommanded with the following:
+- The installation of this GATE V7.1 version is supported, tested and recommended with the following:
 
     - Linux distributions: RED HAT & Fedora & Mandrake & Mandriva & Ubuntu...
     - Compiler: gcc 4.4 to 4.9
@@ -83,6 +83,8 @@ NOTES:
       GATE_USE_OPTICAL                   OFF: by default, set to ON if you want to perform simulation for optical imaging applications
       GEANT4_USE_SYSTEM_CLHEP            OFF: by default, set to ON if you want to use an external CLHEP version (2.2.0.4)
       
+     - Configure CMAKE_INSTALL_PREFIX to the full path of the gate_v7.1-install directory that you just created.
+
      - Like for Geant4, press 'c' to configure and 'g' to generate the makefile.
 
      - Compile:
@@ -98,7 +100,7 @@ NOTES:
 
        • According to your system, you may also have to set environment variables for Root and Geant4
          - Root : source ${ROOTSYS}/bin/thisroot.sh
-         - Geant4 : source ${YOU_GEANT4_INSTALL_FOLDER}/bin/geant4.sh
+         - Geant4 : source ${YOUR_GEANT4_INSTALL_FOLDER}/bin/geant4.sh
 
 
 3/ C O M P I L A T I O N   W A R N I N G S


### PR DESCRIPTION
This is my first github pull request, so this is going to be a very trivial one: fixing some trivial typos in the README file. I also added one line in the build/install instructions, which states something obvious (tell cmake about the intended install directory), but possibly useful for a new user who just literally follows the instructions.