### PR TITLE
correct sigma energy, remove crashing debug msg

### DIFF
--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -689,8 +689,7 @@ void GateSourceTPSPencilBeam::NewGenerateVertex( G4Event *aEvent ) {
     mCurrentLayer = mSpotLayer[mCurrentSpot];
   }
   if ( need_pencilbeam_config ){
-    GateMessage("Beam", 4, "[TPSPencilBeam] configuring pencil beam for spot " << mCurrentSpot
-        << ", to generate " << mNbProtonsToGenerate[mCurrentSpot] << " protons." << Gateendl );
+    GateMessage("Beam", 5, "[TPSPencilBeam] mCurrentSpot = " << mCurrentSpot << Gateendl );
     ConfigurePencilBeam();
   }
   mPencilBeam->GenerateVertex(aEvent);
@@ -707,7 +706,14 @@ void GateSourceTPSPencilBeam::ConfigurePencilBeam() {
   mPencilBeam->SetParticleType(mParticleType);
   //Energy
   mPencilBeam->SetEnergy(GetEnergy(energy));
-  mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy));
+  if ( mSigmaEnergyInMeVFlag ){
+    mPencilBeam->SetEnergy(GetEnergy(energy));
+    mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy));
+  } else {
+    double source_energy = GetEnergy(energy);
+    mPencilBeam->SetEnergy(source_energy);
+    mPencilBeam->SetSigmaEnergy(GetSigmaEnergy(energy)*source_energy/100.);
+  }
   //Weight
   if (mFlatGenerationFlag) {
     mPencilBeam->SetWeight(mSpotWeight[mCurrentSpot]);


### PR DESCRIPTION
The choice between relative and absolute energy spread specification
should be used not only in the 'old' but also in the 'new' vertex
generation method. The default should be 'relative' (like in the docs)
but without this fix the value from sourceproperties would be used as
absolute (like it was in release 7.2).

I removed a debugging message which tried to use the value of an entry
in the NbProtonsToGenerate vector, but that vector has length 0 in case
the user opts for random spot sampling, which would result in an
embarrassing crash. We don't want that.