### PR TITLE
Add an additional security on the confine volume name

### DIFF
--- a/source/physics/src/GateSingleParticleSourceMessenger.cc
+++ b/source/physics/src/GateSingleParticleSourceMessenger.cc
@@ -1051,13 +1051,20 @@ void GateSingleParticleSourceMessenger::SetNewValue( G4UIcommand* command, G4Str
     }
   else if (command == confineCmd )
     {
-      // Modif DS: for all names exept NULL, we add the tag "_phys" at the end
+      // Modif DS/FS: for all names exept NULL, we add the tag "_phys" at the end
       // of the volume name when the user forgot to do it
-      if ( newValues != "NULL" ) {
-        if (newValues.substr( newValues.length()-5 ) != "_phys" )
-          newValues += "_phys";
-        G4cout << "Confirming confinement to volume '" << newValues << "'...\n" ;
-      }
+      if ( newValues != "NULL" )
+      {
+	bool test = false;
+	if (newValues.length() < 5) { test = true; }
+	else if (newValues.substr( newValues.length()-5 ) != "_phys" ) { test = true; }
+
+	if (test)
+	{
+	  newValues += "_phys";
+	  G4cout << "Confirming confinement to volume '" << newValues << "'...\n" ;
+	}
+      }      
       fParticleGun->GetPosDist()->ConfineSourceToVolume( newValues ) ;
     }
   else if (command == ForbidCmd )


### PR DESCRIPTION
In the confine command for the sources, the actual test on the volume name (adding "_phys" at the end) is not sufficiently robust. If the number of characters in the string is lower than 5 ("_phys"), this leads to a fail message.

I modified the test to account for the number of characters in the string.