### PR TITLE
moved SetPDGLifeTime() to GateVSource::Initialize()

### DIFF
--- a/source/physics/include/GateVSource.hh
+++ b/source/physics/include/GateVSource.hh
@@ -35,7 +35,7 @@ public:
   GateVSource( G4String name );
   virtual ~GateVSource();
 
-  virtual  void Initialize(){}
+  virtual  void Initialize();
 
   virtual void SetName( G4String value ) { m_name = value; }
   virtual G4String GetName()             { return m_name; }

--- a/source/physics/src/GateVSource.cc
+++ b/source/physics/src/GateVSource.cc
@@ -125,6 +125,12 @@ GateVSource::~GateVSource()
 }
 //-------------------------------------------------------------------------------------------------
 
+void GateVSource::Initialize()
+{
+  GetParticleDefinition()->SetPDGLifeTime(0); // let Gate control the decay time of radioactive particles
+}
+
+
 #ifndef G4VIS_USE
 void GateVSource::Visualize(G4String){
 #endif
@@ -270,8 +276,6 @@ G4double GateVSource::GetNextTime( G4double timeStart )
         activityNow = 0.;
       else
         {
-	  // Force life time to 0, time is managed by GATE not G4
-	  GetParticleDefinition()->SetPDGLifeTime(0);
 	  if( m_forcedUnstableFlag )
             {
 	      if( m_forcedLifeTime > 0. )


### PR DESCRIPTION
This is a minor fix to the fixed number of primaries mode when using RadioactiveDecay. The call to SetPDGLifeTime(0) to let Gate control the decay time of radioactive ions was in the GateVSource::GetNextTime() function. Setting the lifetime to zero before every event isn't necessary, and in fixed number of primaries mode, GetNextTime isn't used at all, so the decay timing was controlled by Geant4. Moving the call to GateVSource::Initialize() makes the behaviour consistent between timed runs and those with fixed numbers of primaries.