### PR TITLE
Change default random seed in GateToImageCT.cc

### DIFF
--- a/source/digits_hits/src/GateToImageCT.cc
+++ b/source/digits_hits/src/GateToImageCT.cc
@@ -34,7 +34,7 @@ GateToImageCT::GateToImageCT( const G4String& name, GateOutputMgr* outputMgr,
   m_system = itsSystem;
 
   //value by default
-  m_seed = 567665;
+  m_seed = -1;
   m_vrtFactor = 0;
   m_fileName = " "; // All default output file from all output modules are set to " ".
   // They are then checked in GateApplicationMgr::StartDAQ, using
@@ -249,7 +249,9 @@ void GateToImageCT::RecordBeginOfAcquisition()
            << Gateendl;
 
   //Seed the random
-  CLHEP::HepRandom::setTheSeed( m_seed );
+  if(m_seed != -1) {
+    CLHEP::HepRandom::setTheSeed( m_seed );
+  }
 
   //Define the number of the first frame, and check the multiplicity of the
   //frame


### PR DESCRIPTION
The call to `CLHEP::HepRandom::setTheSeed()` in `GateToImageCT.cc` appears to override the random engine seed to using `/gate/random/setEngineSeed`.
Since `m_seed` in `GateToImageCT.cc` is set to `567665` by default, this can lead to different simulations, with apparently different random engine seeds, producing identical outputs.

The proposed change alters the default behaviour. 
`m_seed` in `GateToImageCT.cc` is now set to `-1`, and `CLHEP::HepRandom::setTheSeed()` is only called if `/gate/output/imageCT/setStartSeed` is explicitly called by the user, with a value different to the default.
