### PR TITLE
Headerfile sanitation

### DIFF
--- a/cluster_tools/filemerger/include/GateMergeManager.hh
+++ b/cluster_tools/filemerger/include/GateMergeManager.hh
@@ -18,13 +18,11 @@ See GATE/LICENSE.txt for further details
 #include <TChain.h>
 #include <cstdlib>
 
-using namespace std;
-
 class GateMergeManager
 {
 public:
 
-  GateMergeManager(bool fastMerge,int verboseLevel,bool forced,Long64_t maxRoot,string outDir){
+  GateMergeManager(bool fastMerge,int verboseLevel,bool forced,Long64_t maxRoot,std::string outDir){
      m_verboseLevel = verboseLevel;
      m_forced       =       forced;
      m_maxRoot      =      maxRoot;
@@ -54,37 +52,37 @@ public:
   }
 
 
-  void StartMerging(string splitfileName);
-  void ReadSplitFile(string splitfileName);
-  bool MergeTree(string name);
+  void StartMerging(std::string splitfileName);
+  void ReadSplitFile(std::string splitfileName);
+  bool MergeTree(std::tring name);
   bool MergeGate(TChain* chain);
   bool MergeSing(TChain* chain);
   bool MergeCoin(TChain* chain);
 
   // the cleanup after succesful merging
-  void StartCleaning(string splitfileName,bool test);
+  void StartCleaning(std::tring splitfileName,bool test);
 
   // the merging methods
   void MergeRoot();
 
 private:
   void FastMergeRoot(); 
-  bool FastMergeGate(string name);
-  bool FastMergeSing(string name);
-  bool FastMergeCoin(string name); 
-  bool           m_forced;             // if to overwrite existing files
-  int      m_verboseLevel;  
-  TFile**         filearr;
-  Long64_t      m_maxRoot;             // maximum size of root output file
-  int         m_CompLevel;             // compression level for root output
-  string            m_dir;             // .Gate directory path 
-  string         m_outDir;             // where to save the output files
-  int            m_Nfiles;             // number of files to mergw
-  vector<int> m_lastEvents;            // latestevent from al files
-  vector<string> m_vRootFileNames;     // names of root files to merge
-  TFile*         m_RootTarget;         // root output file
-  string         m_RootTargetName;     // name of target i.e. root output file
-  bool           m_fastMerge;          // fast merge option, corrects the eventIDs locally
+  bool FastMergeGate(std::string name);
+  bool FastMergeSing(std::string name);
+  bool FastMergeCoin(std::string name); 
+  bool                 m_forced;             // if to overwrite existing files
+  int            m_verboseLevel;  
+  TFile**               filearr;
+  Long64_t            m_maxRoot;             // maximum size of root output file
+  int               m_CompLevel;             // compression level for root output
+  std::string             m_dir;             // .Gate directory path 
+  std::string          m_outDir;             // where to save the output files
+  int                  m_Nfiles;             // number of files to mergw
+  std::vector<int> m_lastEvents;             // latestevent from al files
+  std::vector<std::string> m_vRootFileNames; // names of root files to merge
+  TFile*           m_RootTarget;             // root output file
+  std::string  m_RootTargetName;             // name of target i.e. root output file
+  bool              m_fastMerge;             // fast merge option, corrects the eventIDs locally
 };
 
 

--- a/cluster_tools/filemerger/include/GateMergeManager.hh
+++ b/cluster_tools/filemerger/include/GateMergeManager.hh
@@ -14,9 +14,9 @@ See GATE/LICENSE.txt for further details
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include <TFile.h>
 #include <TChain.h>
-#include <cstdlib>
 
 class GateMergeManager
 {
@@ -32,7 +32,7 @@ public:
 
      //check if a .Gate directory can be found
      if (!getenv("GC_DOT_GATE_DIR")) {
-        cout<<"Environment variable GC_DOT_GATE_DIR not set !"<<endl;
+        std::cout<<"Environment variable GC_DOT_GATE_DIR not set !"<<std::endl;
         exit(1);
      }
      m_dir=getenv("GC_DOT_GATE_DIR");
@@ -40,7 +40,7 @@ public:
      else m_dir=m_dir+"/.Gate/";
      ifstream dirstream(m_dir.c_str());
      if (!dirstream) {
-        cout<<"Failed to open .Gate directory"<<endl;
+        std::cout<<"Failed to open .Gate directory"<<std::endl;
         exit(1);
      }
      dirstream.close();
@@ -54,13 +54,13 @@ public:
 
   void StartMerging(std::string splitfileName);
   void ReadSplitFile(std::string splitfileName);
-  bool MergeTree(std::tring name);
+  bool MergeTree(std::string name);
   bool MergeGate(TChain* chain);
   bool MergeSing(TChain* chain);
   bool MergeCoin(TChain* chain);
 
   // the cleanup after succesful merging
-  void StartCleaning(std::tring splitfileName,bool test);
+  void StartCleaning(std::string splitfileName,bool test);
 
   // the merging methods
   void MergeRoot();

--- a/cluster_tools/jobsplitter/include/GateMacfileParser.hh
+++ b/cluster_tools/jobsplitter/include/GateMacfileParser.hh
@@ -13,14 +13,7 @@ See GATE/LICENSE.txt for further details
 #define GateMacfileParser_h 1
 #include "globals.hh"
 #include <vector>
-#include <iostream> 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sstream> 
 #include <fstream> 
-#include <math.h>
-
-using namespace std;
 
 /*use this class to generate fully resolved macfiles and a splitfile*/
 
@@ -36,7 +29,7 @@ public:
   G4int GenerateResolvedMacros(G4String directory);
   G4String GetOutputMacDir();
   G4String GetoutputDir(){return outputDir;}; 
-  void CleanAbort(ofstream& output, ofstream& splitfile);
+  void CleanAbort(std::ofstream& output, std::ofstream& splitfile);
   
  protected:
   
@@ -76,25 +69,25 @@ public:
 	G4String originalSPECTGPUFileName;
   G4String originalARFFileName;
   // Conerning actor
-  vector<G4String> listOfActorType;
-  vector<G4String> listOfActorName;
-  vector<G4String> listOfEnabledActorType;
-  vector<G4String> listOfEnabledActorName;
+  std::vector<G4String> listOfActorType;
+  std::vector<G4String> listOfActorName;
+  std::vector<G4String> listOfEnabledActorType;
+  std::vector<G4String> listOfEnabledActorName;
   // Member functions
   void InsertAliases();
-  void InsertSubMacros(ofstream& output,G4int splitNumber,ofstream& splitfile);
-  void DealWithTimeCommands(ofstream& output,G4int splitNumber,ofstream& splitfile);
+  void InsertSubMacros(std::ofstream& output,G4int splitNumber,std::ofstream& splitfile);
+  void DealWithTimeCommands(std::ofstream& output,G4int splitNumber,std::ofstream& splitfile);
   void IgnoreRandomEngineCommand();
   void ExtractLocalDirectory(G4String macfileName);
-  G4int GenerateResolvedMacro(G4String outputName,G4int splitNumber,ofstream& splitfile);
-  void InsertOutputFileNames(G4int splitNumber,ofstream& splitfile);
-  void SearchForActors(G4int splitNumber,ofstream& output, ofstream& splitfile);
+  G4int GenerateResolvedMacro(G4String outputName,G4int splitNumber,std::ofstream& splitfile);
+  void InsertOutputFileNames(G4int splitNumber,std::ofstream& splitfile);
+  void SearchForActors(G4int splitNumber,std::ofstream& output, std::ofstream& splitfile);
   void AddSplitNumberWithExtension(G4int splitNumber);
   bool IsComment(G4String line);
   void FormatMacline();
   void LookForEnableOutput();
   void CheckOutputPrint();
-  void CheckOutput(ofstream&,ofstream&,G4int);
+  void CheckOutput(std::ofstream&,std::ofstream&,G4int);
   int enable[SIZE];
   int filenames[SIZE];
   bool* usedAliases;

--- a/cluster_tools/jobsplitter/include/GateMacfileParser.hh
+++ b/cluster_tools/jobsplitter/include/GateMacfileParser.hh
@@ -13,6 +13,7 @@ See GATE/LICENSE.txt for further details
 #define GateMacfileParser_h 1
 #include "globals.hh"
 #include <vector>
+#include <string> 
 #include <fstream> 
 
 /*use this class to generate fully resolved macfiles and a splitfile*/
@@ -98,7 +99,7 @@ public:
   void AddPWD(G4String key);
   void CalculateTimeSplit(G4int splitNumber);
   void skipComment(std::istream & is);
-  bool ReadColNameAndUnit(std::istream & is, std::string name, string & unit);
+  bool ReadColNameAndUnit(std::istream & is, std::string name, std::string & unit);
 
 };
 #endif

--- a/cluster_tools/jobsplitter/include/GateSplitManager.hh
+++ b/cluster_tools/jobsplitter/include/GateSplitManager.hh
@@ -12,7 +12,6 @@ See GATE/LICENSE.txt for further details
 #ifndef GateSplitManager_h
 #define GateSplitManager_h 1
 #include "globals.hh"
-#include "vector"
 #include "GateToPlatform.hh"
 #include "GateMacfileParser.hh"
 

--- a/cluster_tools/jobsplitter/include/GateToPlatform.hh
+++ b/cluster_tools/jobsplitter/include/GateToPlatform.hh
@@ -12,14 +12,7 @@ See GATE/LICENSE.txt for further details
 #ifndef GateToPlatform_h
 #define GateToPlatform_h 1
 #include "globals.hh"
-#include "vector"
-#include <iostream> 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sstream> 
-#include <fstream> 
-using namespace std;
-              
+
 /*use this class to generate submit files for different platforms
 based on output from GateMacfileParser*/
 

--- a/cluster_tools/jobsplitter/src/GateMacfileParser.cc
+++ b/cluster_tools/jobsplitter/src/GateMacfileParser.cc
@@ -12,6 +12,20 @@ See GATE/LICENSE.txt for further details
 #include "GateMacfileParser.hh"
 #include <time.h>
 
+#include <iostream> 
+#include <sstream> 
+
+// for log
+#include <cmath>
+// for getenv() and system()
+#include <cstdlib>
+
+using namespace std;
+
+// These were included by I don't know why.
+// #include <sys/types.h>
+// #include <sys/stat.h>
+
 GateMacfileParser::GateMacfileParser(G4String macfileName,G4int numberOfSplits,G4int numberOfAliases,G4String* aliasesPtr)
 {
 	macName=macfileName;
@@ -446,7 +460,7 @@ void GateMacfileParser::DealWithTimeCommands(ofstream& output,G4int splitNumber,
                 }
 		G4String filename = macline.substr(35);
 		// Opening file
-		std::ifstream is;
+		ifstream is;
 		is.open(filename.c_str());
 		if (!is)
 		{
@@ -1014,7 +1028,7 @@ bool GateMacfileParser::TreatOutputStream(G4String key, G4String def, G4String& 
 }
 
 /// Misc functions
-void GateMacfileParser::skipComment(std::istream & is)
+void GateMacfileParser::skipComment(istream & is)
 {
   char c;
   char line[1024];
@@ -1028,10 +1042,10 @@ void GateMacfileParser::skipComment(std::istream & is)
   is.unget();
 }
 
-bool GateMacfileParser::ReadColNameAndUnit(std::istream & is, std::string name, string & unit) {
+bool GateMacfileParser::ReadColNameAndUnit(istream & is, string name, string & unit) {
   skipComment(is);
   // Read name
-  std::string s;
+  string s;
   is >> s;
   if (s != name) {
     for(unsigned int i=0; i<s.size(); i++) is.unget();

--- a/cluster_tools/jobsplitter/src/GateSplitManager.cc
+++ b/cluster_tools/jobsplitter/src/GateSplitManager.cc
@@ -8,8 +8,14 @@ of the GNU Lesser General  Public Licence (LGPL)
 See GATE/LICENSE.txt for further details
 ----------------------*/
 
-
 #include "GateSplitManager.hh"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+using std::cout;
+using std::endl;
+
 GateSplitManager::GateSplitManager(G4int nAliases,G4String* aliases,G4String platform,G4String pbsscript,
                                    G4String condorscript,G4String macfile,G4int nSplits,G4int time)
 {
@@ -79,7 +85,7 @@ void GateSplitManager::StartSplitting()
 
 void GateSplitManager::CleanAbort()
 {
- ofstream tmp1, tmp2;
+ std::ofstream tmp1, tmp2;
  if (macParser) macParser->CleanAbort(tmp1,tmp2);
  cout<<"Made clean exit !"<<endl;  
  exit(1);

--- a/cluster_tools/jobsplitter/src/GateToPlatform.cc
+++ b/cluster_tools/jobsplitter/src/GateToPlatform.cc
@@ -14,10 +14,16 @@ See GATE/LICENSE.txt for further details
 #include <iostream> 
 #include <sstream> 
 #include <fstream> 
+#include <cstdlib> 
+#include <sys/stat.h>
 
 #include "GateToPlatform.hh"
 
-using namespace std;
+using std::cout;
+using std::endl;
+using std::ofstream;
+using std::ifstream;
+using std::ostringstream;
               
 GateToPlatform::GateToPlatform(G4int numberOfSplits, G4String thePlatform, G4String thePbsscript, G4String theCondorScript, G4String outputMacName, G4int time)
 {
@@ -141,7 +147,7 @@ int GateToPlatform::GenerateOpenPBSSubmitfile()
 	G4String submitFilename=outputMacfilename+".submit";
 	ofstream submitFile(submitFilename.c_str());
 	if (!submitFile) {
-		cout<< "Error : could not create submit file! "<<submitFile<< endl;
+		cout<< "Error : could not create submit file! "<<submitFilename<< endl;
 		return(1);
 	}
 	submitFile<<"#! /bin/sh"<<endl;
@@ -174,7 +180,7 @@ int GateToPlatform::GenerateOpenMosixSubmitfile()
 	G4String submitFilename=outputMacfilename+".submit";
 	ofstream submitFile(submitFilename.c_str());
 	if (!submitFile) {
-		cout<< "Error : could not create submit file! "<<submitFile<< endl;
+		cout<< "Error : could not create submit file! "<<submitFilename<< endl;
 		return(1);
 	}
 	submitFile<<"#! /bin/sh"<<endl;
@@ -209,12 +215,12 @@ int GateToPlatform::GenerateCondorSubmitfile()
 	G4String submitFilename=outputMacfilename+".submit";
 	ofstream submitFile(submitFilename.c_str());
 	if (!submitFile) {
-		cout<< "Error : could not create submit file! "<<submitFile<< endl;
+		cout<< "Error : could not create submit file! "<<submitFilename<< endl;
 		return(1);
 	}
 	ifstream scriptFile(condorScript.c_str());
 	if (!scriptFile) {
-		cout<< "Error : could not open the condor script file! "<<scriptFile<< endl;
+		cout<< "Error : could not open the condor script file! "<<condorScript<< endl;
 		return(1);
 	}
 	while(!scriptFile.eof())
@@ -260,7 +266,7 @@ int GateToPlatform::GenerateXgridSubmitfile()
 		G4String submitXgridFilename=outputMacfilename+".plist";
 	ofstream submitXgridFile(submitXgridFilename.c_str());
 	if (!submitXgridFile) {
-		cout<< "Error : could not create submit file! "<<submitXgridFile<< endl;
+		cout<< "Error : could not create submit file! "<<submitXgridFilename<< endl;
 		return(1);
 	}
 	submitXgridFile << "{"<<endl;

--- a/cluster_tools/jobsplitter/src/GateToPlatform.cc
+++ b/cluster_tools/jobsplitter/src/GateToPlatform.cc
@@ -9,7 +9,16 @@ See GATE/LICENSE.txt for further details
 ----------------------*/
 
 
+//#include <sys/types.h>
+//#include <sys/stat.h>
+#include <iostream> 
+#include <sstream> 
+#include <fstream> 
+
 #include "GateToPlatform.hh"
+
+using namespace std;
+              
 GateToPlatform::GateToPlatform(G4int numberOfSplits, G4String thePlatform, G4String thePbsscript, G4String theCondorScript, G4String outputMacName, G4int time)
 {
 	nSplits=numberOfSplits;
@@ -56,7 +65,7 @@ int GateToPlatform::GenerateOpenPBSScriptfile()
 	if (dir.substr(dir.length()-1,dir.length())!="/") dir=dir+"/"; 
 	
 	//check if we have an existing directory
-	std::ifstream dirstream(dir.c_str());
+	ifstream dirstream(dir.c_str());
 	if (!dirstream) { 
 		cout<<"Error : Failed to detect the Gate executable directory"<<endl;
 		cout<<"Please check your environment variables!"<<endl; 
@@ -75,7 +84,7 @@ int GateToPlatform::GenerateOpenPBSScriptfile()
 		ostringstream cnt;
 		cnt<<i;
 		// open template script file
-		std::ifstream inFile(pbsScript);
+		ifstream inFile(pbsScript);
 		if (!inFile) {
 			cout<< "Error : could not access openPBS script template file! "<<pbsScript<< endl;
 			return(1);
@@ -120,7 +129,7 @@ int GateToPlatform::GenerateOpenPBSSubmitfile()
 	if (dir.substr(dir.length()-1,dir.length())!="/") dir=dir+"/"; 
 	
 	//check if we have an existing director
-	std::ifstream dirstream(dir.c_str());
+	ifstream dirstream(dir.c_str());
 	if (!dirstream) { 
 		cout<<"Error : Failed to detect the Gate executable directory"<<endl;
 		cout<<"Please check your environment variables!"<<endl; 
@@ -153,7 +162,7 @@ int GateToPlatform::GenerateOpenMosixSubmitfile()
 	if (dir.substr(dir.length()-1,dir.length())!="/") dir=dir+"/"; 
 	
 	//check if we have an existing directory
-	std::ifstream dirstream(dir.c_str());
+	ifstream dirstream(dir.c_str());
 	if (!dirstream) { 
 		cout<<"Error : Failed to detect the Gate executable directory"<<endl;
 		cout<<"Please check your environment variables!"<<endl; 
@@ -188,7 +197,7 @@ int GateToPlatform::GenerateCondorSubmitfile()
 	if (dir.substr(dir.length()-1,dir.length())!="/") dir=dir+"/"; 
 	
 	//check if we have an existing directory
-	std::ifstream dirstream(dir.c_str());
+	ifstream dirstream(dir.c_str());
 	if (!dirstream) { 
 		cout<<"Error : Failed to detect the Gate executable directory"<<endl;
 		cout<<"Please check your environment variables!"<<endl; 
@@ -203,7 +212,7 @@ int GateToPlatform::GenerateCondorSubmitfile()
 		cout<< "Error : could not create submit file! "<<submitFile<< endl;
 		return(1);
 	}
-	std::ifstream scriptFile(condorScript.c_str());
+	ifstream scriptFile(condorScript.c_str());
 	if (!scriptFile) {
 		cout<< "Error : could not open the condor script file! "<<scriptFile<< endl;
 		return(1);
@@ -240,7 +249,7 @@ int GateToPlatform::GenerateXgridSubmitfile()
 	if (dir.substr(dir.length()-1,dir.length())!="/") dir=dir+"/"; 
 	
 	//check if we have an existing directory
-	std::ifstream dirstream(dir.c_str());
+	ifstream dirstream(dir.c_str());
 	if (!dirstream) { 
 		cout<<"Error : Failed to detect the Gate executable directory"<<endl;
 		cout<<"Please check your environment variables!"<<endl; 

--- a/source/digits_hits/include/GateSimplifiedDecay.hh
+++ b/source/digits_hits/include/GateSimplifiedDecay.hh
@@ -10,18 +10,21 @@
 #ifndef GateSimplifiedDecay_H
 #define GateSimplifiedDecay_H 1
 
+// for_each
+#include <algorithm>
+// mem_fun
+#include <functional>
 #include <vector>
 #include "GateSimplifiedDecayTransition.hh"
-#include "Randomize.hh"
 
 class GateSimplifiedDecay{
 
 public:
 
-  GateSimplifiedDecay():transitionVector(new vector<GateSimplifiedDecayTransition*>){;}
+  GateSimplifiedDecay():transitionVector(new std::vector<GateSimplifiedDecayTransition*>){;}
 
   ~GateSimplifiedDecay(){
-    vector<GateSimplifiedDecayTransition*>::iterator i = this->transitionVector->begin();
+    std::vector<GateSimplifiedDecayTransition*>::iterator i = this->transitionVector->begin();
     for( ; i != this->transitionVector->end(); ++i ) {
       delete *i;
     }
@@ -30,7 +33,7 @@ public:
   }
 
   void print(){
-    for_each(  transitionVector->begin(),  transitionVector->end(), mem_fun( &GateSimplifiedDecayTransition::print)  );
+    std::for_each(  transitionVector->begin(),  transitionVector->end(), std::mem_fun( &GateSimplifiedDecayTransition::print)  );
   }
 
   void sample(int n, int k){
@@ -41,10 +44,10 @@ public:
     transitionVector->push_back(t );
   }
 
-  vector<psd>* doDecay( vector<psd>* );
+  std::vector<psd>* doDecay( std::vector<psd>* );
 
 private:
-  vector<GateSimplifiedDecayTransition*>* transitionVector;
+  std::vector<GateSimplifiedDecayTransition*>* transitionVector;
 
 };
 

--- a/source/digits_hits/include/GateSimplifiedDecayTransition.hh
+++ b/source/digits_hits/include/GateSimplifiedDecayTransition.hh
@@ -15,9 +15,10 @@ See GATE/LICENSE.txt for further details
 #include <utility>
 #include <functional>
 #include "Randomize.hh"
+#include <G4PhysicalConstants.hh>
 
 class GateSimplifiedDecay;
-typedef std::pair<string,double> psd;
+typedef std::pair<std::string,double> psd;
 
 
 class GateSimplifiedDecayTransition {

--- a/source/digits_hits/include/GateSimplifiedDecayTransition.hh
+++ b/source/digits_hits/include/GateSimplifiedDecayTransition.hh
@@ -9,22 +9,15 @@ See GATE/LICENSE.txt for further details
 
 #ifndef GateSimplifiedDecayTransition_H
 #define GateSimplifiedDecayTransition_H 1
-#include "math.h"
-#include <limits>
-#include <cstdlib>
+#include <cmath>
 #include <iostream>
 #include <string>
-#include <vector>
+#include <utility>
 #include <functional>
-#include <algorithm>
-
 #include "Randomize.hh"
-#include <G4PhysicalConstants.hh>
-
-using namespace std;
 
 class GateSimplifiedDecay;
-typedef pair<string,double> psd;
+typedef std::pair<string,double> psd;
 
 
 class GateSimplifiedDecayTransition {
@@ -33,7 +26,7 @@ class GateSimplifiedDecayTransition {
 
  public:
 
-  GateSimplifiedDecayTransition(int cs, int ns, double pr,  mem_fun_t<psd,GateSimplifiedDecayTransition> act, double en=0, double ampl=0, double norm=0, int Z=0):
+  GateSimplifiedDecayTransition(int cs, int ns, double pr,  std::mem_fun_t<psd,GateSimplifiedDecayTransition> act, double en=0, double ampl=0, double norm=0, int Z=0):
     currentState(cs),
     nextState(ns),
     probability(pr),
@@ -59,7 +52,7 @@ class GateSimplifiedDecayTransition {
 
 
   void print(){
-    cout
+    std::cout
 	 << currentState << ", "
 	 <<  nextState << ", "
 	 <<  probability << ", "
@@ -67,11 +60,11 @@ class GateSimplifiedDecayTransition {
 	 <<  amplitude << ", "
 	 <<  normalisationFactor << ", "
 	 <<  atomicNumber
-	 <<  endl;
+	 <<  std::endl;
   }
 
   GateSimplifiedDecayTransition* sample(int n){
-    for (int i=0; i<n; i++) cout << majoredHitAndMiss() << endl;
+    for (int i=0; i<n; i++) std::cout << majoredHitAndMiss() << std::endl;
     return this;
   }
 
@@ -97,7 +90,7 @@ class GateSimplifiedDecayTransition {
   int    currentState;
   int    nextState;
   double probability;
-  mem_fun_t<psd,GateSimplifiedDecayTransition> action;
+  std::mem_fun_t<psd,GateSimplifiedDecayTransition> action;
   double energy;                                    //  Maximum energy (inMeV)
   double amplitude;                                 //  Majoring function amplitude (for positrons)
   double normalisationFactor;                       //  normalisation factor for PDF (for positrons)

--- a/source/digits_hits/src/GateFluenceActor.cc
+++ b/source/digits_hits/src/GateFluenceActor.cc
@@ -14,6 +14,7 @@
 // Gate
 #include "GateFluenceActor.hh"
 #include "GateScatterOrderTrackInformationActor.hh"
+#include <sstream>
 
 //-----------------------------------------------------------------------------
 GateFluenceActor::GateFluenceActor(G4String name, G4int depth):
@@ -173,7 +174,7 @@ void GateFluenceActor::SaveData()
     for(unsigned int i = 0; i<mProcessName.size(); i++){
       it = mProcesses.find(mProcessName[i]);
       if(it!=mProcesses.end()){
-        stringstream filenamestream;
+        std::stringstream filenamestream;
         filenamestream << mSeparateProcessFilename << "_" << mProcessName[i] << ".mhd";
         sprintf(filename, filenamestream.str().c_str(), rID);
         mProcesses[mProcessName[i]]->Write((G4String)filename);

--- a/source/digits_hits/src/GateSETLEMultiplicityActor.cc
+++ b/source/digits_hits/src/GateSETLEMultiplicityActor.cc
@@ -83,7 +83,7 @@ void GateSETLEMultiplicityActor::SetMultiplicity(bool b, int mP, int mS, G4VPhys
 
   // register expTLEDoseActor's volume
   std::map<G4VPhysicalVolume *,int>::iterator it = mSecondaryMultiplicityMap.find(v);  
-  if(it == mSecondaryMultiplicityMap.end()) { mSecondaryMultiplicityMap.insert(make_pair(v,mS)); }
+  if(it == mSecondaryMultiplicityMap.end()) { mSecondaryMultiplicityMap.insert(std::make_pair(v,mS)); }
   else { GateError("Number of 'hybridDoseActor' attached to '" << v->GetName() << "' is too large (1 maximum)"); }
 }
 //-----------------------------------------------------------------------------

--- a/source/digits_hits/src/GateSimplifiedDecay.cc
+++ b/source/digits_hits/src/GateSimplifiedDecay.cc
@@ -7,6 +7,9 @@
   ----------------------*/
 
 #include "GateSimplifiedDecay.hh"
+#include "Randomize.hh"
+
+using namespace std;
 
 //----------------------------------------------------------------------------------------
 //  doDecay: "decays" the isotope according to the simplified scheme.

--- a/source/digits_hits/src/GateSimplifiedDecayTransition.cc
+++ b/source/digits_hits/src/GateSimplifiedDecayTransition.cc
@@ -9,6 +9,7 @@ See GATE/LICENSE.txt for further details
 
 #include "GateSimplifiedDecayTransition.hh"
 #include <G4PhysicalConstants.hh>
+#include <cmath>
 
 // A few static constants
 double GateSimplifiedDecayTransition::kAlphaSquared = fine_structure_const*fine_structure_const;

--- a/source/general/src/GateApplicationMgr.cc
+++ b/source/general/src/GateApplicationMgr.cc
@@ -21,6 +21,7 @@ See GATE/LICENSE.txt for further details
 #include "GateVSource.hh"
 #include "GateSourceMgr.hh"
 #include "GateOutputMgr.hh"
+#include <algorithm> /* min and max */
 
 GateApplicationMgr* GateApplicationMgr::instance = 0; 
 //------------------------------------------------------------------------------------------
@@ -198,7 +199,7 @@ G4double GateApplicationMgr::GetEndTimeSlice(int run)
     GateError("Error in GateApplicationMgr::GetEndTimeSlice, run=" << run << "\n");
   }
 
-  return min(mTimeSlices[run+1], m_clusterStop); // the end of the current time slice or the end of cluster run
+  return std::min(mTimeSlices[run+1], m_clusterStop); // the end of the current time slice or the end of cluster run
 }
 //------------------------------------------------------------------------------------------
 
@@ -438,7 +439,7 @@ void GateApplicationMgr::StartDAQCluster(G4ThreeVector param)
     GateMessage("Geometry", 5, " Time is going to change :  = " << m_time/s << Gateendl;);
     theClock->SetTime(mTimeSlices[slice]);
 
-    m_time = max(mTimeSlices[slice],m_clusterStart);
+    m_time = std::max(mTimeSlices[slice],m_clusterStart);
     theClock->SetTimeNoGeoUpdate(m_time);
 
     // calculate the time steps for total primaries mode

--- a/source/physics/include/GateFastI124.hh
+++ b/source/physics/include/GateFastI124.hh
@@ -9,6 +9,7 @@ See GATE/LICENSE.txt for further details
 #ifndef GATEFASTI124_HH
 #define GATEFASTI124_HH
 
+#include <vector>
 #include "G4Event.hh"
 
 #include "GateVSource.hh"
@@ -30,7 +31,7 @@ public:
 private:
 	GateVSource* m_source;
 	GateSimplifiedDecay* m_simpleDecay;
-	vector<psd>* m_particleVector;
+	std::vector<psd>* m_particleVector;
 	
 };
 

--- a/source/physics/include/GateSourcePencilBeam.hh
+++ b/source/physics/include/GateSourcePencilBeam.hh
@@ -24,6 +24,7 @@
 #include "G4UImessenger.hh"
 #include <iomanip>
 #include <vector>
+#include <string>
 
 #include "GateVSource.hh"
 #include "GateSourcePencilBeamMessenger.hh"
@@ -75,8 +76,8 @@ public:
   //Correlation Position/Direction
   void SetEllipseXThetaArea(double EllipseXThetaArea) {mEllipseXThetaArea=EllipseXThetaArea;}
   void SetEllipseYPhiArea(double EllipseYPhiArea) {mEllipseYPhiArea=EllipseYPhiArea;}
-  void SetEllipseXThetaRotationNorm(string rotation) {mEllipseXThetaRotationNorm=rotation;}
-  void SetEllipseYPhiRotationNorm(string rotation) {mEllipseYPhiRotationNorm=rotation;}
+  void SetEllipseXThetaRotationNorm(std::string rotation) {mEllipseXThetaRotationNorm=rotation;}
+  void SetEllipseYPhiRotationNorm(std::string rotation) {mEllipseYPhiRotationNorm=rotation;}
   void SetTestFlag(bool b) {mTestFlag=b;}
 
 protected:
@@ -107,8 +108,8 @@ protected:
   //Correlation Position/Direction
   double mEllipseXThetaArea;	//mm*rad
   double mEllipseYPhiArea;	//mm*rad
-  string mEllipseXThetaRotationNorm;
-  string mEllipseYPhiRotationNorm;
+  std::string mEllipseXThetaRotationNorm;
+  std::string mEllipseYPhiRotationNorm;
   //Gaussian distribution generation for direction
   RandMultiGauss * mGaussian2DYPhi;
   RandMultiGauss * mGaussian2DXTheta;

--- a/source/physics/include/GateSourceTPSPencilBeam.hh
+++ b/source/physics/include/GateSourceTPSPencilBeam.hh
@@ -55,7 +55,7 @@ public:
   //Test Flag
   void SetTestFlag(bool b) {mTestFlag=b;}
   //Treatment Plan file
-  void SetPlan(string plan) {mPlan=plan;}
+  void SetPlan(std::string plan) {mPlan=plan;}
   //FlatGenerationFlag
   void SetGeneFlatFlag(bool b) {mFlatGenerationFlag=b;}
   //Pencil beam parameters calculation
@@ -96,7 +96,7 @@ protected:
   bool mIsASourceDescriptionFile;
   G4String mSourceDescriptionFile;
 
-  vector<GateSourcePencilBeam*> mPencilBeams;
+  std::vector<GateSourcePencilBeam*> mPencilBeams;
   double mDistanceSMXToIsocenter;
   double mDistanceSMYToIsocenter;
   double mDistanceSourcePatient;
@@ -114,11 +114,11 @@ protected:
   double *mPDF;
   RandGeneral * mDistriGeneral;
   //Not alloweed fields
-  vector<int> mNotAllowedFields;
+  std::vector<int> mNotAllowedFields;
   //Allowed fields
-  vector<int> mAllowedFields;
+  std::vector<int> mAllowedFields;
   //clinical beam parameters (polynomial equations)
-  vector<double> mEnergy, mEnergySpread, mX, mY, mTheta, mPhi, mXThetaEmittance, mYPhiEmittance;
+  std::vector<double> mEnergy, mEnergySpread, mX, mY, mTheta, mPhi, mXThetaEmittance, mYPhiEmittance;
   //Configuration of spot intensity
   bool mSpotIntensityAsNbProtons;
   //Convergent or divergent beam model

--- a/source/physics/src/GateFastI124.cc
+++ b/source/physics/src/GateFastI124.cc
@@ -47,7 +47,7 @@ void GateFastI124::InitializeFastI124()
   //                               ... / amplitude of majoring function / normalisation factor for energy distribution (Fermi function) / atomic number
 
 	m_simpleDecay = new GateSimplifiedDecay();
-	m_particleVector = new vector<psd>;
+	m_particleVector = new std::vector<psd>;
 	
   m_simpleDecay->addTransition( new GateSimplifiedDecayTransition(0, 1, 0.0175,  mem_fun( &GateSimplifiedDecayTransition::issueGamma),     1.376   )  );
   m_simpleDecay->addTransition( new GateSimplifiedDecayTransition(0, 1, 0.0488,  mem_fun( &GateSimplifiedDecayTransition::issueGamma),     1.509   )  );
@@ -86,12 +86,12 @@ void GateFastI124::GenerateVertex( G4Event* aEvent )
 			m_source->GetParticlePosition(), m_source->GetTime() );
 		
 		// From the vector, create particles with own direction, type and energy
-		for( vector<psd>::iterator it = m_particleVector->begin(); 
+		for( std::vector<psd>::iterator it = m_particleVector->begin(); 
 				 it != m_particleVector->end(); ++it )
 		{
 			if( m_source->GetVerboseLevel() > 1 ) 
 					 G4cout << "GateVSource::GeneratePrimaries - fastI124 " << (*it).first
-				 					<< ' ' << (*it).second << endl;
+				 					<< ' ' << (*it).second << Gateendl;
 									
 			m_source->SetParticleDefinition( 
 				G4ParticleTable::GetParticleTable()->FindParticle( (*it).first )  );

--- a/source/physics/src/GateSourcePencilBeam.cc
+++ b/source/physics/src/GateSourcePencilBeam.cc
@@ -39,7 +39,7 @@
 #include "G4UnitsTable.hh"
 
 // std
-#include <iostream>
+#include <string>
 
 GateSourcePencilBeam::GateSourcePencilBeam(G4String name, bool useMessenger):
   GateVSource(name), mGaussian2DYPhi(NULL), mGaussian2DXTheta(NULL), mGaussianEnergy(NULL)
@@ -138,15 +138,15 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
 
     //---------SOURCE PARAMETERS - CONTROL ----------------
     if (pi*mSigmaX*mSigmaTheta<mEllipseXThetaArea){
-      cout<<"\n !!! ERROR !!! -> Wrong Source Parameters: EmmittanceX-Theta is lower than Pi*SigmaX*SigmaTheta! Please correct it."<<endl;
-      cout<<"Please make sure that the energy used belongs to the beam model energy range."<<endl;
-      cout<<"Energy "<<mEnergy<<"\tX "<<mSigmaX<<"\tTheta "<<mSigmaTheta<<"\tEmittance "<<mEllipseXThetaArea<<"\n"<<endl;
+      G4cout<<"\n !!! ERROR !!! -> Wrong Source Parameters: EmmittanceX-Theta is lower than Pi*SigmaX*SigmaTheta! Please correct it."<<Gateendl;
+      G4cout<<"Please make sure that the energy used belongs to the beam model energy range."<<Gateendl;
+      G4cout<<"Energy "<<mEnergy<<"\tX "<<mSigmaX<<"\tTheta "<<mSigmaTheta<<"\tEmittance "<<mEllipseXThetaArea<<"\n"<<Gateendl;
       exit(0);
     }
     if (pi*mSigmaY*mSigmaPhi<mEllipseYPhiArea){
-      cout<<"\n !!! ERROR !!! -> Wrong Source Parameters: EmmittanceY-Phi is lower than Pi*SigmaY*SigmaPhi! Please correct it.\n"<<endl;
-      cout<<"Please make sure that the energy used belongs to the beam model energy range."<<endl;
-      cout<<"Energy "<<mEnergy<<"\tY "<<mSigmaY<<"\tPhi "<<mSigmaPhi<<"\tEmittance "<<mEllipseYPhiArea<<"\n"<<endl;
+      G4cout<<"\n !!! ERROR !!! -> Wrong Source Parameters: EmmittanceY-Phi is lower than Pi*SigmaY*SigmaPhi! Please correct it.\n"<<Gateendl;
+      G4cout<<"Please make sure that the energy used belongs to the beam model energy range."<<Gateendl;
+      G4cout<<"Energy "<<mEnergy<<"\tY "<<mSigmaY<<"\tPhi "<<mSigmaPhi<<"\tEmittance "<<mEllipseYPhiArea<<"\n"<<Gateendl;
       exit(0);
     }
 
@@ -192,11 +192,11 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     mSXTheta(2,2)=gamma*epsilon;
 
     if (mTestFlag){
-      G4cout<<"--ELIPSE X-THETA PARAMETERS--\n";
-      G4cout<<"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<endl;
-      G4cout<<"Outputs - Xmax² "<<mSXTheta(1,1)<<"  Ymax² "<<mSXTheta(2,2)<<endl;
-      G4cout<<"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<endl;
-      G4cout<<"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<"\n"<<endl;
+      G4cout<<"--ELIPSE X-THETA PARAMETERS--" << Gateendl << Gateendl;
+      G4cout<<"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<Gateendl;
+      G4cout<<"Outputs - Xmax² "<<mSXTheta(1,1)<<"  Ymax² "<<mSXTheta(2,2)<<Gateendl;
+      G4cout<<"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<Gateendl;
+      G4cout<<"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<Gateendl<<Gateendl;
     }
 
     mGaussian2DXTheta = new RandMultiGauss(engine,mUXTheta,mSXTheta);
@@ -218,10 +218,10 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
 
     if (mTestFlag){
       G4cout<<"--ELIPSE Y-PHI PARAMETERS--\n";
-      G4cout<<"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<endl;
-      G4cout<<"Outputs - Xmax² "<<mSYPhi(1,1)<<"  Ymax² "<<mSYPhi(2,2)<<endl;
-      G4cout<<"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<endl;
-      G4cout<<"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<"\n"<<endl;
+      G4cout<<"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<Gateendl;
+      G4cout<<"Outputs - Xmax² "<<mSYPhi(1,1)<<"  Ymax² "<<mSYPhi(2,2)<<Gateendl;
+      G4cout<<"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<Gateendl;
+      G4cout<<"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<"\n"<<Gateendl;
     }
     mGaussian2DYPhi = new RandMultiGauss(engine,mUYPhi,mSYPhi);
 
@@ -231,7 +231,7 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
     G4IonTable* ionTable = G4IonTable::GetIonTable();
 
-    string parttype=mParticleType;
+    std::string parttype=mParticleType;
     if ( parttype == "GenericIon" ){
       particle_definition=  ionTable->GetIon( mAtomicNumber, mAtomicMass, mIonExciteEnergy);
       //G4cout<< Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  GenericIon\n";

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -23,10 +23,12 @@
 #ifndef GATESOURCETPSPENCILBEAM_CC
 #define GATESOURCETPSPENCILBEAM_CC
 
-#include <algorithm>
+// #include <algorithm>
 #include "GateConfiguration.h"
 
 #ifdef G4ANALYSIS_USE_ROOT
+#include <string>
+#include <sstream>
 #include "GateSourceTPSPencilBeam.hh"
 #include "G4Proton.hh"
 #include "GateMiscFunctions.hh"
@@ -324,15 +326,15 @@ void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
               mPencilBeams.push_back(Pencil);
 
               if (mTestFlag) {
-                cout << "Energy\t" << energy << endl;
-                cout << "SetEnergy\t" << GetEnergy(energy) << endl;
-                cout << "SetSigmaEnergy\t" << GetSigmaEnergy(energy) << endl;
-                cout << "SetSigmaX\t" << GetSigmaX(energy) << endl;
-                cout << "SetSigmaY\t" << GetSigmaY(energy) << endl;
-                cout << "SetSigmaTheta\t" << GetSigmaTheta(energy) << endl;
-                cout << "SetSigmaPhi\t" << GetSigmaPhi(energy) << endl;
-                cout << "SetEllipseXThetaArea\t" << GetEllipseXThetaArea(energy) << endl;
-                cout << "SetEllipseYPhiArea\t" << GetEllipseYPhiArea(energy) << endl;
+                G4cout << "Energy\t" << energy << Gateendl;
+                G4cout << "SetEnergy\t" << GetEnergy(energy) << Gateendl;
+                G4cout << "SetSigmaEnergy\t" << GetSigmaEnergy(energy) << Gateendl;
+                G4cout << "SetSigmaX\t" << GetSigmaX(energy) << Gateendl;
+                G4cout << "SetSigmaY\t" << GetSigmaY(energy) << Gateendl;
+                G4cout << "SetSigmaTheta\t" << GetSigmaTheta(energy) << Gateendl;
+                G4cout << "SetSigmaPhi\t" << GetSigmaPhi(energy) << Gateendl;
+                G4cout << "SetEllipseXThetaArea\t" << GetEllipseXThetaArea(energy) << Gateendl;
+                G4cout << "SetEllipseYPhiArea\t" << GetEllipseYPhiArea(energy) << Gateendl;
               }
             }
           }
@@ -597,9 +599,9 @@ return v;
 // FUNCTION
 //------------------------------------------------------------------------------------------------------
 void ReadLineTo3Doubles(double *toto, char *oneline) {
-  string data = oneline;
-  istringstream iss(data);
-  string token;
+  std::string data = oneline;
+  std::istringstream iss(data);
+  std::string token;
   for (int j=0; j<3; j++) {
     getline(iss, token, ' ');
     toto[j]=atof(token.c_str());


### PR DESCRIPTION
This is a code gardening patch.

When I started looking into slurm support for gjs, I noticed that there were a few header files with `using namespace std` in them. My c++ gurus always told me that `using` directives should never be used in header files. So I tried to clean that up. While doing that I also noticed that some of those header files had `#include`s in them which were not at all needed for the declarations (and/or inline implementations) of the classes/functions in those header files. So I removed those `#include`s and added them wherever they were needed in implementation files. Some namespace prefix issues also had to be fixed. In header files I think we should always use explicit prefixes (we cannot use `using`). In an implementation file I'll only use a `using` directive if the used thing occurs many times in that file.

While doing this I noticed that there is a bit of a mess concerning printing messages to standard output. Gate has its own `GateMessage` infrastructure. But in many places also `G4out`, `std::cout` and/or `std::endl` are used, all of which should be replaced with `GateMessage`, I guess. That should then be done in a separate pull request.