### PR TITLE
removed material handling from ParameterizedCollimator

### DIFF
--- a/source/geometry/include/GateParameterisedCollimator.hh
+++ b/source/geometry/include/GateParameterisedCollimator.hh
@@ -55,8 +55,6 @@ class GateParameterisedCollimator : public GateBox
 	{ return m_DimensionX; }
      inline G4double GetCollimatorDimensionY() const
 	{ return m_DimensionY; }
-     inline const G4String& GetCollimatorMaterial() const
-	{ return mMaterialName; }
 
      inline void SetCollimatorFocalDistanceX(G4double val)
 	{ m_FocalDistanceX = val; ResizeCollimator();}
@@ -72,12 +70,9 @@ class GateParameterisedCollimator : public GateBox
 	{ m_DimensionX = val; ResizeCollimator(); }
      inline void SetCollimatorDimensionY(G4double val)
 	{ m_DimensionY = val; ResizeCollimator();}
-     inline void SetCollimatorMaterial(const G4String& val)
-	{ mMaterialName = val; ResizeCollimator();}
 
   protected:
      G4double m_FocalDistanceX,m_FocalDistanceY,m_SeptalThickness,m_InnerRadius,m_Height,m_DimensionX,m_DimensionY;
-     G4String mMaterialName;
 
      GateParameterisedHole*                m_holeInserter;
      GateParameterisedCollimatorMessenger* m_messenger;

--- a/source/geometry/src/GateParameterisedCollimator.cc
+++ b/source/geometry/src/GateParameterisedCollimator.cc
@@ -25,8 +25,7 @@ GateParameterisedCollimator::GateParameterisedCollimator(const G4String& itsName
 : GateBox(itsName,"Vacuum",41.,22.,4.,acceptsChildren,depth),
      m_FocalDistanceX(39.7*cm),m_FocalDistanceY(0.0*cm),
      m_SeptalThickness(0.1* cm),m_InnerRadius(0.05*cm),m_Height(4.*cm),
-     m_DimensionX(41.0*cm),m_DimensionY(22.0*cm),
-     mMaterialName("Vacuum")
+     m_DimensionX(41.0*cm),m_DimensionY(22.0*cm)
 { 
   G4cout << " Constructor GateParameterisedCollimator - begin " << itsName << Gateendl;
   
@@ -51,8 +50,7 @@ GateParameterisedCollimator::GateParameterisedCollimator(const G4String& itsName
      : GateBox(itsName,itsMaterialName,itsDimensionX,itsDimensionY,itsHeight,false,false),
      m_FocalDistanceX(itsFocalDistanceX),m_FocalDistanceY(itsFocalDistanceY),
      m_SeptalThickness(itsSeptalThickness),m_InnerRadius(itsInnerRadius),m_Height(itsHeight),
-     m_DimensionX(itsDimensionX),m_DimensionY (itsDimensionY),
-     mMaterialName(itsMaterialName)
+     m_DimensionX(itsDimensionX),m_DimensionY (itsDimensionY)
 {
   m_holeInserter = new GateParameterisedHole("hole","Air",m_FocalDistanceX,m_FocalDistanceY,m_SeptalThickness,
   		m_InnerRadius,m_Height,m_DimensionX,m_DimensionY);
@@ -77,7 +75,6 @@ void GateParameterisedCollimator::ResizeCollimator()
   GetCollimatorCreator()->SetBoxXLength(m_DimensionX);
   GetCollimatorCreator()->SetBoxYLength(m_DimensionY);
   GetCollimatorCreator()->SetBoxZLength(m_Height);
-  GetCollimatorCreator()->SetMaterialName(mMaterialName);
 
   m_holeInserter->ResizeHole(m_FocalDistanceX,m_FocalDistanceY,m_SeptalThickness,m_InnerRadius,
 			     m_Height,m_DimensionX,m_DimensionY);


### PR DESCRIPTION
The GateParameterizedCollimator class had a bug that caused the material of the collimator to be set to Vacuum any time one of the parameters (focal length, hold size, dimensions, etc.) was modified. The work-around was to set the material after all of the other parameters were set, but I've now fixed the code so that's not necessary.

The problem was that the GateParameterizedCollimator class had it's own mMaterialName parameter which defaulted do Vacuum and couldn't be modified. Every time one of the other parameters was updated, the ResizeCollimator function used mMaterialName to update the mMaterialName in the parent-class (grand-parent class ?) GateVVolume. Everything in the GateParameterizedCollimator class that refers to mMaterialName has been deleted. There's no need to duplicate functionality already inherited, much less break the functionality of the parent class.

[There's still a lot of weirdness in this code. I don't understand why the 'this' pointer is accessed by GetCollimatorCreator() (which then calls GetCreater()), rather than just accessing the methods of the parent classes directly. The way this code is written, there's nothing to prevent the user from using the commands inherited from BBox to modify the collimator dimensions, though doing that wouldn't update the holes pattern dimensions to match.]