### PR TITLE
BUG: Fix output of volume names in binary files

### DIFF
--- a/source/digits_hits/include/GateToBinary.hh
+++ b/source/digits_hits/include/GateToBinary.hh
@@ -398,6 +398,9 @@ protected:
 
 	std::ofstream m_outFileRun; /*!< outfile for run */
   std::ofstream m_outFileHits; /*!< outfile for hits */
+
+private:
+    static G4String FixedWidthZeroPaddedString(const G4String & full, size_t length);
 };
 
 #endif


### PR DESCRIPTION
In the binary output format, G4String were being improperly written out so that
the field had invalid data.  This issue is fixed by writing out the volume
string up to a fixed length.  If shorter, the rest of the field is filed with
zeros.

fixes #141