### PR TITLE
Fix crash on deletion of G4Cache object

### DIFF
--- a/source/digits_hits/src/GateDigitizer.cc
+++ b/source/digits_hits/src/GateDigitizer.cc
@@ -383,14 +383,14 @@ void GateDigitizer::Digitize()
   // Have the pulses processed by the coincidence sorters
   for (i=0; i<m_coincidenceSorterList.size() ; ++i) {
     if (nVerboseLevel>1)
-      G4cout << "[GateDigitizer::Digitize]: launching coincidence sorter '" << m_coincidenceChainList[i]->GetObjectName() << "'\n";
+      G4cout << "[GateDigitizer::Digitize]: launching coincidence sorter '" << m_coincidenceSorterList[i]->GetObjectName() << "'\n";
     m_coincidenceSorterList[i]->ProcessSinglePulseList();
   }
 
   // Have the coincidences processed by the coincidence-processor chains
   for (i=0; i<m_coincidenceChainList.size() ; ++i) {
     if (nVerboseLevel>1)
-      G4cout << "[GateDigitizer::Digitize]: launching coincidence-processor '" << m_coincidenceSorterList[i]->GetObjectName() << "'\n";
+      G4cout << "[GateDigitizer::Digitize]: launching coincidence-processor '" << m_coincidenceChainList[i]->GetObjectName() << "'\n";
     m_coincidenceChainList[i]->ProcessCoincidencePulses();
   }
 

--- a/source/physics/include/GateVSource.hh
+++ b/source/physics/include/GateVSource.hh
@@ -206,7 +206,7 @@ protected:
   /* PY Descourt 08/09/2009 */
     G4bool fAbortNow; // detector mode
   G4ThreeVector fPosition;// for detector mode because G4Trajectory does not allow to set first trajectory point position !!!
-G4ParticleDefinition* m_pd;
+  G4ParticleDefinition* m_pd;
 
 };
 

--- a/source/physics/src/GateVSource.cc
+++ b/source/physics/src/GateVSource.cc
@@ -84,8 +84,8 @@ GateVSource::GateVSource(G4String name): m_name( name ) {
   mIsUserFocalShapeActive = false;
   mUserFocalShapeInitialisation = false;
   mUserFocalShape = new G4SPSPosDistribution();
+  mUserPosGenX = 0;
 
-  mUserPosGenX = new G4SPSRandomGenerator();
   m_posSPS = new GateSPSPosDistribution();
   m_posSPS->SetBiasRndm( GetBiasRndm() );
   m_eneSPS = new GateSPSEneDistribution();
@@ -97,8 +97,8 @@ GateVSource::GateVSource(G4String name): m_name( name ) {
   m_sourceMessenger = new GateVSourceMessenger( this );
   m_SPSMessenger    = new GateSingleParticleSourceMessenger( this );
 
-
   SetNumberOfParticles(1); // important !
+
 }
 //-------------------------------------------------------------------------------------------------
 
@@ -117,10 +117,14 @@ GateVSource::~GateVSource()
   delete m_eneSPS;
   delete m_angSPS;
   delete mUserFocalShape;
-  delete mUserPosGenX;
-  for (unsigned int i = 0; i<mUserPosGenY.size(); ++i) {
-    delete mUserPosGenY[i];
+  if(mUserPosGenX != 0)
+    delete mUserPosGenX;
+  for (unsigned int i = 0; i<mUserPosGenY.size(); ++i)
+  {
+    if(mUserPosGenY[i] != 0)
+      delete mUserPosGenY[i];
   }
+
 }
 //-------------------------------------------------------------------------------------------------
 
@@ -887,6 +891,8 @@ void GateVSource::InitializeUserFluence()
     double posX,posY;
     posX = (0.5 * sizeX) + userFluenceImage.GetOrigin().x();
 //     posX = ((0.5 * sizeX) - userFluenceImage.GetHalfSize().x());
+
+    mUserPosGenX = new G4SPSRandomGenerator();
 
     mUserPosGenX->SetXBias(G4ThreeVector(0.,0.,0.));
     for(int i=0; i<resX;i++)

--- a/source/physics/src/GateVSource.cc
+++ b/source/physics/src/GateVSource.cc
@@ -106,16 +106,13 @@ GateVSource::GateVSource(G4String name): m_name( name ) {
 //-------------------------------------------------------------------------------------------------
 GateVSource::~GateVSource()
 {
-  /*delete posGenerator;
-    delete angGenerator;
-    delete eneGenerator;
-    delete biasRndm;*/
-
   delete m_sourceMessenger;
   delete m_SPSMessenger;
+
   delete m_posSPS;
   delete m_eneSPS;
   delete m_angSPS;
+
   delete mUserFocalShape;
   if(mUserPosGenX != 0)
     delete mUserPosGenX;
@@ -905,16 +902,16 @@ void GateVSource::InitializeUserFluence()
 
       if (mUserPosGenY[i]==0) {
         mUserPosGenY[i] = new G4SPSRandomGenerator();
+        mUserPosGenY[i]->SetYBias(G4ThreeVector(0.,0.,0.));
+        mUserPosGenY[i]->GetBiasWeight();       // these two lines are kludges to initialize
+        mUserPosGenY[i]->ReSetHist("biaspp");   // all the G4Cache objects in G4SPSRandomGenerator
       }
-      mUserPosGenY[i]->SetYBias(G4ThreeVector(0.,0.,0.));
+
       for(int j=0; j<resY; j++)
       {
         sum += userFluenceImage.GetValue(i,j,0);
         mUserPosY[j] = posY;
 
-        if (mUserPosGenY[i]==0) {
-          mUserPosGenY[i] = new G4SPSRandomGenerator();
-        }
         mUserPosGenY[i]->SetYBias(G4ThreeVector(j+1,userFluenceImage.GetValue(i,j,0),0.));
         posY += sizeY;
       }


### PR DESCRIPTION
If a G4SPSRandomGenerator() object is created but never used, it causes a crash when the object is deleted for reasons having to do with the design of the G4Cache class. This doesn't cause a problem for GATE simulations since the problem occurs after the simulation is finished while the GateVSource objects are being deleted, but it does cause the output to end with an error message rather than exiting cleanly.

Moving the creation of mUserPosGenX into InitializeUserFluence() fixes the problem since it only creates the object if it's going to be used.

I haven't tested this with a macro that uses the custom user fluence.