### PR TITLE
minor modifications to GateRandomEngine

### DIFF
--- a/source/general/src/GateRandomEngine.cc
+++ b/source/general/src/GateRandomEngine.cc
@@ -115,23 +115,23 @@ void GateRandomEngine::ShowStatus() {
 void GateRandomEngine::Initialize() {
   bool isSeed = false;
   long seed = 0;
-  // rest bits are additionnal bit used for engine initialization
+  // rest bits are additional bit used for engine initialization
   // default engine doesn't use it
   int rest = 0;
 
   if (theSeed=="default" && theSeedFile==" ") {
     isSeed=false;
   } else if (theSeed=="auto") {
-    // initialize seed by reading from kernel random generator /dev/random
-    // FIXME may not be protable
-    FILE *hrandom = fopen("/dev/random","rb");
+    // initialize seed by reading from kernel random generator /dev/urandom
+    // FIXME may not be portable
+    FILE *hrandom = fopen("/dev/urandom","rb");
     if(fread(static_cast<void*>(&seed),sizeof(seed),1,hrandom) == 0 ){G4cerr<< "Problem reading data!!!\n";}
     if(fread(static_cast<void*>(&rest),sizeof(rest),1,hrandom) == 0 ){G4cerr<< "Problem reading data!!!\n";}
     fclose(hrandom);
 
     isSeed=true;
   } else {
-    seed = atoi(theSeed.c_str());
+    seed = atol(theSeed.c_str());
     rest = 0;
 
     isSeed=true;


### PR DESCRIPTION
The /dev/random device blocks if the internal estimate of entropy is too low. In practice, this means that when running multiple simulations in succession, as when debugging a macro in interactive mode, there's often a long pause (15-20 seconds on my system) in the random engine initialization step. Using /dev/urandom fixes this trivial but irritating behaviour.

Also modified the code to read a long instead of an int from the supplied seed. Practically, this almost certainly makes no difference whatsoever, but it is in principle more correct, since the variable being set is a long. (For a given macro that supplies its own random seed, it is now possible to run 2^64 different noise realizations instead if 2^32.)