### PR TITLE
Rename CUDA compute_21 to compute_20; there is no compute_21!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ ENDIF()
 #=========================================================
 # Add the executable, and link it to the Geant4/ROOT/CLHEP/ITK libraries
 IF(GATE_USE_GPU AND CUDA_FOUND)
-  SET(CUDA_NVCC_FLAGS "-gencode arch=compute_20,code=sm_20;-gencode arch=compute_21,code=sm_21;-gencode arch=compute_30,code=sm_30;-gencode arch=compute_32,code=sm_32;-gencode arch=compute_35,code=sm_35;-gencode arch=compute_37,code=sm_37;-gencode arch=compute_50,code=sm_50;-gencode arch=compute_52,code=sm_52;-gencode arch=compute_53,code=sm_53;-gencode arch=compute_60,code=sm_60;-gencode arch=compute_61,code=sm_61;-use_fast_math;-w;--ptxas-options=-v")
+  SET(CUDA_NVCC_FLAGS "-gencode arch=compute_20,code=sm_20;-gencode arch=compute_20,code=sm_21;-gencode arch=compute_30,code=sm_30;-gencode arch=compute_32,code=sm_32;-gencode arch=compute_35,code=sm_35;-gencode arch=compute_37,code=sm_37;-gencode arch=compute_50,code=sm_50;-gencode arch=compute_52,code=sm_52;-gencode arch=compute_53,code=sm_53;-gencode arch=compute_60,code=sm_60;-gencode arch=compute_61,code=sm_61;-use_fast_math;-w;--ptxas-options=-v")
   CUDA_ADD_EXECUTABLE(Gate Gate.cc ${sources} ${sourcesGPU} ${headers})
 ELSE(GATE_USE_GPU AND CUDA_FOUND)
   ADD_EXECUTABLE(Gate Gate.cc ${sources} ${headers})


### PR DESCRIPTION
In commit 2c94cf6b79f9d0d7a5b2b0ca29dff0228a3674c2 @ekleung expanded the list of target Compute Capabilities of GPU devices. My guess is, they did so with copy and paste. There is no `compute_21` (although there is a `sm_21`, confusingly). This commit fixes it.

This was spotted by @djboersma in December (https://github.com/OpenGATE/Gate/commit/2c94cf6b79f9d0d7a5b2b0ca29dff0228a3674c2#commitcomment-20230695) but never fixed.

@djboersma also mentions backwards-compatibility of CUDA versions. One suggestion from my side would be to introduce some guarding in the `CMakeLists.txt` for it. Like in Gromacs: https://github.com/gromacs/gromacs/blob/master/cmake/gmxManageNvccConfig.cmake#L121-L135. This could also cover the deprecation for Compute Capability 2.0 in CUDA 9 and beyond (like `if CUDA < 9.0: add sm_20; else: don't`).  
If you're interested in that, let me know, I can work on that.