### PR TITLE
bugfix: get rid of crash due to double delete

### DIFF
--- a/source/digits_hits/src/GateToImageCT.cc
+++ b/source/digits_hits/src/GateToImageCT.cc
@@ -613,14 +613,10 @@ void GateToImageCT::RecordStepWithVolume( const GateVVolume*,
                   G4ThreeVector posStep = ( path * momentum + pos );
                   G4Step* newStep = (G4Step*)aStep;
 
-                  G4StepPoint* moveStepPoint = newStep->GetPostStepPoint();
-
-                  moveStepPoint->SetPosition( posStep );
-                  newStep->SetPostStepPoint( moveStepPoint );
+                  newStep->GetPostStepPoint()->SetPosition( posStep );
 
                   const G4TouchableHistory* newTouchable;
-                  newTouchable = (const G4TouchableHistory*)(
-                                                             moveStepPoint->GetTouchable() );
+                  newTouchable = (const G4TouchableHistory*)( newStep->GetPostStepPoint()->GetTouchable() );
 
                   GateVolumeID VolumeID(newTouchable);
 


### PR DESCRIPTION
This bugfix makes sure that the `examples/example_CT/vrt/benchmarkVRTCT.mac`
does not crash anymore with an embarrassing "double delete".

(This fix is pretty crude, it's only purpose is to stop the bleeding/crashing. I wonder if the set method behavior described below is actually a bug in Geant4, and maybe it needs to be discussed on a Geant4 mailing list. I checked this fix only for geant4 version 4.10.02.p02.  We may need to insert some ugly preprocessor things if we want these lines to read differently for different geant4 versions. Note, like I say at the end: this fix only prevents the crash, I have no idea if the output is actually correct. A CT imaging expert should look into this.)

Some of the set methods for G4Step have changed during recent Geant4 releases.  Previously,
using the set method would only replace the old pointer with the new pointer.
In the 4.10.2 releases (and also in 4.10.1, I think) the old pointer is
deleted, without checking if the old and the new pointer happen to be the same
pointer. In Gate, we used the get method to get the old pointer, then we
updated it with a new position, and then we set it back into a G4Step object.
But we are effectively setting back the same pointer. So it will be deleted,
and the second time we call the set method it gets deleted again, which results
in the crash that was first reported by Elnur Sadihov on the Gate-users mailing
list (subject: "CT simulation with VRT").

The bug was found because I could reproduce Elnur's crash and after building
Gate in Debug mode and running in gdb, the backtrace pointed directly to the
offending line.

With ROOT 6, the above mentioned VRT example now runs without crashing.
I also tried last week with ROOT 5.34.34, and then I got strange ROOT related
errors, something about TMembers stuff. With my test today, I did a fresh
checkout from git, which seems to include a bunch of commits that I did not have
last week, and that do seem to involve ROOT, so that mysterious TMember issue
probably has been fixed in parallel by someone else. That would mean that this
example may be completely crash-free now. However, I am not at all a CT expert,
so I hope that an actual expert can check this example as well to make sure
that the output is still correct, and once that has been done, we can declare
this issue as "fixed".