### PR TITLE
silence clang warnings, avoid ref/ptr conundrums

### DIFF
--- a/source/geometry/include/GateVoxelCompressor.hh
+++ b/source/geometry/include/GateVoxelCompressor.hh
@@ -31,8 +31,6 @@ public:
     void Initialize();/* PY Descourt 08/09/2009 */  
 	
   void      Compress();
-  void      runLength(int x1, int x2, voxelSet& vs);
-  voxelSet& runLength2nd(voxelSet& vs, const std::valarray<unsigned short int>& chk, int fusion);
 
   const GateCompressedVoxel& GetVoxel(int copyNo) const { return (*m_voxelSet)[copyNo]; }
   int                        GetNbOfCopies()      const { return m_voxelSet->size();    }
@@ -49,6 +47,8 @@ public:
 
 private:
 
+  void runLength(int x1, int x2, voxelSet& vs);
+  void runLength2nd(voxelSet& vs, const std::valarray<unsigned short int>& chk, int fusion);
   void AddMaterial(G4String m);
   bool isNotExcluded(unsigned short int n) const { return  m_exclusionList->find( n )==m_exclusionList->end();}
 

--- a/source/geometry/src/GateVoxelCompressor.cc
+++ b/source/geometry/src/GateVoxelCompressor.cc
@@ -92,17 +92,22 @@ void GateVoxelCompressor::Initialize()
 // Compression is performed in three passes: first along x, then along y and z.
 void GateVoxelCompressor::Compress(){
   
-        // Allocate a voxel set for the first pass
-        voxelSet& voxelSetPass1(*new voxelSet);
-	if (!&voxelSetPass1)
-	  std::cerr << "GateVoxelCompressor::Compress - Insufficient memory for voxel set\n"<<std::flush;
+        // just to be sure: clean up old voxel set before allocating a new one
+        // almost the same as Initialize(), but I don't know if it's OK to clear the exclusion list.
+        if (m_voxelSet != 0){
+           m_voxelSet->clear();
+           delete m_voxelSet;
+        }
+        m_voxelSet = new voxelSet;
+
+        // Allocate the voxel set for the first pass
 	int voxelEstimate ( m_array->GetVoxelNx() * m_array->GetVoxelNy() * m_array->GetVoxelNz() );
-	voxelSetPass1.reserve(voxelEstimate);
+	m_voxelSet->reserve(voxelEstimate);
 	
 	// First pass - run length along X3 ( or x,  the direction varying the most rapidly)
 	for(int i=0; i<m_array->GetVoxelNz() ; i++){
 	  for(int j=0; j< m_array->GetVoxelNy();  j++)
-	    runLength(i, j, voxelSetPass1);
+	    runLength(i, j, *m_voxelSet);
 	}
 
 
@@ -110,7 +115,7 @@ void GateVoxelCompressor::Compress(){
 	
 	//       a) sort with  minor dimension as X2 (along y). X2 is index 1.
 	
-	sort(voxelSetPass1.begin(), voxelSetPass1.end(),  GateCompressedVoxelOrdering(0,2,1)); // ordering( major, ..., minor)
+	sort(m_voxelSet->begin(), m_voxelSet->end(),  GateCompressedVoxelOrdering(0,2,1)); // ordering( major, ..., minor)
 	
 	//       b) the valarray<> is the expected difference for adjacent voxels
 	//          in comparison.  The last parameter (4) means that if two voxels
@@ -118,15 +123,12 @@ void GateVoxelCompressor::Compress(){
 	//          are to be added
 	
 	unsigned short int passTwo[]={0,1,0};
-	voxelSet& voxelSetPass2 = runLength2nd(voxelSetPass1, std::valarray<unsigned short int>(passTwo,3), 4);
-	delete &voxelSetPass1;
+	runLength2nd(*m_voxelSet, std::valarray<unsigned short int>(passTwo,3), 4);
 	
 	// Third pass - run length along X1 (or z)
-	sort(voxelSetPass2.begin(), voxelSetPass2.end(),  GateCompressedVoxelOrdering(1,2,0)); // ordering( major, ..., minor)
+	sort(m_voxelSet->begin(), m_voxelSet->end(),  GateCompressedVoxelOrdering(1,2,0)); // ordering( major, ..., minor)
 	unsigned short int passThree[]={1,0,0}; 
-	m_voxelSet  = & runLength2nd(voxelSetPass2, std::valarray<unsigned short int>(passThree,3), 3);
-	delete &voxelSetPass2;
-	
+	runLength2nd(*m_voxelSet, std::valarray<unsigned short int>(passThree,3), 3);
 }
 //-----------------------------------------------------------------------------
 
@@ -161,12 +163,13 @@ void GateVoxelCompressor::runLength(int x1, int x2, voxelSet& vs){
 //  vs     : the current voxel set
 //  diff   : the expected difference in position for adjacent voxels
 //  fusion : an index in GateCompressedVoxel representing one of the dimensions (dx1, dx2 or dx3) that is to be fused
-voxelSet& GateVoxelCompressor::runLength2nd(voxelSet& vs, const std::valarray<unsigned short int>& diff, int fusion){
-  voxelSet& newVoxels( *new voxelSet() );
+void GateVoxelCompressor::runLength2nd(voxelSet& vs, const std::valarray<unsigned short int>& diff, int fusion){
+  voxelSet newVoxels;
   newVoxels.reserve( vs.size() );
   
-  if (!&newVoxels) {
+  if (newVoxels.capacity()<vs.size()) {
     std::cerr <<  "GateVoxelCompressor::runLength2nd - Insufficient memory for new voxel set\n"<<std::flush;
+    // DJB: TODO: shouldn't we throw an error in this case? Continuing seems pointless.
   }
   
   //  These are the indices in GateCompressedVoxel used for comparison (3:dx1, 4:dx2, 5:dx3, 6:value)
@@ -201,7 +204,7 @@ voxelSet& GateVoxelCompressor::runLength2nd(voxelSet& vs, const std::valarray<un
   v[fusion]=runLength;
   newVoxels.push_back( v );
 
-  return newVoxels;
+  newVoxels.swap(vs);
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Before this commit I got these warnings from clang:
[...]
[ 36%] Building CXX object
CMakeFiles/Gate.dir/source/geometry/src/GateWedge.cc.o
/Users/montecarlo/Software/CERN/GATE/Gate/source/geometry/src/GateVoxelCompressor.cc:97:8:
warning: reference cannot be bound to dereferenced
      null pointer in well-defined C++ code; pointer may be assumed to
always convert to true [-Wundefined-bool-conversion]
        if (!&voxelSetPass1)
            ~ ^~~~~~~~~~~~~
/Users/montecarlo/Software/CERN/GATE/Gate/source/geometry/src/GateVoxelCompressor.cc:168:9:
warning: reference cannot be bound to dereferenced
      null pointer in well-defined C++ code; pointer may be assumed to
always convert to true [-Wundefined-bool-conversion]
  if (!&newVoxels) {
      ~ ^~~~~~~~~
[...]

The voxelSetPass1 reference was defined as:

voxelSet& voxelSetPass1(*new voxelSet);

... and followed by this test:

        if (!&voxelSetPass1)

That is pretty strange. If the new fails, then you'll either get an
uncaught bad_alloc exception or a reference to a dereferenced null
pointer, which should result in a segfault.  And why would new fail? A
freshly constructed voxelSet is just an empty vector, does not (yet)
cost much memory. And if it *would* fail, then the (!&voxel2SetPass1)
check comes too late, as clang tries to explain in its warning. The
problem in runLength2nd is similar.

I removed these pointer/reference conundra, and decided that
runLength and runLength2nd are implementation methods and should
therefore be private. The Compress() method does not need temporary
objects for Pass1 and Pass2, I think; without them, the code is less
cluttered. At least clang does not complain anymore.