### PR TITLE
TPS pencilbeam issue #73

### DIFF
--- a/source/digits_hits/src/GatePhaseSpaceActor.cc
+++ b/source/digits_hits/src/GatePhaseSpaceActor.cc
@@ -108,7 +108,7 @@ void GatePhaseSpaceActor::Construct() {
   EnableBeginOfEventAction(false);
 
   // bEnableEmissionPoint=true;
-  if (bEnablePrimaryEnergy || bEnableEmissionPoint) EnableBeginOfEventAction(true);
+  if (bEnablePrimaryEnergy || bEnableEmissionPoint || bEnableSpotID) EnableBeginOfEventAction(true);
 
   EnablePreUserTrackingAction(true);
   EnableUserSteppingAction(true);

--- a/source/physics/include/GateSourcePencilBeam.hh
+++ b/source/physics/include/GateSourcePencilBeam.hh
@@ -11,7 +11,6 @@
 
 #include "GateConfiguration.h"
 
-#ifdef G4ANALYSIS_USE_ROOT
 #include "G4Event.hh"
 #include "globals.hh"
 #include "G4VPrimaryGenerator.hh"
@@ -34,7 +33,6 @@
 #include "CLHEP/Matrix/Vector.h"
 #include "CLHEP/Matrix/SymMatrix.h"
 #include "GateRandomEngine.hh"
-#include "TMath.h"
 
 class GateSourcePencilBeam : public GateVSource, G4UImessenger
 {
@@ -125,5 +123,4 @@ protected:
   int mCurrentParticleNumber;
 };
 
-#endif
 #endif

--- a/source/physics/include/GateSourcePencilBeam.hh
+++ b/source/physics/include/GateSourcePencilBeam.hh
@@ -76,8 +76,10 @@ public:
   //Correlation Position/Direction
   void SetEllipseXThetaArea(double EllipseXThetaArea) {mEllipseXThetaArea=EllipseXThetaArea;}
   void SetEllipseYPhiArea(double EllipseYPhiArea) {mEllipseYPhiArea=EllipseYPhiArea;}
-  void SetEllipseXThetaRotationNorm(std::string rotation) {mEllipseXThetaRotationNorm=rotation;}
-  void SetEllipseYPhiRotationNorm(std::string rotation) {mEllipseYPhiRotationNorm=rotation;}
+  void SetEllipseXThetaRotationNorm(std::string rotation) {mConvergenceX=(rotation=="positive");}
+  void SetEllipseYPhiRotationNorm(std::string rotation) {mConvergenceY=(rotation=="positive");}
+  void SetConvergenceX(bool b) {mConvergenceX=b;}
+  void SetConvergenceY(bool b) {mConvergenceY=b;}
   void SetTestFlag(bool b) {mTestFlag=b;}
 
 protected:
@@ -108,8 +110,8 @@ protected:
   //Correlation Position/Direction
   double mEllipseXThetaArea;	//mm*rad
   double mEllipseYPhiArea;	//mm*rad
-  std::string mEllipseXThetaRotationNorm;
-  std::string mEllipseYPhiRotationNorm;
+  bool mConvergenceX; // true corresponds to: X-Theta rotation norm is positive
+  bool mConvergenceY; // true corresponds to: Y-Phi rotation norm is positive
   //Gaussian distribution generation for direction
   RandMultiGauss * mGaussian2DYPhi;
   RandMultiGauss * mGaussian2DXTheta;

--- a/source/physics/include/GateSourcePencilBeam.hh
+++ b/source/physics/include/GateSourcePencilBeam.hh
@@ -51,41 +51,41 @@ public:
   void GenerateVertex( G4Event* );
 
   //Particle Type
-  void SetParticleType(G4String ParticleType) {strcpy(mParticleType, ParticleType);}
-  void SetWeight(double w) {mWeight=w; }
+  void SetParticleType(G4String ParticleType) {mIsInitialized &= (ParticleType==mParticleType); mParticleType = ParticleType;}
+  void SetWeight(double w) { mWeight=w; } // no need for re-initialization
   double GetWeight() {return mWeight; }
   //Particle Properties If GenericIon
   void SetIonParameter(G4String ParticleParameters);
   //Energy
-  void SetEnergy(double energy) {mEnergy=energy;}
-  void SetSigmaEnergy(double sigmaE) {mSigmaEnergy=sigmaE;}
+  void SetEnergy(double energy) {mIsInitialized &= (mEnergy==energy); mEnergy=energy;}
+  void SetSigmaEnergy(double sigmaE) {mIsInitialized &= (mSigmaEnergy==sigmaE); mSigmaEnergy=sigmaE;}
   //Position
-  void SetPosition(G4ThreeVector p) {mPosition=p;}
-  void SetSigmaX(double SigmaX) {mSigmaX=SigmaX;}
-  void SetSigmaY(double SigmaY) {mSigmaY=SigmaY;}
+  void SetPosition(G4ThreeVector p) {mPosition=p;} // no need for re-initialization
+  void SetSigmaX(double SigmaX) {mIsInitialized &= (mSigmaX==SigmaX); mSigmaX=SigmaX;}
+  void SetSigmaY(double SigmaY) {mIsInitialized &= (mSigmaY==SigmaY); mSigmaY=SigmaY;}
   //Direction
-  void SetSigmaTheta(double SigmaTheta) {mSigmaTheta=SigmaTheta;}
-  void SetSigmaPhi(double SigmaPhi) {mSigmaPhi=SigmaPhi;}
+  void SetSigmaTheta(double SigmaTheta) {mIsInitialized &= (mSigmaTheta==SigmaTheta); mSigmaTheta=SigmaTheta;}
+  void SetSigmaPhi(double SigmaPhi) {mIsInitialized &= (mSigmaPhi==SigmaPhi); mSigmaPhi=SigmaPhi;}
   // first rotation possibility => Necessary for the GateSourceTPSPencilBeam !!!!!!
-  void SetRotation(G4ThreeVector rot) {mRotation=rot;}
+  void SetRotation(G4ThreeVector rot) {mRotation=rot;} // no need for re-initialization
   //second rotation possibility
-  void SetRotationAxis(G4ThreeVector axis) {mRotationAxis=axis;}
-  void SetRotationAngle(double angle) {mRotationAngle=angle;}
+  void SetRotationAxis(G4ThreeVector axis) {mRotationAxis=axis;} // no need for re-initialization
+  void SetRotationAngle(double angle) {mRotationAngle=angle;} // no need for re-initialization
   //Correlation Position/Direction
-  void SetEllipseXThetaArea(double EllipseXThetaArea) {mEllipseXThetaArea=EllipseXThetaArea;}
-  void SetEllipseYPhiArea(double EllipseYPhiArea) {mEllipseYPhiArea=EllipseYPhiArea;}
-  void SetEllipseXThetaRotationNorm(std::string rotation) {mConvergenceX=(rotation=="positive");}
-  void SetEllipseYPhiRotationNorm(std::string rotation) {mConvergenceY=(rotation=="positive");}
-  void SetConvergenceX(bool b) {mConvergenceX=b;}
-  void SetConvergenceY(bool b) {mConvergenceY=b;}
-  void SetTestFlag(bool b) {mTestFlag=b;}
+  void SetEllipseXThetaArea(double EllipseXThetaArea) {mIsInitialized &= (mEllipseXThetaArea==EllipseXThetaArea); mEllipseXThetaArea=EllipseXThetaArea;}
+  void SetEllipseYPhiArea(double EllipseYPhiArea) {mIsInitialized &= (mEllipseYPhiArea==EllipseYPhiArea); mEllipseYPhiArea=EllipseYPhiArea;}
+  void SetEllipseXThetaRotationNorm(std::string rotation) { SetConvergenceX(rotation=="positive");}
+  void SetEllipseYPhiRotationNorm(std::string rotation) { SetConvergenceY(rotation=="positive");}
+  void SetConvergenceX(bool b) {mIsInitialized &= (mConvergenceX==b); mConvergenceX=b;}
+  void SetConvergenceY(bool b) {mIsInitialized &= (mConvergenceY==b); mConvergenceY=b;}
+  void SetTestFlag(bool b) {mTestFlag=b;} // no need for re-initialization
 
 protected:
   GateSourcePencilBeamMessenger * pMessenger;
 
   bool mIsInitialized;
   //Particle Type
-  char mParticleType[64];
+  G4String mParticleType;
   double mWeight;
   //Particle Properties If GenericIon
   G4int    mAtomicNumber;

--- a/source/physics/include/GateSourcePencilBeamMessenger.hh
+++ b/source/physics/include/GateSourcePencilBeamMessenger.hh
@@ -6,11 +6,10 @@
   See GATE/LICENSE.txt for further details
   ----------------------*/
 
-#include "GateConfiguration.h"
-
-#ifdef G4ANALYSIS_USE_ROOT
 #ifndef GateSourcePencilBeamMessenger_h
 #define GateSourcePencilBeamMessenger_h 1
+
+#include "GateConfiguration.h"
 
 #include "globals.hh"
 #include "G4UImessenger.hh"
@@ -69,6 +68,3 @@ class GateSourcePencilBeamMessenger: public GateVSourceMessenger
 };
 
 #endif
-
-#endif
-

--- a/source/physics/include/GateSourceTPSPencilBeam.hh
+++ b/source/physics/include/GateSourceTPSPencilBeam.hh
@@ -21,6 +21,7 @@
 #include "G4ParticleMomentum.hh"
 #include <iomanip>
 #include <vector>
+#include <string>
 
 #include "GateVSource.hh"
 #include "GateSourceTPSPencilBeamMessenger.hh"
@@ -34,7 +35,7 @@
 #include "GateRandomEngine.hh"
 #include "TMath.h"
 
-void ReadLineTo3Doubles(double *toto, char *oneline);
+void ReadLineTo3Doubles(double *toto, const std::string &oneline);
 
 //------------------------------------------------------------------------------------------------------
 class GateSourceTPSPencilBeam : public GateVSource

--- a/source/physics/include/GateSourceTPSPencilBeam.hh
+++ b/source/physics/include/GateSourceTPSPencilBeam.hh
@@ -95,7 +95,8 @@ protected:
   GateSourceTPSPencilBeamMessenger * pMessenger;
 
   bool mIsInitialized;
-  int mCurrentSpot, mTotalNumberOfSpots, mTotalNbProtons;
+  int mCurrentSpot, mTotalNumberOfSpots;
+  double mTotalNbProtons;
   bool mIsASourceDescriptionFile;
   G4String mSourceDescriptionFile;
 

--- a/source/physics/include/GateSourceTPSPencilBeam.hh
+++ b/source/physics/include/GateSourceTPSPencilBeam.hh
@@ -10,7 +10,6 @@
 
 #include "GateConfiguration.h"
 
-#ifdef G4ANALYSIS_USE_ROOT
 #include "G4Event.hh"
 #include "globals.hh"
 #include "G4VPrimaryGenerator.hh"
@@ -33,7 +32,6 @@
 #include "CLHEP/Matrix/Vector.h"
 #include "CLHEP/Matrix/SymMatrix.h"
 #include "GateRandomEngine.hh"
-#include "TMath.h"
 
 void ReadLineTo3Doubles(double *toto, const std::string &oneline);
 
@@ -55,6 +53,8 @@ public:
   void SetParticleType(G4String ParticleType) {strcpy(mParticleType, ParticleType);}
   //Test Flag
   void SetTestFlag(bool b) {mTestFlag=b;}
+  //Temporary Flag to switch between old and new style vertex generation
+  void SetOldStyleFlag(bool b) {mOldStyleFlag=b;}
   //Treatment Plan file
   void SetPlan(std::string plan) {mPlan=plan;}
   //FlatGenerationFlag
@@ -90,14 +90,17 @@ public:
 
 protected:
 
+  void ConfigurePencilBeam();
+
   GateSourceTPSPencilBeamMessenger * pMessenger;
 
   bool mIsInitialized;
-  int mCurrentSpot, mTotalNumberOfSpots;
+  int mCurrentSpot, mTotalNumberOfSpots, mTotalNbProtons;
   bool mIsASourceDescriptionFile;
   G4String mSourceDescriptionFile;
 
   std::vector<GateSourcePencilBeam*> mPencilBeams;
+  GateSourcePencilBeam* mPencilBeam; // new style vertex generation uses only one pencil beam
   double mDistanceSMXToIsocenter;
   double mDistanceSMYToIsocenter;
   double mDistanceSourcePatient;
@@ -105,6 +108,8 @@ protected:
   char mParticleType[64];
   //Test flag (for verbosity)
   bool mTestFlag;
+  //Old style flag (temporary, for debugging new pencil beam vertex generation)
+  bool mOldStyleFlag;
   //Treatment Plan file
   G4String mPlan;
   //Others
@@ -126,9 +131,15 @@ protected:
   bool mConvergentSource;
   int mSelectedLayerID;
   int mSelectedSpot;
+  std::vector<double> mSpotEnergy;
+  std::vector<double> mSpotWeight; // (proportional to) the expected number (for each bin in a multinomial distribution)
+  std::vector<int> mNbProtonsToGenerate; // the actual number (for each bin in a multinomial distribution)
+  std::vector<G4ThreeVector> mSpotPosition, mSpotRotation;
+private:
+  void OldGenerateVertex( G4Event* );
+  void NewGenerateVertex( G4Event* );
 };
 //------------------------------------------------------------------------------------------------------
 
-
-#endif
+// vim: ai sw=2 ts=2 et
 #endif

--- a/source/physics/include/GateSourceTPSPencilBeamMessenger.hh
+++ b/source/physics/include/GateSourceTPSPencilBeamMessenger.hh
@@ -6,11 +6,10 @@
   See GATE/LICENSE.txt for further details
   ----------------------*/
 
-#include "GateConfiguration.h"
-#ifdef G4ANALYSIS_USE_ROOT
 #ifndef GateSourceTPSPencilBeamMessenger_h
 #define GateSourceTPSPencilBeamMessenger_h 1
 
+#include "GateConfiguration.h"
 #include "globals.hh"
 #include "G4UImessenger.hh"
 #include "GateMessenger.hh"
@@ -48,6 +47,8 @@ class GateSourceTPSPencilBeamMessenger: public GateVSourceMessenger
     G4UIcmdWithAString * pParticleTypeCmd;
     //Configuration of tests
     G4UIcmdWithABool* pTestCmd;
+    //Configuration of vertex generation method
+    G4UIcmdWithABool* pOldStyleCmd;
     //Treatment Plan file
     G4UIcmdWithAString * pPlanCmd;
     //FlatGenerationFlag
@@ -68,6 +69,5 @@ class GateSourceTPSPencilBeamMessenger: public GateVSourceMessenger
     G4UIcmdWithAnInteger * pSelectSpotCmd;
 };
 
-#endif
-
+// vim: ai sw=2 ts=2 et
 #endif

--- a/source/physics/src/GateSourcePencilBeam.cc
+++ b/source/physics/src/GateSourcePencilBeam.cc
@@ -26,11 +26,8 @@
 #ifndef GATESOURCEPENCILBEAM_CC
 #define GATESOURCEPENCILBEAM_CC
 
-#include "GateConfiguration.h"
-
-#ifdef G4ANALYSIS_USE_ROOT
-
 // gate
+#include "GateConfiguration.h"
 #include "GateSourcePencilBeam.hh"
 
 // g4
@@ -390,5 +387,4 @@ G4int GateSourcePencilBeam::GeneratePrimaries( G4Event* event )
   }
 */
 
-#endif
 #endif

--- a/source/physics/src/GateSourcePencilBeam.cc
+++ b/source/physics/src/GateSourcePencilBeam.cc
@@ -73,7 +73,7 @@ GateSourcePencilBeam::GateSourcePencilBeam(G4String name, bool useMessenger):
   mRotationAngle=0;
   //Correlation Position/Direction
   mEllipseXThetaArea=1.;  mEllipseYPhiArea=1.;
-  mEllipseXThetaRotationNorm="negative";  mEllipseYPhiRotationNorm="negative";
+  mConvergenceX = mConvergenceY = false;
   //Gaussian distribution generation for direction
   mUXTheta = HepVector(2); mUYPhi = HepVector(2);
   mSXTheta = HepSymMatrix(2,0); mSYPhi = HepSymMatrix(2,0);
@@ -162,7 +162,7 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
       G4cout<<"*Position: sigmaX = "<<mSigmaX<<" mm   sigmaY = "<<mSigmaY<<" mm\n";
       G4cout<<"*Direction: sigmaTheta = "<<mSigmaTheta<<" rad   sigmaY' = "<<mSigmaPhi<<" rad\n";
       G4cout<<"*Correlation: XTheta ellipse emittance:  "<<mEllipseXThetaArea<<" mm.rad  YPhi ellipse emittance: "<<mEllipseYPhiArea<<" mm.rad\n";
-      G4cout<<"*Correlation: XTheta ellipse rotation DirNorm:  "<<mEllipseXThetaRotationNorm<<"   YPhi ellipse rotation DirNorm: "<<mEllipseYPhiRotationNorm<< Gateendl;
+      G4cout<<"*Correlation: XTheta ellipse rotation DirNorm:  "<<(mConvergenceX?"positive":"negative")<<"   YPhi ellipse rotation DirNorm: "<<(mConvergenceY?"positive":"negative")<< Gateendl;
     }
 
     // for initialization mu=0 everywhere.
@@ -185,7 +185,7 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     gamma=mSigmaTheta*mSigmaTheta/epsilon;
     alpha=sqrt(beta*gamma-1.);
 
-    if (mEllipseXThetaRotationNorm=="negative") {alpha=-alpha;}
+    if (!mConvergenceX) {alpha=-alpha;}
 
     mSXTheta(1,1)=beta*epsilon;
     mSXTheta(1,2)=-alpha*epsilon;
@@ -211,7 +211,7 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     gamma=mSigmaPhi*mSigmaPhi/epsilon;
     alpha=sqrt(beta*gamma-1.);
 
-    if (mEllipseYPhiRotationNorm=="negative") {alpha=-alpha;}
+    if (!mConvergenceY) {alpha=-alpha;}
 
     mSYPhi(1,1)=beta*epsilon;
     mSYPhi(1,2)=-alpha*epsilon;

--- a/source/physics/src/GateSourcePencilBeam.cc
+++ b/source/physics/src/GateSourcePencilBeam.cc
@@ -23,9 +23,6 @@
 //    thanks to the SetX0, SetY0, SetZ0 and SetRotation methods.
 //=======================================================
 
-#ifndef GATESOURCEPENCILBEAM_CC
-#define GATESOURCEPENCILBEAM_CC
-
 // gate
 #include "GateConfiguration.h"
 #include "GateSourcePencilBeam.hh"
@@ -42,7 +39,7 @@ GateSourcePencilBeam::GateSourcePencilBeam(G4String name, bool useMessenger):
   GateVSource(name), mGaussian2DYPhi(NULL), mGaussian2DXTheta(NULL), mGaussianEnergy(NULL)
 {
   //Particle Type
-  strcpy(mParticleType,"proton");
+  mParticleType="proton";
   mWeight=1.;
   //Particle Properties If GenericIon [C12]
   mAtomicNumber=6;
@@ -87,6 +84,9 @@ GateSourcePencilBeam::GateSourcePencilBeam(G4String name, bool useMessenger):
 GateSourcePencilBeam::~GateSourcePencilBeam()
 {
   delete pMessenger;
+  delete mGaussianEnergy;
+  delete mGaussian2DXTheta;
+  delete mGaussian2DYPhi;
   //FIXME segfault when uncommented
   //if (mGaussian2DXTheta) delete mGaussian2DXTheta;
   //if (mGaussian2DYPhi) delete mGaussian2DYPhi;
@@ -135,31 +135,29 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
 
     //---------SOURCE PARAMETERS - CONTROL ----------------
     if (pi*mSigmaX*mSigmaTheta<mEllipseXThetaArea){
-      G4cout<<"\n !!! ERROR !!! -> Wrong Source Parameters: EmmittanceX-Theta is lower than Pi*SigmaX*SigmaTheta! Please correct it."<<Gateendl;
-      G4cout<<"Please make sure that the energy used belongs to the beam model energy range."<<Gateendl;
-      G4cout<<"Energy "<<mEnergy<<"\tX "<<mSigmaX<<"\tTheta "<<mSigmaTheta<<"\tEmittance "<<mEllipseXThetaArea<<"\n"<<Gateendl;
-      exit(0);
+      GateMessage("Beam",0,"Please make sure that the energy used belongs to the beam model energy range."<<Gateendl);
+      GateMessage("Beam",0,"Energy "<<mEnergy<<"\tX "<<mSigmaX<<"\tTheta "<<mSigmaTheta<<"\tEmittance "<<mEllipseXThetaArea<<"\n"<<Gateendl);
+      GateError("!!! ERROR !!! -> Wrong Source Parameters: EmittanceX-Theta is lower than Pi*SigmaX*SigmaTheta! Please correct it."<<Gateendl);
     }
     if (pi*mSigmaY*mSigmaPhi<mEllipseYPhiArea){
-      G4cout<<"\n !!! ERROR !!! -> Wrong Source Parameters: EmmittanceY-Phi is lower than Pi*SigmaY*SigmaPhi! Please correct it.\n"<<Gateendl;
-      G4cout<<"Please make sure that the energy used belongs to the beam model energy range."<<Gateendl;
-      G4cout<<"Energy "<<mEnergy<<"\tY "<<mSigmaY<<"\tPhi "<<mSigmaPhi<<"\tEmittance "<<mEllipseYPhiArea<<"\n"<<Gateendl;
-      exit(0);
+      GateMessage("Beam",0,"Please make sure that the energy used belongs to the beam model energy range."<<Gateendl);
+      GateMessage("Beam",0,"Energy "<<mEnergy<<"\tY "<<mSigmaY<<"\tPhi "<<mSigmaPhi<<"\tEmittance "<<mEllipseYPhiArea<<"\n"<<Gateendl);
+      GateError("!!! ERROR !!! -> Wrong Source Parameters: EmmittanceY-Phi is lower than Pi*SigmaY*SigmaPhi! Please correct it.\n"<<Gateendl);
     }
 
     //---------INITIALIZATION - START----------------------
     mIsInitialized=true;
 
     if (mTestFlag){
-      G4cout<<"----------------TEST CONFIG---------------------------\n";
-      G4cout<<"--PENCIL BEAM PARAMETERS--\n";
-      G4cout<<"*Energy: E0 = "<<mEnergy<<" MeV   SigmaEnergy = "<<mSigmaEnergy<<" MeV\n";
-      //G4cout<<"*Position: X0 = "<<mX0<<"   Y0 = "<<mY0<<"   Z0 = "<<mZ0<< Gateendl;
-      G4cout<<"*Position: X0 = "<<mPosition[0]<<"   Y0 = "<<mPosition[1]<<"   Z0 = "<<mPosition[2]<< Gateendl;
-      G4cout<<"*Position: sigmaX = "<<mSigmaX<<" mm   sigmaY = "<<mSigmaY<<" mm\n";
-      G4cout<<"*Direction: sigmaTheta = "<<mSigmaTheta<<" rad   sigmaY' = "<<mSigmaPhi<<" rad\n";
-      G4cout<<"*Correlation: XTheta ellipse emittance:  "<<mEllipseXThetaArea<<" mm.rad  YPhi ellipse emittance: "<<mEllipseYPhiArea<<" mm.rad\n";
-      G4cout<<"*Correlation: XTheta ellipse rotation DirNorm:  "<<(mConvergenceX?"positive":"negative")<<"   YPhi ellipse rotation DirNorm: "<<(mConvergenceY?"positive":"negative")<< Gateendl;
+      GateMessage("Beam",0,"----------------TEST CONFIG---------------------------" << Gateendl);
+      GateMessage("Beam",0,"--PENCIL BEAM PARAMETERS--" << Gateendl);
+      GateMessage("Beam",0,"*Energy: E0 = "<<mEnergy<<" MeV   SigmaEnergy = "<<mSigmaEnergy<<" MeV" << Gateendl);
+      //GateMessage("Beam",0,"*Position: X0 = "<<mX0<<"   Y0 = "<<mY0<<"   Z0 = "<<mZ0<< Gateendl);
+      GateMessage("Beam",0,"*Position: X0 = "<<mPosition[0]<<"   Y0 = "<<mPosition[1]<<"   Z0 = "<<mPosition[2]<< Gateendl);
+      GateMessage("Beam",0,"*Position: sigmaX = "<<mSigmaX<<" mm   sigmaY = "<<mSigmaY<<" mm" << Gateendl);
+      GateMessage("Beam",0,"*Direction: sigmaTheta = "<<mSigmaTheta<<" rad   sigmaY' = "<<mSigmaPhi<<" rad" << Gateendl);
+      GateMessage("Beam",0,"*Correlation: XTheta ellipse emittance:  "<<mEllipseXThetaArea<<" mm.rad  YPhi ellipse emittance: "<<mEllipseYPhiArea<<" mm.rad" << Gateendl);
+      GateMessage("Beam",0,"*Correlation: XTheta ellipse rotation DirNorm:  "<<(mConvergenceX?"positive":"negative")<<"   YPhi ellipse rotation DirNorm: "<<(mConvergenceY?"positive":"negative")<< Gateendl);
     }
 
     // for initialization mu=0 everywhere.
@@ -169,15 +167,18 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     mUYPhi(1)=0.;		//mu Y
     mUYPhi(2)=0.;		//mu phi
 
-    mGaussianEnergy = new RandGauss(engine, mEnergy, mSigmaEnergy);
-    //G4cout << "A.Resch 2016: mGaussianEnergy " << mGaussianEnergy<<G4endl<<G4endl<<G4endl<<G4endl<<G4endl;
+    delete mGaussianEnergy;
+    mGaussianEnergy = new RandGauss(*engine, mEnergy, mSigmaEnergy);
+    //GateMessage("Beam",0,< "A.Resch 2016: mGaussianEnergy " << mGaussianEnergy<<G4endl<<G4endl<<G4endl<<G4endl<<G4endl);
 	
     // Notations & Calculations based on Transport code - Beam Phase Space Notations - P35
     double alpha, beta, gamma, epsilon;
     //==============================================================
     // X Theta Phase Space Ellipse
     epsilon=mEllipseXThetaArea/pi;
-    if (epsilon==0) { G4cout<<"Error Elipse area is 0 !!!\n";}
+    if (epsilon==0) {
+      GateError("Error Elipse area is 0 !!!" << Gateendl);
+    }
     beta=mSigmaX*mSigmaX/epsilon;
     gamma=mSigmaTheta*mSigmaTheta/epsilon;
     alpha=sqrt(beta*gamma-1.);
@@ -190,21 +191,24 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     mSXTheta(2,2)=gamma*epsilon;
 
     if (mTestFlag){
-      G4cout<<"--ELIPSE X-THETA PARAMETERS--" << Gateendl << Gateendl;
-      G4cout<<"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<Gateendl;
-      G4cout<<"Outputs - Xmax² "<<mSXTheta(1,1)<<"  Ymax² "<<mSXTheta(2,2)<<Gateendl;
-      G4cout<<"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<Gateendl;
-      G4cout<<"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<Gateendl<<Gateendl;
+      GateMessage("Beam",0,"--ELIPSE X-THETA PARAMETERS--" << Gateendl);
+      GateMessage("Beam",0,"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<Gateendl);
+      GateMessage("Beam",0,"Outputs - Xmax² "<<mSXTheta(1,1)<<"  Ymax² "<<mSXTheta(2,2)<<Gateendl);
+      GateMessage("Beam",0,"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<Gateendl);
+      GateMessage("Beam",0,"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<Gateendl);
     }
 
-    mGaussian2DXTheta = new RandMultiGauss(engine,mUXTheta,mSXTheta);
+    delete mGaussian2DXTheta;
+    mGaussian2DXTheta = new RandMultiGauss(*engine,mUXTheta,mSXTheta);
 
-    //G4cout << "A.Resch 2016: mGaussian2DXThetay " << mGaussian2DXTheta<<G4endl;
+    //GateMessage("Beam",0,< "A.Resch 2016: mGaussian2DXThetay " << mGaussian2DXTheta<<G4endl);
     //==============================================================
     // Y Phi Phase Space Ellipse
     epsilon=mEllipseYPhiArea/pi;
     beta=mSigmaY*mSigmaY/epsilon;
-    if (epsilon==0) {G4cout<<"Error Elipse area is 0 !!!\n";}
+    if (epsilon==0) {
+      GateError("Error Elipse area is 0 !!!" << Gateendl);
+    }
     gamma=mSigmaPhi*mSigmaPhi/epsilon;
     alpha=sqrt(beta*gamma-1.);
 
@@ -216,13 +220,14 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     mSYPhi(2,2)=gamma*epsilon;
 
     if (mTestFlag){
-      G4cout<<"--ELIPSE Y-PHI PARAMETERS--\n";
-      G4cout<<"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<Gateendl;
-      G4cout<<"Outputs - Xmax² "<<mSYPhi(1,1)<<"  Ymax² "<<mSYPhi(2,2)<<Gateendl;
-      G4cout<<"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<Gateendl;
-      G4cout<<"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<"\n"<<Gateendl;
+      GateMessage("Beam",0,"--ELIPSE Y-PHI PARAMETERS--\n");
+      GateMessage("Beam",0,"Outputs - beta "<<beta<<"  gamma "<<gamma<<"   alpha" <<alpha<<"   epsilon" <<epsilon<<Gateendl);
+      GateMessage("Beam",0,"Outputs - Xmax² "<<mSYPhi(1,1)<<"  Ymax² "<<mSYPhi(2,2)<<Gateendl);
+      GateMessage("Beam",0,"Outputs - beta*gamma-1 = "<<beta*gamma-1.<<Gateendl);
+      GateMessage("Beam",0,"Outputs - beta*gamma-alpha*alpha = "<<beta*gamma-alpha*alpha<<Gateendl);
     }
-    mGaussian2DYPhi = new RandMultiGauss(engine,mUYPhi,mSYPhi);
+    delete mGaussian2DYPhi;
+    mGaussian2DYPhi = new RandMultiGauss(*engine,mUYPhi,mSYPhi);
 
     //---------INITIALIZATION - END-----------------------
 
@@ -230,18 +235,19 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
     G4IonTable* ionTable = G4IonTable::GetIonTable();
 
-    std::string parttype=mParticleType;
-    if ( parttype == "GenericIon" ){
+    if ( mParticleType == "GenericIon" ){
       particle_definition=  ionTable->GetIon( mAtomicNumber, mAtomicMass, mIonExciteEnergy);
-      //G4cout<< Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  GenericIon\n";
-      //G4cout<<mAtomicNumber<<"  "<<mAtomicMass<<"  "<<mIonCharge<<"  "<<mIonExciteEnergy<< Gateendl;
+      GateMessage("Beam",3, "mParticleType  "<<mParticleType<<"     selected loop \"GenericIon\"" << Gateendl);
+      GateMessage("Beam",3,mAtomicNumber<<"  "<<mAtomicMass<<"  "<<mIonCharge<<"  "<<mIonExciteEnergy<< Gateendl);
     }
     else{
       particle_definition = particleTable->FindParticle(mParticleType);
-      //G4cout<< Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  other\n";
+      GateMessage("Beam",3, "mParticleType  "<<mParticleType<<"     selected loop \"other\"" << Gateendl);
     }
 
-    if(particle_definition==0) return;
+    if(particle_definition==0){
+      GateError("ERROR: UNSUPPORTED PARTICLE TYPE: " << mParticleType << Gateendl);
+    }
   }
 
   //=======================================================
@@ -269,10 +275,10 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
   if (mTestFlag){
     //Pos[0]=1; Pos[1]=2; Pos[2]=1000;
     //Dir[0]=0; Dir[1]=0; Dir[2]=1;
-    G4cout<<" \n";
-    G4cout<<"--SPOT GENERATION--\n";
-    G4cout<<"°Initial Position        "<<Pos[0]<<"  "<<Pos[1]<<"  "<<Pos[2]<< Gateendl;
-    G4cout<<"°Initial Direction       "<<Dir[0]<<"  "<<Dir[1]<<"  "<<Dir[2]<< Gateendl;
+    GateMessage("Beam",0,"===================" << Gateendl);
+    GateMessage("Beam",0,"--SPOT GENERATION--" << Gateendl);
+    GateMessage("Beam",0,"°Initial Position        "<<Pos[0]<<"  "<<Pos[1]<<"  "<<Pos[2]<< Gateendl);
+    GateMessage("Beam",0,"°Initial Direction       "<<Dir[0]<<"  "<<Dir[1]<<"  "<<Dir[2]<< Gateendl);
   }
 
   //Rotation and position are performed so that user defines the beam at 0,0,0, with beam direction +Z.
@@ -288,9 +294,9 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
   Pos.rotate(mRotationAngle, mRotationAxis);
 
   if (mTestFlag){
-    G4cout<<"-AFTER ROTATION \n";
-    G4cout<<"°Intermediate Position   "<<Pos[0]<<"  "<<Pos[1]<<"  "<<Pos[2]<< Gateendl;
-    G4cout<<"°Final Direction         "<<Dir[0]<<"  "<<Dir[1]<<"  "<<Dir[2]<< Gateendl;
+    GateMessage("Beam",0,"-AFTER ROTATION \n");
+    GateMessage("Beam",0,"°Intermediate Position   "<<Pos[0]<<"  "<<Pos[1]<<"  "<<Pos[2]<< Gateendl);
+    GateMessage("Beam",0,"°Final Direction         "<<Dir[0]<<"  "<<Dir[1]<<"  "<<Dir[2]<< Gateendl);
   }
   // initial position offset
   Pos[0]+=mPosition[0];
@@ -299,9 +305,9 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
 
 
   if (mTestFlag){
-    G4cout<<"-AFTER POSITION OFFSET \n";
-    G4cout<<"°Final Position   "<<Pos[0]<<"  "<<Pos[1]<<"  "<<Pos[2]<< Gateendl;
-    //G4cout<<"°Final Direction  "<<Dir[0]<<"  "<<Dir[1]<<"  "<<Dir[2]<< Gateendl;
+    GateMessage("Beam",0,"-AFTER POSITION OFFSET \n");
+    GateMessage("Beam",0,"°Final Position   "<<Pos[0]<<"  "<<Pos[1]<<"  "<<Pos[2]<< Gateendl);
+    //GateMessage("Beam",0,"°Final Direction  "<<Dir[0]<<"  "<<Dir[1]<<"  "<<Dir[2]<< Gateendl);
   }
 
   //-------- PARTICLE SAMPLING - END------------------
@@ -316,12 +322,12 @@ void GateSourcePencilBeam::GenerateVertex( G4Event* aEvent )
     string parttype=mParticleType;
     if ( parttype == "GenericIon" ){
     particle_definition=  particleTable->GetIon( mAtomicNumber, mAtomicMass, mIonExciteEnergy);
-    //G4cout<< Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  GenericIon\n";
-    //G4cout<<mAtomicNumber<<"  "<<mAtomicMass<<"  "<<mIonCharge<<"  "<<mIonExciteEnergy<< Gateendl;
+    //GateMessage("Beam",0, Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  GenericIon\n");
+    //GateMessage("Beam",0,mAtomicNumber<<"  "<<mAtomicMass<<"  "<<mIonCharge<<"  "<<mIonExciteEnergy<< Gateendl);
     }
     else{
     particle_definition = particleTable->FindParticle(mParticleType);
-    //G4cout<< Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  other\n";
+    //GateMessage("Beam",0, Gateendl<< Gateendl<<"mParticleType  "<<mParticleType<<"     selected loop  other\n");
     }
 
     if(particle_definition==0) return;
@@ -365,7 +371,7 @@ G4int GateSourcePencilBeam::GeneratePrimaries( G4Event* event )
               << " mom=" << p->GetMomentum()
               << " ptime=" <<  G4BestUnit(p->GetProperTime(), "Time")
               << " atime=" <<  G4BestUnit(GetTime(), "Time")
-              << ")\n");
+              << ")" << Gateendl);
 
   numVertices++;
   return numVertices;
@@ -387,4 +393,4 @@ G4int GateSourcePencilBeam::GeneratePrimaries( G4Event* event )
   }
 */
 
-#endif
+// vim: ai sw=2 ts=2 et

--- a/source/physics/src/GateSourcePencilBeamMessenger.cc
+++ b/source/physics/src/GateSourcePencilBeamMessenger.cc
@@ -5,12 +5,9 @@
   of the GNU Lesser General  Public Licence (LGPL)
   See GATE/LICENSE.txt for further details
   ----------------------*/
-#ifndef GATESOURCEPENCILBEAMMESSENGER_CC
-#define GATESOURCEPENCILBEAMMESSENGER_CC
 
 #include "GateConfiguration.h"
 
-#ifdef G4ANALYSIS_USE_ROOT
 #include "GateSourcePencilBeamMessenger.hh"
 #include "GateSourcePencilBeam.hh"
 #include "GateUIcmdWithTwoDouble.hh"
@@ -147,6 +144,3 @@ void GateSourcePencilBeamMessenger::SetNewValue(G4UIcommand* command,G4String ne
   //Tests
   if (command == pTestCmd) {pSourcePencilBeam->SetTestFlag(pTestCmd->GetNewBoolValue(newValue)); }
 }
-#endif
-
-#endif

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -54,6 +54,7 @@ GateSourceTPSPencilBeam::GateSourceTPSPencilBeam(G4String name ):GateVSource( na
   mConvergentSource=false;
   mSelectedLayerID = -1; // all layer selected by default
   mSelectedSpot = -1; // all spots selected by default
+  mTotalNbProtons = 0.;
 }
 //------------------------------------------------------------------------------------------------------
 
@@ -808,17 +809,17 @@ void GateSourceTPSPencilBeam::LoadClinicalBeamProperties() {
   }
 
   if (mTestFlag) {
-    G4cout<<"DSP "<<mDistanceSourcePatient<< Gateendl;
-    G4cout<<"SMX "<<mDistanceSMXToIsocenter<< Gateendl;
-    G4cout<<"SMY "<<mDistanceSMYToIsocenter<< Gateendl;
-    for (unsigned int i=0; i<mEnergy.size(); i++) G4cout<<"mEnergy\t"<<mEnergy[i]<< Gateendl;
-    for (unsigned int i=0; i<mEnergySpread.size(); i++) G4cout<<"mEnergySpread\t"<<mEnergySpread[i]<< Gateendl;
-    for (unsigned int i=0; i<mX.size(); i++) G4cout<<"mX\t"<<mX[i]<< Gateendl;
-    for (unsigned int i=0; i<mTheta.size(); i++) G4cout<<"mTheta\t"<<mTheta[i]<< Gateendl;
-    for (unsigned int i=0; i<mY.size(); i++) G4cout<<"mY\t"<<mY[i]<< Gateendl;
-    for (unsigned int i=0; i<mPhi.size(); i++) G4cout<<"mPhi\t"<<mPhi[i]<< Gateendl;
-    for (unsigned int i=0; i<mXThetaEmittance.size(); i++) G4cout<<"mXThetaEmittance\t"<<mXThetaEmittance[i]<< Gateendl;
-    for (unsigned int i=0; i<mYPhiEmittance.size(); i++) G4cout<<"mYPhiEmittance\t"<<mYPhiEmittance[i]<< Gateendl;
+    GateMessage("Beam",0,"TESTREAD DSP "<<mDistanceSourcePatient<< Gateendl);
+    GateMessage("Beam",0,"TESTREAD SMX "<<mDistanceSMXToIsocenter<< Gateendl);
+    GateMessage("Beam",0,"TESTREAD SMY "<<mDistanceSMYToIsocenter<< Gateendl);
+    for (unsigned int i=0; i<mEnergy.size(); i++) GateMessage("Beam",0,"TESTREAD mEnergy\t"<<mEnergy[i]<< Gateendl);
+    for (unsigned int i=0; i<mEnergySpread.size(); i++) GateMessage("Beam",0,"TESTREAD mEnergySpread\t"<<mEnergySpread[i]<< Gateendl);
+    for (unsigned int i=0; i<mX.size(); i++) GateMessage("Beam",0,"TESTREAD mX\t"<<mX[i]<< Gateendl);
+    for (unsigned int i=0; i<mTheta.size(); i++) GateMessage("Beam",0,"TESTREAD mTheta\t"<<mTheta[i]<< Gateendl);
+    for (unsigned int i=0; i<mY.size(); i++) GateMessage("Beam",0,"TESTREAD mY\t"<<mY[i]<< Gateendl);
+    for (unsigned int i=0; i<mPhi.size(); i++) GateMessage("Beam",0,"TESTREAD mPhi\t"<<mPhi[i]<< Gateendl);
+    for (unsigned int i=0; i<mXThetaEmittance.size(); i++) GateMessage("Beam",0,"TESTREAD mXThetaEmittance\t"<<mXThetaEmittance[i]<< Gateendl);
+    for (unsigned int i=0; i<mYPhiEmittance.size(); i++) GateMessage("Beam",0,"TESTREAD mYPhiEmittance\t"<<mYPhiEmittance[i]<< Gateendl);
   }
 }
 //------------------------------------------------------------------------------------------------------

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -102,7 +102,7 @@ void GateSourceTPSPencilBeam::OldGenerateVertex( G4Event *aEvent ) {
 
     if (mIsASourceDescriptionFile) {
       LoadClinicalBeamProperties();
-      GateMessage("Physic", 1, "[TPSPencilBeam] Source description file successfully loaded.\n");
+      GateMessage("Beam", 1, "[TPSPencilBeam] Source description file successfully loaded." << Gateendl);
     } else {
       GateError("No clinical beam loaded !");
     }
@@ -353,7 +353,7 @@ void GateSourceTPSPencilBeam::OldGenerateVertex( G4Event *aEvent ) {
         }
       }
       again = false;
-      GateMessage("Physic", 1, "[TPSPencilBeam] Plan description file successfully loaded.\n");
+      GateMessage("Beam", 1, "[TPSPencilBeam] Plan description file successfully loaded." << Gateendl);
     }
     inFile.close();
 
@@ -362,8 +362,8 @@ void GateSourceTPSPencilBeam::OldGenerateVertex( G4Event *aEvent ) {
       GateError("0 spots have been loaded from the file \"" << mPlan << "\" simulation abort!");
     }
 
-    GateMessage("Physic", 1, "[TPSPencilBeam] Starting particle generation:  "
-                << mTotalNumberOfSpots << " spots loaded.\n");
+    GateMessage("Beam", 1, "[TPSPencilBeam] Starting particle generation:  "
+                << mTotalNumberOfSpots << " spots loaded." << Gateendl );
     mPDF = new double[mTotalNumberOfSpots];
     for (int i = 0; i < mTotalNumberOfSpots; i++) {
       // it is strongly adviced to set mFlatGenerationFlag=false
@@ -411,7 +411,7 @@ typename std::vector<T> parse_N_items_of_type_T(std::string line,int lineno, con
 // * check that we really get N items of type T from the current line
 // * throw exception with informative error message in case of trouble
 template<typename T, int N>
-typename std::vector<T>  ReadNextContentLine( istream& input, int& lineno, const G4String& fname ) {
+typename std::vector<T>  ReadNextContentLine( istream& input, int& lineno, const std::string& fname ) {
   while ( input ){
     std::string line;
     std::getline(input,line);
@@ -429,7 +429,7 @@ void GateSourceTPSPencilBeam::NewGenerateVertex( G4Event *aEvent ) {
 
   bool need_pencilbeam_config = false;
   if (!mIsInitialized) {
-    GateMessage("Beam", 0, "[TPSPencilBeam] going to try loading the PBS plan description.\n");
+    GateMessage("Beam", 1, "[TPSPencilBeam] Going to try loading the PBS plan description." << Gateendl );
     // get GATE random engine
     CLHEP::HepRandomEngine *engine = GateRandomEngine::GetInstance()->GetRandomEngine();
     // the "false" means -> do not create messenger (memory gain)
@@ -447,7 +447,7 @@ void GateSourceTPSPencilBeam::NewGenerateVertex( G4Event *aEvent ) {
 
     if (mIsASourceDescriptionFile) {
       LoadClinicalBeamProperties();
-      GateMessage("Beam", 1, "[TPSPencilBeam] Source description file successfully loaded.\n");
+      GateMessage("Beam", 1, "[TPSPencilBeam] Source description file successfully loaded." << Gateendl );
     } else {
       GateError("No clinical beam loaded !");
     }
@@ -588,7 +588,7 @@ void GateSourceTPSPencilBeam::NewGenerateVertex( G4Event *aEvent ) {
         }
       }
       mTotalNumberOfSpots = mSpotWeight.size();
-      GateMessage("Beam", 1, "[TPSPencilBeam] Plan description file \"" << mPlan << "\" successfully loaded: " << NbFields << " field(s) with a total of " << mTotalNumberOfSpots << " spots, " << nrejected << " spots rejected.\n");
+      GateMessage("Beam", 1, "[TPSPencilBeam] Plan description file \"" << mPlan << "\" successfully loaded: " << NbFields << " field(s) with a total of " << mTotalNumberOfSpots << " spots, " << nrejected << " spots rejected." << Gateendl );
     } catch ( const std::runtime_error& oops ){
       GateError("Something went wrong while parsing plan description file \"" << mPlan << "\": " << Gateendl << oops.what() << Gateendl );
     }
@@ -622,6 +622,7 @@ void GateSourceTPSPencilBeam::NewGenerateVertex( G4Event *aEvent ) {
       GateMessage("Beam", 3, "[TPSPencilBeam] bin " << std::setw(5) << i << ": spotweight=" << std::setw(8) << mPDF[i] << ", Ngen=" << mNbProtonsToGenerate[i] << Gateendl );
     }
     need_pencilbeam_config = true;
+    GateMessage("Beam", 1, "[TPSPencilBeam] Plan description file successfully loaded." << Gateendl );
 
     //---------INITIALIZATION - END-----------------------
   }

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -20,21 +20,22 @@
 //Corrected angle calculation to be conform with DICOM standards
 //Corrected energy distribution to conform to expected behaviour and publication
 
-#ifndef GATESOURCETPSPENCILBEAM_CC
-#define GATESOURCETPSPENCILBEAM_CC
-
-// #include <algorithm>
 #include "GateConfiguration.h"
-
-#ifdef G4ANALYSIS_USE_ROOT
 #include <string>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+#include <iomanip>
+#include <iterator>
+#include <exception>
 #include <sstream>
 #include "GateSourceTPSPencilBeam.hh"
 #include "G4Proton.hh"
 #include "GateMiscFunctions.hh"
+#include "GateApplicationMgr.hh"
 
 //------------------------------------------------------------------------------------------------------
-GateSourceTPSPencilBeam::GateSourceTPSPencilBeam(G4String name ):GateVSource( name ), mDistriGeneral(NULL)
+GateSourceTPSPencilBeam::GateSourceTPSPencilBeam(G4String name ):GateVSource( name ), mPencilBeam(NULL), mDistriGeneral(NULL)
 {
 
   strcpy(mParticleType,"proton");
@@ -42,6 +43,7 @@ GateSourceTPSPencilBeam::GateSourceTPSPencilBeam(G4String name ):GateVSource( na
   mDistanceSMYToIsocenter=1000;
   mDistanceSourcePatient=500;
   pMessenger = new GateSourceTPSPencilBeamMessenger(this);
+  mOldStyleFlag=false;
   mTestFlag=false;
   mCurrentParticleNumber=0;
   mCurrentSpot=0;
@@ -62,12 +64,20 @@ GateSourceTPSPencilBeam::~GateSourceTPSPencilBeam() {
   //  for (int i=0; i<mPencilBeams.size(); i++)  { delete mPencilBeams[i]; }
   //FIXME segfault when uncommented
   //if (mDistriGeneral) delete mDistriGeneral;
+  // maybe we should delete mPencilBeam, maybe not...
 }
 //------------------------------------------------------------------------------------------------------
 
+void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
+  if (mOldStyleFlag) {
+    this->OldGenerateVertex(aEvent);
+  } else {
+    this->NewGenerateVertex(aEvent);
+  }
+}
 
 //------------------------------------------------------------------------------------------------------
-void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
+void GateSourceTPSPencilBeam::OldGenerateVertex( G4Event *aEvent ) {
 
   if (!mIsInitialized) {
     // get GATE random engine
@@ -368,12 +378,321 @@ void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
 
     //---------INITIALIZATION - END-----------------------
   }
-  //---------GENERATION - START-----------------------
+  //---------OLD GENERATION - START-----------------------
   int bin = mTotalNumberOfSpots * mDistriGeneral->fire();
   mCurrentSpot = bin;
   mPencilBeams[bin]->GenerateVertex(aEvent);
 }
+//---------OLD GENERATION - END-----------------------
+
+template<typename T, int N>
+typename std::vector<T> parse_N_items_of_type_T(std::string line,int lineno, const std::string& fname){
+    std::istringstream sin(line);
+    typename std::istream_iterator<T> eos;
+    typename std::istream_iterator<T> isd(sin);
+    typename std::vector<T> vecT(N);
+    typename std::vector<T>::iterator endT = std::copy(isd,eos,vecT.begin());
+    size_t nread = endT - vecT.begin();
+    if (nread != N){
+        std::ostringstream errMsg;
+        errMsg << "wrong number of items ("
+               << nread << ") on line " << lineno << " of " << fname
+               << "; expected " << N << " item(s) of type " << typeid(T).name()<< std::endl;
+        throw std::runtime_error(errMsg.str());
+    }
+    return vecT;
+}
+
+
+// Function to read the next content line
+// * skip all comment lines (lines string with a '#')
+// * skip empty
+// * check that we really get N items of type T from the current line
+// * throw exception with informative error message in case of trouble
+template<typename T, int N>
+typename std::vector<T>  ReadNextContentLine( istream& input, int& lineno, const G4String& fname ) {
+  while ( input ){
+    std::string line;
+    std::getline(input,line);
+    ++lineno;
+    if (line.empty()) continue;
+    if (line[0]=='#') continue;
+    return parse_N_items_of_type_T<T,N>(line,lineno,fname);
+  }
+  throw std::runtime_error(std::string("reached end of file")+fname+std::string("unexpectedly"));
+}
+
+
+//------------------------------------------------------------------------------------------------------
+void GateSourceTPSPencilBeam::NewGenerateVertex( G4Event *aEvent ) {
+
+  bool need_pencilbeam_config = false;
+  if (!mIsInitialized) {
+    GateMessage("Beam", 0, "[TPSPencilBeam] going to try loading the PBS plan description.\n");
+    // get GATE random engine
+    CLHEP::HepRandomEngine *engine = GateRandomEngine::GetInstance()->GetRandomEngine();
+    // the "false" means -> do not create messenger (memory gain)
+    mPencilBeam = new GateSourcePencilBeam("PencilBeam", false);
+
+
+    //---------INITIALIZATION - START----------------------
+    mIsInitialized = true;
+
+    double NbProtons = 0.; // actually: spot weight
+
+    if (mSelectedLayerID != -1 && mSelectedLayerID%2 == 1){
+      GateError("Invalid LayerID selected! Select the first ControlPointIndex of a pair (an even number).");
+    }
+
+    if (mIsASourceDescriptionFile) {
+      LoadClinicalBeamProperties();
+      GateMessage("Beam", 1, "[TPSPencilBeam] Source description file successfully loaded.\n");
+    } else {
+      GateError("No clinical beam loaded !");
+    }
+
+    std::ifstream inFile(mPlan);
+    if (! inFile) {
+      GateError("Cannot open Treatment plan file!");
+    }
+
+    // integrating the plan description file data
+    try {
+      int lineno = 0;
+      std::string dummy_PlanName = ReadNextContentLine<std::string,1>(inFile,lineno,mPlan)[0];
+      int dummy_NbOfFractions = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0]; // not used
+      std::string dummy_FractionID = ReadNextContentLine<std::string,1>(inFile,lineno,mPlan)[0]; // not used
+      if ( dummy_NbOfFractions != 1){
+        GateMessage("Beam",0,"WARNING: nb of fractions is assumed to be 1, but plan file says: " << dummy_NbOfFractions << " and fractionID=" << dummy_FractionID << Gateendl);
+      }
+      int NbFields = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0];
+      for (int f = 0; f < NbFields; f++) {
+        // field IDs, not used
+        int dummy_fieldID = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0];
+        GateMessage("Beam",4,"Field ID " << dummy_fieldID << Gateendl );
+      }
+      double TotalMeterSet = ReadNextContentLine<double,1>(inFile,lineno,mPlan)[0];
+      int nrejected = 0; // number of spots rejected based on layer/spot selection configuration
+      for (int f = 0; f < NbFields; f++) {
+        int FieldID = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0];
+        double MeterSetWeight = ReadNextContentLine<double,1>(inFile,lineno,mPlan)[0];
+        GateMessage("Beam",4,"TODO: check that total MSW for this field is indeed " << MeterSetWeight << Gateendl );
+        double GantryAngle = deg2rad(ReadNextContentLine<double,1>(inFile,lineno,mPlan)[0]);
+        double CouchAngle = deg2rad(ReadNextContentLine<double,1>(inFile,lineno,mPlan)[0]);
+        std::vector<double> IsocenterPosition = ReadNextContentLine<double,3>(inFile,lineno,mPlan);
+        int NbOfLayers = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0];
+        for (int j = 0; j < NbOfLayers; j++) {
+          int currentLayerID = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0];
+          std::string dummy_spotID = ReadNextContentLine<std::string,1>(inFile,lineno,mPlan)[0];
+          GateMessage("Beam",4,"spot ID " << dummy_spotID << Gateendl );
+          int dummy_cumulative_msw = ReadNextContentLine<double,1>(inFile,lineno,mPlan)[0];
+          GateMessage("Beam",4,"cumulative MSW = " << dummy_cumulative_msw << Gateendl );
+          double energy = ReadNextContentLine<double,1>(inFile,lineno,mPlan)[0];
+          int NbOfSpots = ReadNextContentLine<int,1>(inFile,lineno,mPlan)[0];
+          if (mTestFlag) {
+            GateMessage( "Beam", 1, "TESTREAD NbFields " << NbFields << Gateendl );
+            GateMessage( "Beam", 1, "TESTREAD TotalMeterSet " << TotalMeterSet << Gateendl );
+            GateMessage( "Beam", 1, "TESTREAD FieldID " << FieldID << Gateendl );
+            GateMessage( "Beam", 1, "TESTREAD GantryAngle " << GantryAngle << Gateendl );
+            GateMessage( "Beam", 1, "TESTREAD CouchAngle " << CouchAngle << Gateendl );
+            GateMessage( "Beam", 1, "TESTREAD Layers No. " << j << Gateendl );
+            GateMessage( "Beam", 1, "TESTREAD NbOfSpots " << NbOfSpots << Gateendl );
+          }
+          for (int k = 0; k < NbOfSpots; k++) {
+            std::vector<double> SpotParameters = ReadNextContentLine<double,3>(inFile,lineno,mPlan);
+            if (mTestFlag) {
+              GateMessage( "Beam", 1, "TESTREAD Spot No. " << k << "    parameters: "
+                                      << SpotParameters[0] << " "
+                                      << SpotParameters[1] << " "
+                                      << SpotParameters[2] << Gateendl);
+            }
+
+            // Brent 2014-02-19: This check is in an inner loop, but with good reason: we're in the parsing stage.
+            // Rewrote to work also with AllowedFields.
+            bool allowedField = true;
+            // if mNotAllowedFields was set, then check if FieldID was NotAllowed
+            if (!mNotAllowedFields.empty()) if ( std::count(mNotAllowedFields.begin(), mNotAllowedFields.end(), FieldID) >  0 ) allowedField = false;
+            // if mAllowedFields was set, then check if FieldID was not Allowed.
+            if (!mAllowedFields.empty()   ) if ( std::count(mAllowedFields.begin()   , mAllowedFields.end()   , FieldID) == 0 ) allowedField = false;
+
+
+            bool allowedLayer = true;
+            if ((mSelectedLayerID != -1) && (currentLayerID != mSelectedLayerID)) allowedLayer = false;
+
+            bool allowedSpot = true;
+            if ((mSelectedSpot != -1) && (k != mSelectedSpot)) allowedSpot = false;
+
+            // Skip empty spots
+            if (SpotParameters[2] == 0) allowedSpot = false;
+
+            if (allowedField && allowedLayer && allowedSpot) { // loading the spots only for allowed fields
+
+              //POSITION
+              // To calculate the beam position with a gantry angle
+              G4ThreeVector position;
+              position[0] = SpotParameters[0] * (mDistanceSMXToIsocenter - mDistanceSourcePatient) / mDistanceSMXToIsocenter;
+              position[1] = SpotParameters[1] * (mDistanceSMYToIsocenter - mDistanceSourcePatient) / mDistanceSMYToIsocenter;
+              position[2] = mDistanceSourcePatient;
+              //correct orientation problem by rotation 90 degrees around x-Axis
+              double xCorrection = halfpi; // 90.*TMath::Pi() / 180.;
+              position.rotateX(xCorrection - CouchAngle);
+              //include gantry rotation
+              position.rotateZ(GantryAngle);
+
+              if (mTestFlag) {
+                GateMessage( "Beam", 1, "TESTREAD Spot Effective source position " << position[0] << " " << position[1] << " " << position[2] << Gateendl );
+                GateMessage( "Beam", 1, "TESTREAD IsocenterPosition " << IsocenterPosition[0] << " " << IsocenterPosition[1] << " " << IsocenterPosition[2] << Gateendl );
+                GateMessage( "Beam", 1, "TESTREAD NbOfLayers " << NbOfLayers << Gateendl );
+              }
+
+              //DIRECTION
+              // To calculate the 3 required rotation angles to rotate the beam according to the direction set in the TPS
+              G4ThreeVector rotation, direction, test;
+
+              rotation[0] = -xCorrection; //270 degrees
+
+              // deltaY in the patient plan
+              double y = atan(SpotParameters[1] / mDistanceSMYToIsocenter);
+              rotation[0] += y;
+              // deltaX in the patient plan
+              double x = -atan(SpotParameters[0] / mDistanceSMXToIsocenter);
+              double z = 0.;
+              rotation[1] = sin(CouchAngle) * (x) + cos(CouchAngle) * z;
+              // no gantry head rotation
+              rotation[2] = cos(CouchAngle) * (x) + sin(CouchAngle) * z;
+              //set gantry angle rotation
+              rotation[2] += GantryAngle; //+CouchAngle;
+              rotation[0] += -CouchAngle; //-couchAngle
+
+              if (mTestFlag) {
+                GateMessage( "Beam", 1, "TESTREAD source rotation " << rotation[0] << " " << rotation[1] << " " << rotation[2] << Gateendl );
+              }
+
+              if (mSpotIntensityAsNbProtons) {
+                NbProtons = SpotParameters[2];
+              } else {
+                NbProtons = ConvertMuToProtons(SpotParameters[2], GetEnergy(energy));
+              }
+              mTotalNbProtons += NbProtons;
+              mSpotEnergy.push_back(energy);
+              mSpotWeight.push_back(NbProtons);
+              mSpotPosition.push_back(position);
+              mSpotRotation.push_back(rotation);
+
+            } else if (mTestFlag) {
+              ++nrejected;
+              GateMessage("Beam",1,"Rejected spot nr " << k << " for energy=" << energy << " MeV, layer " << j << " in field=" << f << " lineno=" << lineno << Gateendl );
+            }
+          }
+        }
+      }
+      mTotalNumberOfSpots = mSpotWeight.size();
+      GateMessage("Beam", 1, "[TPSPencilBeam] Plan description file \"" << mPlan << "\" successfully loaded: " << NbFields << " field(s) with a total of " << mTotalNumberOfSpots << " spots, " << nrejected << " spots rejected.\n");
+    } catch ( const std::runtime_error& oops ){
+      GateError("Something went wrong while parsing plan description file \"" << mPlan << "\": " << Gateendl << oops.what() << Gateendl );
+    }
+    inFile.close();
+
+    if (mTotalNumberOfSpots == 0) {
+      GateError("0 spots have been loaded from the file \"" << mPlan << "\" simulation abort!");
+    }
+
+    mPDF = new double[mTotalNumberOfSpots];
+    if (mFlatGenerationFlag) {
+      GateMessage("Beam", 0, "WARNING [TPSPencilBeam]: flat generation flag is ON (not recommended for patient simulation)" << Gateendl);
+    }
+    for (int i = 0; i < mTotalNumberOfSpots; i++) {
+      // it is strongly adviced to set mFlatGenerationFlag=false
+      // a few test demonstrated a lot more efficiency for "real field like" simulation in patients.
+      if (mFlatGenerationFlag) {
+        mPDF[i] = 1;
+      } else {
+        mPDF[i] = mSpotWeight[i];
+      }
+    }
+    mDistriGeneral = new RandGeneral(engine, mPDF, mTotalNumberOfSpots, 0);
+    mNbProtonsToGenerate.resize(mTotalNumberOfSpots,0);
+    long int ntotal = GateApplicationMgr::GetInstance()->GetTotalNumberOfPrimaries();
+    for (long int i = 0; i<ntotal; i++){
+      int bin = mTotalNumberOfSpots * mDistriGeneral->fire();
+      ++mNbProtonsToGenerate[bin];
+    }
+    for (int i = 0; i < mTotalNumberOfSpots; i++) {
+      GateMessage("Beam", 3, "[TPSPencilBeam] bin " << std::setw(5) << i << ": spotweight=" << std::setw(8) << mPDF[i] << ", Ngen=" << mNbProtonsToGenerate[i] << Gateendl );
+    }
+    need_pencilbeam_config = true;
+
+    //---------INITIALIZATION - END-----------------------
+  }
+  //---------GENERATION - START-----------------------
+  while ( (mCurrentSpot<mTotalNumberOfSpots) && (mNbProtonsToGenerate[mCurrentSpot] <= 0) ){
+    GateMessage("Beam", 4, "[TPSPencilBeam] spot " << mCurrentSpot << " has no protons left to generate." << Gateendl );
+    mCurrentSpot++;
+    need_pencilbeam_config = true;
+  }
+  if ( mCurrentSpot>=mTotalNumberOfSpots ){
+    GateError("Too many primary vertex requests!");
+  }
+  if ( need_pencilbeam_config ){
+    GateMessage("Beam", 4, "[TPSPencilBeam] configuring pencil beam for spot " << mCurrentSpot
+        << ", to generate " << mNbProtonsToGenerate[mCurrentSpot] << " protons." << Gateendl );
+    ConfigurePencilBeam();
+  }
+  mPencilBeam->GenerateVertex(aEvent);
+  --mNbProtonsToGenerate[mCurrentSpot];
+}
 //---------GENERATION - END-----------------------
+
+void GateSourceTPSPencilBeam::ConfigurePencilBeam() {
+  double energy = mSpotEnergy[mCurrentSpot];
+  //Particle Type
+  mPencilBeam->SetParticleType(mParticleType);
+  //Energy
+  mPencilBeam->SetEnergy(GetEnergy(energy));
+  mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy));
+  //Weight
+  if (mFlatGenerationFlag) {
+    mPencilBeam->SetWeight(mSpotWeight[mCurrentSpot]);
+  } else {
+    mPencilBeam->SetWeight(1.);
+  }
+  //Position
+  mPencilBeam->SetPosition(mSpotPosition[mCurrentSpot]);
+  mPencilBeam->SetSigmaX(GetSigmaX(energy));
+  mPencilBeam->SetSigmaY(GetSigmaY(energy));
+  //Direction
+  mPencilBeam->SetSigmaTheta(GetSigmaTheta(energy));
+  mPencilBeam->SetEllipseXThetaArea(GetEllipseXThetaArea(energy));
+  mPencilBeam->SetSigmaPhi(GetSigmaPhi(energy));
+  mPencilBeam->SetEllipseYPhiArea(GetEllipseYPhiArea(energy));
+  mPencilBeam->SetRotation(mSpotRotation[mCurrentSpot]);
+
+  //Correlation Position/Direction
+  if (mConvergentSource) {
+    mPencilBeam->SetEllipseXThetaRotationNorm("positive");   // convergent beam
+    mPencilBeam->SetEllipseYPhiRotationNorm("positive"); // convergent beam
+  } else {
+    mPencilBeam->SetEllipseXThetaRotationNorm("negative");   // divergent beam
+    mPencilBeam->SetEllipseYPhiRotationNorm("negative"); // divergent beam
+  }
+  mPencilBeam->SetTestFlag(mTestFlag);
+
+  if (mTestFlag) {
+    GateMessage("Beam", 1, "Configuration of spot No. " << mCurrentSpot << " (out of " << mTotalNumberOfSpots << ")" << Gateendl);
+    GateMessage("Beam", 1, "Energy\t" << energy << Gateendl);
+    GateMessage("Beam", 1, "Spot weight (\"expected number of protons\")\t" << mSpotWeight[mCurrentSpot] << Gateendl);
+    GateMessage("Beam", 1, "Number of protons to generate\t" << mNbProtonsToGenerate[mCurrentSpot] << Gateendl);
+    GateMessage("Beam", 1, "Total Spot weight\t" << mTotalNbProtons << Gateendl);
+    GateMessage("Beam", 1, "SetEnergy\t" << GetEnergy(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetSigmaEnergy\t" << GetSigmaEnergy(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetSigmaX\t" << GetSigmaX(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetSigmaY\t" << GetSigmaY(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetSigmaTheta\t" << GetSigmaTheta(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetSigmaPhi\t" << GetSigmaPhi(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetEllipseXThetaArea\t" << GetEllipseXThetaArea(energy) << Gateendl);
+    GateMessage("Beam", 1, "SetEllipseYPhiArea\t" << GetEllipseYPhiArea(energy) << Gateendl);
+  }
+}
 
 //------------------------------------------------------------------------------------------------------
 double GateSourceTPSPencilBeam::ConvertMuToProtons(double weight, double energy) {
@@ -607,5 +926,4 @@ void ReadLineTo3Doubles(double *toto, const std::string &data) {
     //  G4cout<<"toto "<<toto[j]<< Gateendl;
   }
 }
-#endif
-#endif
+// vim: ai sw=2 ts=2 et

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -76,8 +76,7 @@ void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
     //---------INITIALIZATION - START----------------------
     mIsInitialized = true;
 
-    const int MAXLINE = 256;
-    char oneline[MAXLINE];
+    std::string oneline;
     int NbFields, FieldID, TotalMeterSet, NbOfLayers;
     double GantryAngle;
     double CouchAngle;
@@ -104,39 +103,39 @@ void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
 
     // integrating the plan description file data
     while (inFile && again) {
-      for (int i = 0; i < 9; i++) inFile.getline(oneline, MAXLINE);
-      NbFields = atoi(oneline);
-      for (int i = 0; i < 2 * NbFields; i++) inFile.getline(oneline, MAXLINE);
-      for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
-      TotalMeterSet = atoi(oneline);
+      for (int i = 0; i < 9; i++) std::getline(inFile,oneline);
+      NbFields = atoi(oneline.c_str());
+      for (int i = 0; i < 2 * NbFields; i++) std::getline(inFile,oneline);
+      for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
+      TotalMeterSet = atoi(oneline.c_str());
 
       for (int f = 0; f < NbFields; f++) {
-        for (int i = 0; i < 4; i++) inFile.getline(oneline, MAXLINE);
-        FieldID = atoi(oneline);
+        for (int i = 0; i < 4; i++) std::getline(inFile,oneline);
+        FieldID = atoi(oneline.c_str());
 
-        for (int i = 0; i < 4; i++) inFile.getline(oneline, MAXLINE);
-        GantryAngle = deg2rad(atof(oneline));
+        for (int i = 0; i < 4; i++) std::getline(inFile,oneline);
+        GantryAngle = deg2rad(atof(oneline.c_str()));
 
         //MISSING COUCH ANGLE inserted
-        for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
-        CouchAngle = deg2rad(atof(oneline));
+        for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
+        CouchAngle = deg2rad(atof(oneline.c_str()));
 
-        for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
+        for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
         ReadLineTo3Doubles(IsocenterPosition, oneline);
-        for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
-        NbOfLayers = atoi(oneline);
-        for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
+        for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
+        NbOfLayers = atoi(oneline.c_str());
+        for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
 
         for (int j = 0; j < NbOfLayers; j++) {
-          for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
-          int currentLayerID = atoi(oneline); // ControlPointIndex
+          for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
+          int currentLayerID = atoi(oneline.c_str()); // ControlPointIndex
 
-          for (int i = 0; i < 6; i++) inFile.getline(oneline, MAXLINE);
-          double energy = atof(oneline);
+          for (int i = 0; i < 6; i++) std::getline(inFile,oneline);
+          double energy = atof(oneline.c_str());
 
-          for (int i = 0; i < 2; i++) inFile.getline(oneline, MAXLINE);
-          int NbOfSpots = atof(oneline);
-          for (int i = 0; i < 1; i++) inFile.getline(oneline, MAXLINE);
+          for (int i = 0; i < 2; i++) std::getline(inFile,oneline);
+          int NbOfSpots = atof(oneline.c_str());
+          for (int i = 0; i < 1; i++) std::getline(inFile,oneline);
 
           if (mTestFlag) {
             G4cout << "TESTREAD NbFields " << NbFields << Gateendl;
@@ -148,7 +147,7 @@ void GateSourceTPSPencilBeam::GenerateVertex( G4Event *aEvent ) {
             G4cout << "TESTREAD NbOfSpots " << NbOfSpots << Gateendl;
           }
           for (int k = 0; k < NbOfSpots; k++) {
-            inFile.getline(oneline, MAXLINE);
+            std::getline(inFile,oneline);
             double SpotParameters[3];
             ReadLineTo3Doubles(SpotParameters, oneline);
             if (mTestFlag) {
@@ -389,8 +388,7 @@ double GateSourceTPSPencilBeam::ConvertMuToProtons(double weight, double energy)
 //------------------------------------------------------------------------------------------------------
 void GateSourceTPSPencilBeam::LoadClinicalBeamProperties() {
 
-  const int MAXLINE=256;
-  char oneline[MAXLINE];
+  std::string oneline;
   int PolOrder;
 
   std::ifstream inFile(mSourceDescriptionFile);
@@ -398,96 +396,96 @@ void GateSourceTPSPencilBeam::LoadClinicalBeamProperties() {
     GateError("Cannot open source description file!");
   }
 
-  for (int i=0; i<4; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<4; i++) std::getline(inFile,oneline);
   // distance source patient
-  mDistanceSourcePatient=atof(oneline);
+  mDistanceSourcePatient=atof(oneline.c_str());
 
-  for (int i=0; i<2; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<2; i++) std::getline(inFile,oneline);
   // distance SMX patient
-  mDistanceSMXToIsocenter=atof(oneline);
+  mDistanceSMXToIsocenter=atof(oneline.c_str());
 
-  for (int i=0; i<2; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<2; i++) std::getline(inFile,oneline);
   // distance SMY patient
-  mDistanceSMYToIsocenter=atof(oneline);
+  mDistanceSMYToIsocenter=atof(oneline.c_str());
 
-  for (int i=0; i<5; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<5; i++) std::getline(inFile,oneline);
   // Energy
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mEnergy.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mEnergy.push_back(atof(oneline));
+      std::getline(inFile,oneline);
+    mEnergy.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<4; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<4; i++) std::getline(inFile,oneline);
   // Energy
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mEnergySpread.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mEnergySpread.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mEnergySpread.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<5; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<5; i++) std::getline(inFile,oneline);
   // X
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mX.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mX.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mX.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<3; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<3; i++) std::getline(inFile,oneline);
   // Theta
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mTheta.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mTheta.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mTheta.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<3; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<3; i++) std::getline(inFile,oneline);
   // Y
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mY.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mY.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mY.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<3; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<3; i++) std::getline(inFile,oneline);
   // Phi
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mPhi.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mPhi.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mPhi.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<5; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<5; i++) std::getline(inFile,oneline);
   // Emittance X Theta
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mXThetaEmittance.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mXThetaEmittance.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mXThetaEmittance.push_back(atof(oneline.c_str()));
   }
 
-  for (int i=0; i<3; i++) inFile.getline(oneline, MAXLINE);
+  for (int i=0; i<3; i++) std::getline(inFile,oneline);
   // Emittance Y Phi
-  PolOrder=atoi(oneline);
+  PolOrder=atoi(oneline.c_str());
   mYPhiEmittance.push_back(PolOrder);
-  inFile.getline(oneline, MAXLINE);
+  std::getline(inFile,oneline);
   for (int i=0; i<=PolOrder; i++) {
-    inFile.getline(oneline, MAXLINE);
-    mYPhiEmittance.push_back(atof(oneline));
+    std::getline(inFile,oneline);
+    mYPhiEmittance.push_back(atof(oneline.c_str()));
   }
 
   if (mTestFlag) {
@@ -600,8 +598,7 @@ return v;
 */
 // FUNCTION
 //------------------------------------------------------------------------------------------------------
-void ReadLineTo3Doubles(double *toto, char *oneline) {
-  std::string data = oneline;
+void ReadLineTo3Doubles(double *toto, const std::string &data) {
   std::istringstream iss(data);
   std::string token;
   for (int j=0; j<3; j++) {

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -411,7 +411,7 @@ typename std::vector<T> parse_N_items_of_type_T(std::string line,int lineno, con
 // * check that we really get N items of type T from the current line
 // * throw exception with informative error message in case of trouble
 template<typename T, int N>
-typename std::vector<T>  ReadNextContentLine( istream& input, int& lineno, const std::string& fname ) {
+typename std::vector<T>  ReadNextContentLine( std::istream& input, int& lineno, const std::string& fname ) {
   while ( input ){
     std::string line;
     std::getline(input,line);

--- a/source/physics/src/GateSourceTPSPencilBeamMessenger.cc
+++ b/source/physics/src/GateSourceTPSPencilBeamMessenger.cc
@@ -5,12 +5,8 @@
   of the GNU Lesser General  Public Licence (LGPL)
   See GATE/LICENSE.txt for further details
   ----------------------*/
-#ifndef GATESOURCETPSPENCILBEAMMESSENGER_CC
-#define GATESOURCETPSPENCILBEAMMESSENGER_CC
 
 #include "GateConfiguration.h"
-
-#ifdef G4ANALYSIS_USE_ROOT
 #include "GateSourceTPSPencilBeamMessenger.hh"
 #include "GateSourceTPSPencilBeam.hh"
 #include "GateUIcmdWithTwoDouble.hh"
@@ -35,6 +31,9 @@
   //Configuration of tests
   cmdName = GetDirectoryName()+"setTestFlag";
   pTestCmd = new G4UIcmdWithABool(cmdName,this);
+  //Temporary configuration of vertex generation method
+  cmdName = GetDirectoryName()+"setOldStyleFlag";
+  pOldStyleCmd = new G4UIcmdWithABool(cmdName,this);
   //Treatment Plan file
   cmdName = GetDirectoryName()+"setPlan";
   pPlanCmd = new G4UIcmdWithAString(cmdName,this);
@@ -74,6 +73,8 @@ GateSourceTPSPencilBeamMessenger::~GateSourceTPSPencilBeamMessenger()
   delete pParticleTypeCmd;
   //Configuration of tests
   delete pTestCmd;
+  //Temporary configuration of vertex generation method
+  delete pOldStyleCmd;
   //Treatment Plan file
   delete pPlanCmd;
   //FlatGenerationFlag
@@ -103,6 +104,8 @@ void GateSourceTPSPencilBeamMessenger::SetNewValue(G4UIcommand* command,G4String
   if (command == pParticleTypeCmd) {pSourceTPSPencilBeam->SetParticleType(newValue);  }
   //Configuration of tests
   if (command == pTestCmd) {pSourceTPSPencilBeam->SetTestFlag(pTestCmd->GetNewBoolValue(newValue)); }
+  //Configuration of tests
+  if (command == pOldStyleCmd) {pSourceTPSPencilBeam->SetOldStyleFlag(pOldStyleCmd->GetNewBoolValue(newValue)); }
   //Treatment Plan file
   if (command == pPlanCmd) {pSourceTPSPencilBeam->SetPlan(newValue);  }
   //Configuration of FlatFlag gene
@@ -122,6 +125,4 @@ void GateSourceTPSPencilBeamMessenger::SetNewValue(G4UIcommand* command,G4String
   //Convergent or divergent beam model
   if (command == pDivergenceCmd) {pSourceTPSPencilBeam->SetBeamConvergence(pDivergenceCmd->GetNewBoolValue(newValue)); }
 }
-#endif
-
-#endif
+// vim: ai sw=2 ts=2 et


### PR DESCRIPTION
This pull request tries to address several of the issues raised in issue #73 about the `GateTPSPencilBeam` actor. This is not yet the final version of the pull request, there are some things that I probably want to change/add based on your feedback.

Changes:

1. It replaces the vector of pencil beam objects, one for each spot in the plan file, with a single pencil beam. Instead of randomly sampling from all spots, the spots are simulated in the same order as configured (the number of protons per spot is still random, of course). Every time we move from one spot to the next, the pencil beam object gets re-initialized with the relevant spot position, direction, energy, and spreads on those.
2. The parsing of the PBS plan description file has been rewritten. The number of comment and/or empty lines between the actual content lines is now free, so adding a comment line does not result in wrong results anymore. Also the type and number of items on each content line is checked and a descriptive error message is emitted when something does not seem right

.

Temporary:

The old code for particle generation is still available in the `OldVertexGeneration` method. The new code is in the `NewVertexGeneration` method. The user can now choose between the two methods with a configurable parameter. This is only for development and debugging, for a release we keep only one of these two implementations. I used this to run example5 of the radiotherapy examples with OldStyle on and off with a million protons and then check that the two methods yield statistically compatible distributions for `X`, `Y`, `Z`, `dX`, `dY`, `dZ` and `Ekine` for every single spot. 

Additionally:

1. I tried to make the text output a bit more consistent: use `GateMessage("Beam',lvl,msg << Gateend)` everywhere and avoid `cout`, `G4cout` and `\n`.
2. A small fix in `GatePhaseSpaceActor`, included in this pull request, was needed to enable spot-wise testing.

Not yet done, to be discussed:

1. In issue #73 I proposed (extra wish "b") to add optional keywords at the start of every line, to increase readability and facilitate debugging. If we want this then we should also add this feature to VV's `clitkDicomRTPlan2Gate`.
2. The new vertex generation method generates the protons sorted according configured spots, but for some use cases, in particular visualization (the `--qt` option) it might be nice to also support random sampling. This can be done of course, but since the pencil beam is going to be reconfigured for almost every proton this will be a tiny bit slower. For visualization with low statics this is not a problem, I think.
3. The new generation method obtains the "total number of primaries to be generated" from the `GateApplicationManager` instance. This is fine if there is only one source of primaries which is supposed to generate all those primaries and then Gate stops, which is typically the case for a non-interactive TPS simulation. But if there are several sources then the TPS pencil beam source will probably be asked for a smaller number of primaries, which is bad, because this will mean that some of the spots at the end of the plan will not be sampled. The actor will also not run correctly if in a GUI run the user requests a number of primaries more than once. If these situations (multiple source actors, or multiple runs in a GUI) are valid use cases then there is still work to do on the new version of this this actor (the old version has no problem with these use cases). It is not hard to make these fixes, but before I do it I want to make sure that I understand the potential use cases well enough.
4. I did not yet implement the option to configure convergence/divergence properties for X and Y separately. I think this should be done in the source properties file, with two extra lines at the end. The convergence might depend on energy. In that case I think a reasonably flexible syntax would be that the user specifies whether the lowest possible energy beam is convergent or divergent, as well as a list of energies this flips between one and the other. E.g.:
```
X divergent 50 250
Y convergent
```
In this example the beam is always convergent in Y but for X it is divergent for energies less than 50 and higher than 250 MeV. 