### PR TITLE
Correction of the PDG encoding in PhaseSpaceActor (IAEA format)

### DIFF
--- a/source/digits_hits/src/GatePhaseSpaceActor.cc
+++ b/source/digits_hits/src/GatePhaseSpaceActor.cc
@@ -461,7 +461,7 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     else if ( pdg == 11) pIAEARecordType->particle = 2; // electron
     else if ( pdg == -11) pIAEARecordType->particle = 3; // positron
     else if ( pdg == 2112) pIAEARecordType->particle = 4; // neutron
-    else if ( pdg == 2122) pIAEARecordType->particle = 5; // proton
+    else if ( pdg == 2212) pIAEARecordType->particle = 5; // proton
     else GateError("Actor phase space: particle not available in IAEA format." );
 
     pIAEARecordType->energy = e;


### PR DESCRIPTION
Simple inversion of numbers in the PDG encoding of protons for IAEA PS files.
2122 is for delta(1620)+ particles
2212 if for protons 