### PR TITLE
HU builder fix

### DIFF
--- a/source/general/src/GateHounsfieldDensityTable.cc
+++ b/source/general/src/GateHounsfieldDensityTable.cc
@@ -49,7 +49,7 @@ double GateHounsfieldDensityTable::FindMaxDensityDifference(double HMin, double 
   int j=0;
   while (j<n && HMax>mH[j]) j++;
   j--;
-  for(int x=i; x<j; x++) {
+  for(int x=i; x<=j; x++) {
     // DD(G4BestUnit(mD[x], "Volumic Mass"));
     if (mD[x] < dMin) dMin = mD[x];
     if (mD[x] > dMax) dMax = mD[x];

--- a/source/general/src/GateHounsfieldToMaterialsBuilder.cc
+++ b/source/general/src/GateHounsfieldToMaterialsBuilder.cc
@@ -107,7 +107,15 @@ void GateHounsfieldToMaterialsBuilder::BuildAndWriteMaterials() {
     double dDiffMax = mDensityTable->FindMaxDensityDifference(HMin, HMax);
 
     double n = std::max(1.,dDiffMax/dTol);
-    // GateMessage("Core", 0, "n = " << n << Gateendl);
+    double nNaive = std::max(1.,(dMax-dMin)/dTol);
+    G4String alert = (n==nNaive) ? "" : G4String(" ***** ");
+    GateMessage("Core", 2, alert << "i=" << i
+                                 << " (HMin,dMin)=(" << HMin << "," << G4BestUnit(dMin,"Volumic Mass") << "),"
+                                 << " (HMax,dMax)=(" << HMax << "," << G4BestUnit(dMax,"Volumic Mass") << "),"
+                                 << " dDiffMax=" << G4BestUnit(dDiffMax,"Volumic Mass") << ","
+                                 << " n = " << n
+                                 << " nNaive = " << nNaive
+                                 << alert << Gateendl);
 
     //If material is Air divide into only one range
     if (mHounsfieldMaterialPropertiesVector[i]->GetName() == "Air") n = 1;


### PR DESCRIPTION
The method that should find the largest density difference within a given HU range contained an off-by-one error. After the `while` loop through the HU vector to find the index `j` corresponding to `HMax`, the index `j` was decremented, but then also a strict "less than" operator was used in the following loop over the corresponding densities. This caused the density of the last entry within the given HU range to be ignored, and this in turn resulted in a wrong answer near the typical Schneider bump: the density vs HU curve has a negative step in the soft tissue range.

The bug is now fixed by replacing the "less than" operator by a "less than or equal" operator in the loop over the densities.

This bug was found while working on issue #37 but this bugfix pull request does *NOT* resolve it. More work on this is ongoing.