### PR TITLE
fixed some minor bugs in fixed number of primaries mode

### DIFF
--- a/source/general/src/GateApplicationMgr.cc
+++ b/source/general/src/GateApplicationMgr.cc
@@ -289,6 +289,7 @@ void GateApplicationMgr::StartDAQComplete(G4ThreeVector param)
 //------------------------------------------------------------------------------------------
 void GateApplicationMgr::StartDAQ() 
 {
+
   // With this method we check for all output module enabled but with no
   // filename given. In this case we disable the output module and send a warning.
   GateOutputMgr::GetInstance()->CheckFileNameForAllOutput();
@@ -339,25 +340,34 @@ void GateApplicationMgr::StartDAQ()
     theClock->SetTime(m_time);
 
     // calculate the time steps for total primaries mode
-    if(mATotalAmountOfPrimariesIsRequested){
+    if(mATotalAmountOfPrimariesIsRequested)
+    {
       if(mAnAmountOfPrimariesPerRunIsRequested)
       {
         mTimeStepInTotalAmountOfPrimariesMode = GetTimeSlice(slice)/mRequestedAmountOfPrimariesPerRun;
         m_weight=GetTimeSlice(slice)/(mTimeSlices.back()-mTimeSlices.front());
       }
-      else {
+      else
+      {
         mTimeStepInTotalAmountOfPrimariesMode = (mTimeSlices.back()-mTimeSlices.front())/mRequestedAmountOfPrimaries;
+        mRequestedAmountOfPrimariesPerRun = int(mTimeSlices[slice+1]/mTimeStepInTotalAmountOfPrimariesMode)
+                                              - int(mTimeSlices[slice]/mTimeStepInTotalAmountOfPrimariesMode);
+      }
+      GateRunManager::GetRunManager()->SetRunIDCounter(slice);                    // Must explicitly keep the RunID in sync with the slice #
+      GateRunManager::GetRunManager()->BeamOn(mRequestedAmountOfPrimariesPerRun); // otherwise RunID is automatically incremented
+      m_time = mTimeSlices[slice+1];
+    }
+    else
+    {
+      while(m_time<GetEndTimeSlice(slice))  // sometimes a single slice might require more than MAX_INT events
+      {
+        GateRunManager::GetRunManager()->SetRunIDCounter(slice); // Must explicitly keep the RunID in sync with the slice #
+        GateRunManager::GetRunManager()->BeamOn(INT_MAX);        // otherwise RunID is automatically incremented
+        theClock->SetTimeNoGeoUpdate(m_time);
       }
     }
 
-    while(m_time<GetEndTimeSlice(slice))  // sometimes a single slice might require more than MAX_INT events
-    {
-      GateRunManager::GetRunManager()->SetRunIDCounter(slice); // keep the RunID in sync with the slice #
-      GateRunManager::GetRunManager()->BeamOn(INT_MAX);
-      theClock->SetTimeNoGeoUpdate(m_time);
-    }
     slice++;
-
   }
   
   if (mOutputMode) GateOutputMgr::GetInstance()->RecordEndOfAcquisition();
@@ -406,7 +416,7 @@ void GateApplicationMgr::StartDAQCluster(G4ThreeVector param)
   if(m_clusterStop<mTimeSlices.front() || m_clusterStop>mTimeSlices.back())
     GateError("Cluster stop time is outside of [StartTime,StopTime]");
   if (nVerboseLevel>0)
-    G4cout << "Cluster: virtual time start " <<m_clusterStart/s<<", virtual time stop "<<m_clusterStop/s<< Gateendl;
+    G4cout << "Cluster: virtual time start " << m_clusterStart/s <<", virtual time stop "<<m_clusterStop/s<< Gateendl;
 
   if (mOutputMode) GateOutputMgr::GetInstance()->RecordBeginOfAcquisition();
 
@@ -432,22 +442,31 @@ void GateApplicationMgr::StartDAQCluster(G4ThreeVector param)
     theClock->SetTimeNoGeoUpdate(m_time);
 
     // calculate the time steps for total primaries mode
-    if(mATotalAmountOfPrimariesIsRequested){
+    if(mATotalAmountOfPrimariesIsRequested)
+    {
       if(mAnAmountOfPrimariesPerRunIsRequested)
       {
         mTimeStepInTotalAmountOfPrimariesMode = GetTimeSlice(slice)/mRequestedAmountOfPrimariesPerRun;
         m_weight=GetTimeSlice(slice)/(mTimeSlices.back()-mTimeSlices.front());
       }
-      else {
+      else
+      {
         mTimeStepInTotalAmountOfPrimariesMode = (mTimeSlices.back()-mTimeSlices.front())/mRequestedAmountOfPrimaries;
+        mRequestedAmountOfPrimariesPerRun = int(mTimeSlices[slice+1]/mTimeStepInTotalAmountOfPrimariesMode)
+                                              - int(mTimeSlices[slice]/mTimeStepInTotalAmountOfPrimariesMode);
       }
+      GateRunManager::GetRunManager()->SetRunIDCounter(slice);                    // Must explicitly keep the RunID in sync with the slice #
+      GateRunManager::GetRunManager()->BeamOn(mRequestedAmountOfPrimariesPerRun); // otherwise RunID is automatically incremented
+      m_time = mTimeSlices[slice+1];
     }
-
-    while(m_time<GetEndTimeSlice(slice))  // sometimes a single slice might require more than MAX_INT events
+    else
     {
-      GateRunManager::GetRunManager()->SetRunIDCounter(slice); // Must explicitly keep the RunID in sync with the slice #
-      GateRunManager::GetRunManager()->BeamOn(INT_MAX);        // otherwise RunID is automatically incremented
-      theClock->SetTimeNoGeoUpdate(m_time);
+      while(m_time<GetEndTimeSlice(slice))  // sometimes a single slice might require more than MAX_INT events
+      {
+        GateRunManager::GetRunManager()->SetRunIDCounter(slice); // Must explicitly keep the RunID in sync with the slice #
+        GateRunManager::GetRunManager()->BeamOn(INT_MAX);        // otherwise RunID is automatically incremented
+        theClock->SetTimeNoGeoUpdate(m_time);
+      }
     }
     slice++;
 
@@ -479,7 +498,7 @@ void GateApplicationMgr::Describe()
 
 void GateApplicationMgr::InitializeTimeSlices()
 {
-  if(mTimeSliceIsSetUsingAddSlice || mTimeSliceIsSetUsingReadSliceInFile)
+  if( mTimeSlices.size()>2 || mTimeSliceIsSetUsingAddSlice || mTimeSliceIsSetUsingReadSliceInFile) // already initialized
   {
     // TODO: could check that slices are in order but this was already done in the routines that create the slices
     ;

--- a/source/physics/src/GateSourceMgr.cc
+++ b/source/physics/src/GateSourceMgr.cc
@@ -555,64 +555,47 @@ G4int GateSourceMgr::PrepareNextEvent( G4Event* event )
       GateVSource* source = GetNextSource();
 
       if( source )
-        {
-          // obsolete: to avoid the initialization phase for the source if it's the same as
-          // the previous event (always the same with only 1 source). Not needed now with one gps
-          // per source
-          if( source != m_previousSource ) m_needSourceInit = true;
-          m_previousSource = source;
+      {
+        // obsolete: to avoid the initialization phase for the source if it's the same as
+        // the previous event (always the same with only 1 source). Not needed now with one gps
+        // per source
+        if( source != m_previousSource ) m_needSourceInit = true;
+        m_previousSource = source;
 
-          // save the information, that can then be asked during the analysis phase
-          m_currentSources.push_back( source );
+        // save the information, that can then be asked during the analysis phase
+        m_currentSources.push_back( source );
 
-          // update the internal time
-          m_time += m_firstTime;
+        // update the internal time
+        m_time += m_firstTime;
 
 
-          GateApplicationMgr* appMgr = GateApplicationMgr::GetInstance();
-          // G4double timeStop           = appMgr->GetTimeStop();
-          appMgr->SetCurrentTime(m_time);
+        GateApplicationMgr* appMgr = GateApplicationMgr::GetInstance();
+        // G4double timeStop           = appMgr->GetTimeStop();
+        appMgr->SetCurrentTime(m_time);
 
-          if( mVerboseLevel > 1 )
-            G4cout << "GateSourceMgr::PrepareNextEvent :  m_time (s) " << m_time/s
-                   << "  m_timeLimit (s) " << m_timeLimit/s << Gateendl;
+        if( mVerboseLevel > 1 )
+          G4cout << "GateSourceMgr::PrepareNextEvent :  m_time (s) " << m_time/s
+                 << "  m_timeLimit (s) " << m_timeLimit/s << Gateendl;
 
-          // Warning: the comparison  m_time <= m_timeLimit should be wrong due to decimal floating point problem
+        if( m_time <= m_timeLimit || appMgr->IsTotalAmountOfPrimariesModeEnabled())
+          {
+            if( mVerboseLevel > 1 )
+              G4cout << "GateSourceMgr::PrepareNextEvent : source selected <"
+                     << source->GetName() << ">\n";
 
-          /*  if (((!appMgr->IsAnAmountOfPrimariesPerRunModeEnabled() && ( m_time <= m_timeLimit ))
-              || (appMgr->IsAnAmountOfPrimariesPerRunModeEnabled()
-              && (mNbOfParticleInTheCurrentRun < appMgr->GetNumberOfPrimariesPerRun()) ))
-              && ( m_time <= timeStop ) ) */
-          //      if( (  m_timeLimit - m_time >= -0.001 ) && ( m_time <= timeStop ) )
-          // G4cout << m_time - m_timeLimit<<"   "<<m_firstTime<<"    "<<m_firstTime*(1-1.E-10) <<"  "<< (m_time - m_timeLimit) - m_firstTime << Gateendl;
-
-//          if( !appMgr->IsTotalAmountOfPrimariesModeEnabled() && ( m_time <= m_timeLimit ) )
-          if( m_time <= m_timeLimit )
- //             || (appMgr->IsTotalAmountOfPrimariesModeEnabled() && appMgr->IsAnAmountOfPrimariesPerRunModeEnabled() && (mNbOfParticleInTheCurrentRun < appMgr->GetNumberOfPrimariesPerRun()))
- //             || (appMgr->IsTotalAmountOfPrimariesModeEnabled() && ( fabs(m_time - m_timeLimit - m_firstTime) > m_firstTime*0.5  ) && ( m_time - timeStop  <= m_firstTime )))
-            {
-	      if( mVerboseLevel > 1 )
-                G4cout << "GateSourceMgr::PrepareNextEvent : source selected <"
-                       << source->GetName() << ">\n";
-
-              // transmit the time to the source and ask it to generate the primary vertex
-              source->SetTime( m_time );
-              source->SetNeedInit( m_needSourceInit );
-              SetWeight(appMgr->GetWeight());
-              source->SetSourceWeight(GetWeight());
-              mNumberOfEventBySource[source->GetSourceID()+1]+=1;
-              numVertices = source->GeneratePrimaries( event );
-            }
-          else {
-            if( mVerboseLevel > 0 )
-              G4cout << "GateSourceMgr::PrepareNextEvent : m_time > m_timeLimit. No vertex generated\n";
-
-            /*if(m_time <= timeStop){
-              m_time-=m_firstTime;
-              appMgr->SetCurrentTime(m_time);
-            }*/
+            // transmit the time to the source and ask it to generate the primary vertex
+            source->SetTime( m_time );
+            source->SetNeedInit( m_needSourceInit );
+            SetWeight(appMgr->GetWeight());
+            source->SetSourceWeight(GetWeight());
+            mNumberOfEventBySource[source->GetSourceID()+1]+=1;
+            numVertices = source->GeneratePrimaries( event );
           }
+        else {
+          if( mVerboseLevel > 0 )
+            G4cout << "GateSourceMgr::PrepareNextEvent : m_time > m_timeLimit. No vertex generated\n";
         }
+      }
       else {
         G4cout << "GateSourceMgr::PrepareNextEvent : WARNING : GateSourceMgr::GetNextSource gave no source\n";
       }


### PR DESCRIPTION
Previously, in 'fixed number of primaries mode', to generate N primaries the code calculated the total duration of the simulation, T, and generated a particle every (T/N) seconds, until the time limit was reached. The slight inexactness of floating point representation led to the simulation sometimes generating N-1 particles instead of N. The code now passes the exact number of particles to be generated to BeamOn() in 'fixed number of primaries' mode instead of using the simulation time to stop the simulation.

A minor bug that occurred when running simulations with multiple time slices back-to-back (i.e. without closing and reopening GATE) has also been fixed.

Also cleaned out some dead code and realigned some indenting.