### PR TITLE
TPS pencil beam: bug fixes and requested features

### DIFF
--- a/examples/example_Radiotherapy/example5/data/Source-Properties.txt
+++ b/examples/example_Radiotherapy/example5/data/Source-Properties.txt
@@ -17,6 +17,7 @@
 
 # energy spread
 # polynomial order
+percent
 1
 # polynomial parameters (highest to lowest)
 0.01

--- a/examples/example_Radiotherapy/example5/mac/main.mac
+++ b/examples/example_Radiotherapy/example5/mac/main.mac
@@ -88,6 +88,8 @@
 #/gate/source/PBS/setNotAllowedFieldID 1
 #/gate/source/PBS/setNotAllowedFieldID 2
 /gate/source/PBS/setFlatGenerationFlag false
+/gate/source/PBS/setSortedSpotGenerationFlag false
+/gate/source/PBS/setSigmaEnergyInMeVFlag false
 /gate/source/PBS/setSourceDescriptionFile data/Source-Properties.txt
 
 #=====================================================

--- a/source/physics/include/GateSourceTPSPencilBeam.hh
+++ b/source/physics/include/GateSourceTPSPencilBeam.hh
@@ -55,6 +55,8 @@ public:
   void SetTestFlag(bool b) {mTestFlag=b;}
   //Temporary Flag to switch between old and new style vertex generation
   void SetOldStyleFlag(bool b) {mOldStyleFlag=b;}
+  //Flag to switch between sorted and random spot selection
+  void SetSortedSpotGenerationFlag(bool b) {mSortedSpotGenerationFlag=b;}
   //Treatment Plan file
   void SetPlan(std::string plan) {mPlan=plan;}
   //FlatGenerationFlag
@@ -115,6 +117,8 @@ protected:
   bool mTestFlag;
   //Old style flag (temporary, for debugging new pencil beam vertex generation)
   bool mOldStyleFlag;
+  //generate protons sorted by spot, or every proton on a random spot?
+  bool mSortedSpotGenerationFlag;
   //Treatment Plan file
   G4String mPlan;
   //Others

--- a/source/physics/include/GateSourceTPSPencilBeam.hh
+++ b/source/physics/include/GateSourceTPSPencilBeam.hh
@@ -57,6 +57,8 @@ public:
   void SetOldStyleFlag(bool b) {mOldStyleFlag=b;}
   //Flag to switch between sorted and random spot selection
   void SetSortedSpotGenerationFlag(bool b) {mSortedSpotGenerationFlag=b;}
+  //Flag to switch between absolute (MeV) and relative (%) energy spread specification
+  void SetSigmaEnergyInMeVFlag(bool b) {mSigmaEnergyInMeVFlag=b;}
   //Treatment Plan file
   void SetPlan(std::string plan) {mPlan=plan;}
   //FlatGenerationFlag
@@ -119,6 +121,8 @@ protected:
   bool mOldStyleFlag;
   //generate protons sorted by spot, or every proton on a random spot?
   bool mSortedSpotGenerationFlag;
+  //does the source properties file give the absolute sigma (in MeV) or relative (in %)?
+  bool mSigmaEnergyInMeVFlag;
   //Treatment Plan file
   G4String mPlan;
   //Others

--- a/source/physics/include/GateSourceTPSPencilBeamMessenger.hh
+++ b/source/physics/include/GateSourceTPSPencilBeamMessenger.hh
@@ -49,6 +49,8 @@ class GateSourceTPSPencilBeamMessenger: public GateVSourceMessenger
     G4UIcmdWithABool* pTestCmd;
     //Configuration of vertex generation method
     G4UIcmdWithABool* pOldStyleCmd;
+    //Configuration of vertex generation method
+    G4UIcmdWithABool* pSortedSpotGenerationCmd;
     //Treatment Plan file
     G4UIcmdWithAString * pPlanCmd;
     //FlatGenerationFlag

--- a/source/physics/include/GateSourceTPSPencilBeamMessenger.hh
+++ b/source/physics/include/GateSourceTPSPencilBeamMessenger.hh
@@ -51,6 +51,8 @@ class GateSourceTPSPencilBeamMessenger: public GateVSourceMessenger
     G4UIcmdWithABool* pOldStyleCmd;
     //Configuration of vertex generation method
     G4UIcmdWithABool* pSortedSpotGenerationCmd;
+    //Configuration of absolute/relative energy spread specification
+    G4UIcmdWithABool* pSigmaEnergyInMeVCmd;
     //Treatment Plan file
     G4UIcmdWithAString * pPlanCmd;
     //FlatGenerationFlag

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -707,7 +707,14 @@ void GateSourceTPSPencilBeam::ConfigurePencilBeam() {
   mPencilBeam->SetParticleType(mParticleType);
   //Energy
   mPencilBeam->SetEnergy(GetEnergy(energy));
-  mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy));
+  if ( mSigmaEnergyInMeVFlag ){
+    mPencilBeam->SetEnergy(GetEnergy(energy));
+    mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy));
+  } else {
+    double source_energy = GetEnergy(energy);
+    mPencilBeam->SetEnergy(source_energy);
+    mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy)*source_energy/100.);
+  }
   //Weight
   if (mFlatGenerationFlag) {
     mPencilBeam->SetWeight(mSpotWeight[mCurrentSpot]);

--- a/source/physics/src/GateSourceTPSPencilBeamMessenger.cc
+++ b/source/physics/src/GateSourceTPSPencilBeamMessenger.cc
@@ -34,6 +34,9 @@
   //Temporary configuration of vertex generation method
   cmdName = GetDirectoryName()+"setOldStyleFlag";
   pOldStyleCmd = new G4UIcmdWithABool(cmdName,this);
+  //Generate protons on random spots or by the same spot order as given in the plan
+  cmdName = GetDirectoryName()+"setSortedSpotGenerationFlag";
+  pSortedSpotGenerationCmd = new G4UIcmdWithABool(cmdName,this);
   //Treatment Plan file
   cmdName = GetDirectoryName()+"setPlan";
   pPlanCmd = new G4UIcmdWithAString(cmdName,this);
@@ -75,6 +78,8 @@ GateSourceTPSPencilBeamMessenger::~GateSourceTPSPencilBeamMessenger()
   delete pTestCmd;
   //Temporary configuration of vertex generation method
   delete pOldStyleCmd;
+  //sorted or random generation
+  delete pSortedSpotGenerationCmd;
   //Treatment Plan file
   delete pPlanCmd;
   //FlatGenerationFlag
@@ -104,8 +109,10 @@ void GateSourceTPSPencilBeamMessenger::SetNewValue(G4UIcommand* command,G4String
   if (command == pParticleTypeCmd) {pSourceTPSPencilBeam->SetParticleType(newValue);  }
   //Configuration of tests
   if (command == pTestCmd) {pSourceTPSPencilBeam->SetTestFlag(pTestCmd->GetNewBoolValue(newValue)); }
-  //Configuration of tests
+  //For debugging: generate spots with the old code
   if (command == pOldStyleCmd) {pSourceTPSPencilBeam->SetOldStyleFlag(pOldStyleCmd->GetNewBoolValue(newValue)); }
+  //random or sorted spot generation
+  if (command == pSortedSpotGenerationCmd) {pSourceTPSPencilBeam->SetSortedSpotGenerationFlag(pSortedSpotGenerationCmd->GetNewBoolValue(newValue)); }
   //Treatment Plan file
   if (command == pPlanCmd) {pSourceTPSPencilBeam->SetPlan(newValue);  }
   //Configuration of FlatFlag gene

--- a/source/physics/src/GateSourceTPSPencilBeamMessenger.cc
+++ b/source/physics/src/GateSourceTPSPencilBeamMessenger.cc
@@ -37,6 +37,9 @@
   //Generate protons on random spots or by the same spot order as given in the plan
   cmdName = GetDirectoryName()+"setSortedSpotGenerationFlag";
   pSortedSpotGenerationCmd = new G4UIcmdWithABool(cmdName,this);
+  //Choose absolute/relative energy spread specification (if not set in source properties file)
+  cmdName = GetDirectoryName()+"setSigmaEnergyInMeVFlag";
+  pSigmaEnergyInMeVCmd = new G4UIcmdWithABool(cmdName,this);
   //Treatment Plan file
   cmdName = GetDirectoryName()+"setPlan";
   pPlanCmd = new G4UIcmdWithAString(cmdName,this);
@@ -78,8 +81,10 @@ GateSourceTPSPencilBeamMessenger::~GateSourceTPSPencilBeamMessenger()
   delete pTestCmd;
   //Temporary configuration of vertex generation method
   delete pOldStyleCmd;
-  //sorted or random generation
+  //Sorted or random generation
   delete pSortedSpotGenerationCmd;
+  //Absolute/relative energy spread specification
+  delete pSigmaEnergyInMeVCmd;
   //Treatment Plan file
   delete pPlanCmd;
   //FlatGenerationFlag
@@ -113,6 +118,8 @@ void GateSourceTPSPencilBeamMessenger::SetNewValue(G4UIcommand* command,G4String
   if (command == pOldStyleCmd) {pSourceTPSPencilBeam->SetOldStyleFlag(pOldStyleCmd->GetNewBoolValue(newValue)); }
   //random or sorted spot generation
   if (command == pSortedSpotGenerationCmd) {pSourceTPSPencilBeam->SetSortedSpotGenerationFlag(pSortedSpotGenerationCmd->GetNewBoolValue(newValue)); }
+  //Absolute/relative energy spread specification
+  if (command == pSigmaEnergyInMeVCmd) {pSourceTPSPencilBeam->SetSigmaEnergyInMeVFlag(pSigmaEnergyInMeVCmd->GetNewBoolValue(newValue)); }
   //Treatment Plan file
   if (command == pPlanCmd) {pSourceTPSPencilBeam->SetPlan(newValue);  }
   //Configuration of FlatFlag gene


### PR DESCRIPTION
This pull request contains:
1. A bug fix for RT plan file reading. If a line would contain more words than expected (e.g. in the first content line: the plan name) you'd get a crash instead of the intended helpful error message. Now you do get this helpful message. After that Gate may still crash, but that is because ROOT/Geant4 fail to terminate gracefully.
2. As requested by MedAustron, the new vertex generation method can now also sample randomly from all spots. You get this when SortedSpotGenerationFlag is set to` false`.
3. As requested by MedAustron, the default interpretation of the energy spread polynomial is now relative (a percentage of the energy). The best place to explicitly configure is the source properties file, by putting the keyword 'MeV' or 'percent' in the line before the polynomial order, to get an absolute or relative interpretation, respectively.

I did some very rudimentary testing, using example5 in examples_Radiotherapy. I get the same X/Z/Ekine phase space distributions for spot-sorted and random generation. I ran with both absolute and relative energy spread, but the effect is too subtle to be noticed. Either that, or I did something wrong. Hopefully this will become clearer during MedAustron's testing & validation in the next few days/weeks.

The `OldStyleFlag` and the old vertex generation code is still present. If MedAustron's testing and validation gives us enough confidence that the new code is good, then it would be nice to delete the old code before we do the release.