### PR TITLE
The 'register' keyword is deprecated (says clang)

### DIFF
--- a/source/geometry/include/GateCompressedVoxel.hh
+++ b/source/geometry/include/GateCompressedVoxel.hh
@@ -77,8 +77,7 @@ public:
   }
   
   bool operator() (const GateCompressedVoxel& lhs,  const GateCompressedVoxel& rhs){ 
-    register int i;
-    for( i=0; i<3; i++){
+    for( int i=0; i<3; i++){
       if ( lhs[index[i]] < rhs[index[i]] ) return true;
       else 
 	if ( lhs[index[i]] > rhs[index[i]] ) return false;

--- a/source/geometry/include/GateCompressedVoxel.hh
+++ b/source/geometry/include/GateCompressedVoxel.hh
@@ -77,7 +77,7 @@ public:
   }
   
   bool operator() (const GateCompressedVoxel& lhs,  const GateCompressedVoxel& rhs){ 
-    for( int i=0; i<3; i++){
+    for( int i=0; i<3; ++i){
       if ( lhs[index[i]] < rhs[index[i]] ) return true;
       else 
 	if ( lhs[index[i]] > rhs[index[i]] ) return false;


### PR DESCRIPTION
So: let's not use it.