### PR TITLE
use std::abs instead of abs(int) or fabs(float)

### DIFF
--- a/source/digits_hits/src/GateSinogram.cc
+++ b/source/digits_hits/src/GateSinogram.cc
@@ -24,6 +24,9 @@ See GATE/LICENSE.txt for further details
 #include "GateConstants.hh"
 #include "GateMessageManager.hh"
 
+// for std::abs
+#include <cmath>
+
 // Reset the matrix and prepare a new acquisition
 void GateSinogram::Reset(size_t ringNumber, size_t crystalNumber, size_t radialElemNb, size_t virtualRingNumber, size_t virtualCrystalPerBlockNumber)
 {
@@ -205,15 +208,15 @@ G4int GateSinogram::Fill( G4int ring1ID, G4int ring2ID, G4int crystal1ID, G4int 
 
   det1_c = binViewID;
   //det2_c = binViewID + (m_crystalNb/2);
-  if (fabs(crystal1ID - det1_c) < fabs(crystal1ID - (det1_c + (G4int)m_crystalNb)))
+  if (std::abs(crystal1ID - det1_c) < std::abs(crystal1ID - (det1_c + (G4int)m_crystalNb)))
     diff1 = crystal1ID - det1_c;
   else
     diff1 = crystal1ID - (det1_c + m_crystalNb);
-  if (fabs(crystal2ID - det1_c) < fabs(crystal2ID - (det1_c + (G4int)m_crystalNb)))
+  if (std::abs(crystal2ID - det1_c) < std::abs(crystal2ID - (det1_c + (G4int)m_crystalNb)))
     diff2 = crystal2ID - det1_c;
   else
     diff2 = crystal2ID - (det1_c + m_crystalNb);
-  if (fabs(diff1) < fabs(diff2)) sigma = crystal1ID - crystal2ID;
+  if (std::abs(diff1) < std::abs(diff2)) sigma = crystal1ID - crystal2ID;
   else sigma = crystal2ID - crystal1ID;
   if (sigma < 0)  sigma += m_crystalNb;
   // m_elemNb :=  m_crystalNb/2

--- a/source/geometry/src/GateVoxelOutput.cc
+++ b/source/geometry/src/GateVoxelOutput.cc
@@ -38,6 +38,9 @@ See GATE/LICENSE.txt for further details
 #include "GatePhantomHit.hh"
 #include "GateRecorderBase.hh"
 
+// for std::abs
+#include <cmath>
+
 //--------------------------------------------------------------------------------------------------
 GateVoxelOutput::GateVoxelOutput(const G4String& name,const G4String& phantomName, GateOutputMgr* outputMgr,DigiMode digiMode,GateVoxelBoxParameterized* inserter) 
   : GateVOutputModule(name,outputMgr,digiMode),
@@ -211,7 +214,7 @@ void GateVoxelOutput::RecordEndOfAcquisition()
 	double SS( (*m_array)[i] * (*m_array)[i]      );
 	double S2( (*m_arraySquare)[i]                );
 	relativeErrorSquared = ( N*S2 - SS )/ ( (N-1)*SS );
-	if ( abs(relativeErrorSquared) < 1.0e-15 ) relativeErrorSquared=0; // Chop tiny values 
+	if ( std::abs(relativeErrorSquared) < 1.0e-15 ) relativeErrorSquared=0; // Chop tiny values 
 	relativeError=sqrt(relativeErrorSquared);
       }
       


### PR DESCRIPTION
My compiler (Apple LLVM version 6.1.0 (clang-602.0.53)) is complaining when abs and fabs are used with the wrong type, e.g. abs() when argument is a float, and fabs when argument is an int. It recommends to always use the C++ overloaded std::abs function instead of the old fixed-type C abs(int) and fabs(float) functions, and that seems very reasonable.

Note: in GateSinogram this is just a matter of grammar, but it looks like this change is actually a bugfix for GateVoxelOutput that may slightly change program behavior in some cases (I think the old code rounds the "relativeErrorSquared" argument to integer before comparing with the 1e-15 threshold value).