### PR TITLE
DoseToWater 

### DIFF
--- a/source/digits_hits/include/GateDoseActor.hh
+++ b/source/digits_hits/include/GateDoseActor.hh
@@ -103,6 +103,7 @@ protected:
   bool mIsNumberOfHitsImageEnabled;
   bool mIsDoseNormalisationEnabled;
   bool mIsDoseToWaterNormalisationEnabled;
+  bool mDose2WaterWarningFlag;
 
   GateImageWithStatistic mEdepImage;
   GateImageWithStatistic mDoseImage;

--- a/source/digits_hits/src/GateFixedForcedDetectionActor.cc
+++ b/source/digits_hits/src/GateFixedForcedDetectionActor.cc
@@ -138,6 +138,10 @@ void GateFixedForcedDetectionActor::TestSource(GateSourceMgr * sm)
         {
         GateError("Error: forced detection only supports focused distributions for plane sources.");
         }
+      if (mSource->GetPosDist()->GetPosDisShape() != "Rectangle")
+        {
+        GateError("Error: forced detection only supports rectangle plane sources.");
+        }
       }
     }
   else if (mSourceType == "isotropic" or mSourceType == "isotropicWoP")


### PR DESCRIPTION
Hello, 

You will find here a pull request that try to take care of what have been said, being:
- add gamma in the if condition
- consider Electron DEDX if particle is a gamma
- ignore the 'else' condition of the loop
- replace ComputeTotalDEDX with pointer rather dans string comparison

Some remarks:

- when shooting proton, what about all the other generated particles: C13, O16, N14 (to only name a few), they don't directly contribute to the dose to water ? Before the modification, their deposited energy was added via 'proton' DEDX. Now, with this implementation, they are ignored. It seems wrong to me ?

- I implement the ComputeTotalDEDX with pointer, I think it will change anything about speed, but it is clearer, good catch. 

Could you please test and report ? 

Thanks, 