### PR TITLE
Fixed relative path to visu.mac in example_fastY90

### DIFF
--- a/examples/example_fastY90/mac/main.mac
+++ b/examples/example_fastY90/mac/main.mac
@@ -7,7 +7,7 @@
 # VISUALISATION
 #=====================================================
 
-#/control/execute visu.mac
+#/control/execute mac/visu.mac
 
 
 #=====================================================


### PR DESCRIPTION
The relative path to visu.mac was missing the 'mac/' folder prefix