### PR TITLE
Abort on critical errors.

### DIFF
--- a/Gate.cc
+++ b/Gate.cc
@@ -20,6 +20,7 @@
 
 #include "G4UImanager.hh"
 #include "G4UIterminal.hh"
+#include "GateUIterminal.hh"
 #include "G4UItcsh.hh"
 #include "GateRunManager.hh"
 #include "GateMessageManager.hh"
@@ -349,9 +350,9 @@ int main( int argc, char* argv[] )
 	#endif
 #else
 #ifdef G4UI_USE_TCSH
-      session = new G4UIterminal( new G4UItcsh );
+      session = new GateUIterminal( new G4UItcsh );
 #else
-      session = new G4UIterminal();
+      session = new GateUIterminal();
 #endif
 #endif
 #ifndef _WIN32
@@ -361,9 +362,9 @@ int main( int argc, char* argv[] )
   else
     {
 #ifdef G4UI_USE_TCSH
-      session = new G4UIterminal( new G4UItcsh );
+      session = new GateUIterminal( new G4UItcsh );
 #else
-      session = new G4UIterminal();
+      session = new GateUIterminal();
 #endif
     }
 

--- a/source/general/src/GateUIcontrolMessenger.cc
+++ b/source/general/src/GateUIcontrolMessenger.cc
@@ -69,7 +69,7 @@ void GateUIcontrolMessenger::LaunchMacroFile(G4String fileName)
 {
   G4String filePath = GateTools::FindGateFile(fileName);
   if (filePath.empty()) {
-    G4cerr << "Could not find macro file '" << fileName << "'! Ignored!\n";
+    GateGlobalError("Could not find macro file <" << fileName << ">, execution aborted!\n");
     return;
   }
 

--- a/source/general/src/GateUIterminal.cc
+++ b/source/general/src/GateUIterminal.cc
@@ -52,7 +52,25 @@ G4int GateUIterminal::ReceiveG4cout(G4String coutString)
 #ifdef Geant496_COMPATIBILITY
 G4int GateUIterminal::ReceiveG4cerr(const G4String& cerrString)
 {
-  std::cerr << cerrString << std::flush;
+	std::cerr << "[G4-cerr] " <<  cerrString << std::flush;
+	// Check if this error is 'command not found' (or related) to stop Gate
+    bool isMacroError = false;
+    std::string::size_type i = cerrString.find("***** COMMAND NOT FOUND <", 0);
+    isMacroError = isMacroError || (i != std::string::npos);
+    i = cerrString.find("***** Illegal application state <", 0);
+    isMacroError = isMacroError || (i != std::string::npos);
+    i = cerrString.find("***** Illegal parameter (", 0);
+    isMacroError = isMacroError || (i != std::string::npos);
+    i = cerrString.find("***** Can not open a macro file <", 0);
+    isMacroError = isMacroError || (i != std::string::npos);
+    i = cerrString.find("ERROR: Can not open a macro file <", 0);
+    isMacroError = isMacroError || (i != std::string::npos);
+
+    if (isMacroError) {
+      std::cerr << "[Gate] Sorry, error in a macro command : abort.\n";
+      exit(-1);
+    }
+
   return 0;
 }
 #else


### PR DESCRIPTION
Current code implementation is full of "safe" guesswork which turns debugging unnecessarily difficult.
If an include file is not present, only a log message is emitted:
```ERROR: Can not open a macro file <name_of_the_macro>. Set macro path with "/control/macroPath" if needed.```

If there is an unresolved alias, e.g.
```Alias <zposition> not found -- command ignored```
```***** Illegal parameter (0) </gate/source/sourceName/gps/centre 12.0 34.0 {zposition} mm> *****```
```***** Batch is interrupted!! *****```

but the program still continues to run, with a who-knows-what kind of default setup.
In this particular case the default value is zero, which might or might not be a good guess, but it clearly contradicts the intended use case (i.e. to control a parameter of the simulation).

Such silent errors shall terminate the simulation immediately, with an error message and a nonzero return value.
