### PR TITLE
move text parsing utilities to 'Misc Functions'

### DIFF
--- a/source/digits_hits/src/GateDoseActor.cc
+++ b/source/digits_hits/src/GateDoseActor.cc
@@ -31,53 +31,6 @@
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
 
-//------------------------------------------------------------------------------------------------------
-//  try get N values of type T from a given input line
-// * throw exception with informative error message in case of trouble.
-// * NOTE that while this catches some common errors, it is not yet fool proof.
-template<typename T, int N>
-typename std::vector<T> parse_N_values_of_type_T(std::string line,int lineno, const std::string& fname){
-  GateMessage("Beam", 5, "[DoseActor] trying to parse line " << lineno << " from file " << fname << Gateendl );
-  std::istringstream iss(line);
-  typename std::istream_iterator<T> iss_end;
-  typename std::istream_iterator<T> isiT(iss);
-  typename std::vector<T> vecT;
-  while (isiT != iss_end) vecT.push_back(*(isiT++));
-  int nread = vecT.size();
-  if (nread != N){
-    std::ostringstream errMsg;
-    errMsg << "wrong number of values (" << nread << ") on line " << lineno << " of " << fname
-           << ", expected " << N << " value(s) of type " << typeid(T).name() << std::endl;
-    throw std::runtime_error(errMsg.str());
-  }
-  return vecT;
-}
-//------------------------------------------------------------------------------------------------------
-// Function to read the next content line
-// * skip all comment lines (lines string with a '#')
-// * skip empty
-// * throw exception with informative error message in case of missing data
-std::string ReadNextLine( std::istream& input, int& lineno, const std::string& fname ) {
-  while ( input ){
-    std::string line;
-    std::getline(input,line);
-    ++lineno;
-    if (line.empty()) continue;
-    if (line[0]=='#') continue;
-    return line;
-  }
-  throw std::runtime_error(std::string("reached end of file '")+fname+std::string("' unexpectedly."));
-}
-//------------------------------------------------------------------------------------------------------
-// Function to read AND parse the next content line
-// * check that we really get N values of type T from the current line
-template<typename T, int N>
-typename std::vector<T>  ParseNextLine( std::istream& input, int& lineno, const std::string& fname ) {
-  std::string line = ReadNextLine(input,lineno,fname);
-  return parse_N_values_of_type_T<T,N>(line,lineno,fname);
-}
-//------------------------------------------------------------------------------------------------------
-
 //-----------------------------------------------------------------------------
 GateDoseActor::GateDoseActor(G4String name, G4int depth):
   GateVImageActor(name,depth) {
@@ -280,11 +233,11 @@ void GateDoseActor::Construct() {
    std::vector<double> mDoseEfficiencyParameters;
    std::string line;
    int lineno = 0;
-   int NbLines = ParseNextLine<int,1>(inFile,lineno,mDoseEfficiencyFile)[0];
+   int NbLines = ParseNextContentLine<int,1>(inFile,lineno,mDoseEfficiencyFile)[0];
 //   std::cout<<NbLines<<std::endl;
    for (int k = 0; k < NbLines; k++) {
 //    std::cout<<k<<std::endl;
-    mDoseEfficiencyParameters = ParseNextLine<double,2>(inFile,lineno,mDoseEfficiencyFile);
+    mDoseEfficiencyParameters = ParseNextContentLine<double,2>(inFile,lineno,mDoseEfficiencyFile);
   	 mDoseEnergy.push_back(mDoseEfficiencyParameters[0]);
     mDoseEfficiency.push_back(mDoseEfficiencyParameters[1]);
     GateMessage("Actor", 5, "[DoseActor] mDoseEfficiencyParameters: "<<mDoseEfficiencyParameters[0]<<"\t"<<mDoseEfficiencyParameters[1]<< Gateendl);

--- a/source/general/include/GateMiscFunctions.hh
+++ b/source/general/include/GateMiscFunctions.hh
@@ -19,6 +19,9 @@ See GATE/LICENSE.txt for further details
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <sstream>
+#include <iterator>
+#include <exception>
 
 #include "G4UIcommand.hh"
 #include "G4VSolid.hh"
@@ -150,6 +153,27 @@ int GetIndexFromTime(std::vector<double> & mTimeList, double aTime);
 
 //-----------------------------------------------------------------------------
 G4String GetSaveCurrentFilename(G4String & mSaveFilename);
+
+//------------------------------------------------------------------------------------------------------
+//  try get N values of type T from a given input line
+// * throw exception with informative error message in case of trouble.
+// * NOTE that while this catches some common errors, it is not yet fool proof.
+template<typename T, int N>
+typename std::vector<T> parse_N_values_of_type_T(std::string line,int lineno, const std::string& fname);
+
+//------------------------------------------------------------------------------------------------------
+// Function to read the next content line
+// * skip all comment lines (lines string with a '#')
+// * skip empty
+// * throw exception with informative error message in case of missing data
+std::string ReadNextContentLine( std::istream& input, int& lineno, const std::string& fname );
+
+//------------------------------------------------------------------------------------------------------
+// Function to read AND parse the next content line
+// * check that we really get N values of type T from the current line
+template<typename T, int N>
+typename std::vector<T>  ParseNextContentLine( std::istream& input, int& lineno, const std::string& fname );
+
 
 
 #include "GateMiscFunctions.icc"

--- a/source/general/include/GateMiscFunctions.icc
+++ b/source/general/include/GateMiscFunctions.icc
@@ -24,4 +24,31 @@ bool ConvertFromString( const std::string & Str, T & Dest )
   return iss >> Dest != 0;
 }
 
+//------------------------------------------------------------------------------------------------------
+template<typename T, int N>
+typename std::vector<T> parse_N_values_of_type_T(std::string line,int lineno, const std::string& fname){
+  GateMessage("Beam", 5, "[TPSPencilBeam] trying to parse line " << lineno << " from file " << fname << Gateendl );
+  std::istringstream iss(line);
+  typename std::istream_iterator<T> iss_end;
+  typename std::istream_iterator<T> isiT(iss);
+  typename std::vector<T> vecT;
+  while (isiT != iss_end) vecT.push_back(*(isiT++));
+  int nread = vecT.size();
+  if (nread != N){
+    std::ostringstream errMsg;
+    errMsg << "wrong number of values (" << nread << ") on line " << lineno << " of " << fname
+           << ", expected " << N << " value(s) of type " << typeid(T).name() << std::endl;
+    throw std::runtime_error(errMsg.str());
+  }
+  return vecT;
+}
+
+//------------------------------------------------------------------------------------------------------
+template<typename T, int N>
+typename std::vector<T>  ParseNextContentLine( std::istream& input, int& lineno, const std::string& fname ) {
+  std::string line = ReadNextContentLine(input,lineno,fname);
+  return parse_N_values_of_type_T<T,N>(line,lineno,fname);
+}
+//------------------------------------------------------------------------------------------------------
+
 #endif // GATEMISCFUNCTIONS_ICC

--- a/source/general/src/GateMiscFunctions.cc
+++ b/source/general/src/GateMiscFunctions.cc
@@ -672,6 +672,20 @@ G4String GetSaveCurrentFilename(G4String & mSaveFilename) {
   G4String mSaveCurrentFilename = G4String(removeExtension(mSaveFilename))+oss.str()+extension;
   return mSaveCurrentFilename;
 }
+//------------------------------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------------------------------
+std::string ReadNextContentLine( std::istream& input, int& lineno, const std::string& fname ) {
+  while ( input ){
+    std::string line;
+    std::getline(input,line);
+    ++lineno;
+    if (line.empty()) continue;
+    if (line[0]=='#') continue;
+    return line;
+  }
+  throw std::runtime_error(std::string("reached end of file '")+fname+std::string("' unexpectedly."));
+}
 //-----------------------------------------------------------------------------
 
 #endif // GATEMISCFUNCTIONS_CC

--- a/source/physics/src/GateSourceTPSPencilBeam.cc
+++ b/source/physics/src/GateSourceTPSPencilBeam.cc
@@ -20,60 +20,12 @@
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
-#include <iterator>
-#include <exception>
 #include <sstream>
 #include "GateSourceTPSPencilBeam.hh"
 #include "G4Proton.hh"
 #include "GateMiscFunctions.hh"
 #include "GateApplicationMgr.hh"
 
-//------------------------------------------------------------------------------------------------------
-//  try get N values of type T from a given input line
-// * throw exception with informative error message in case of trouble.
-// * NOTE that while this catches some common errors, it is not yet fool proof.
-template<typename T, int N>
-typename std::vector<T> parse_N_values_of_type_T(std::string line,int lineno, const std::string& fname){
-  GateMessage("Beam", 5, "[TPSPencilBeam] trying to parse line " << lineno << " from file " << fname << Gateendl );
-  std::istringstream iss(line);
-  typename std::istream_iterator<T> iss_end;
-  typename std::istream_iterator<T> isiT(iss);
-  typename std::vector<T> vecT;
-  while (isiT != iss_end) vecT.push_back(*(isiT++));
-  int nread = vecT.size();
-  if (nread != N){
-    std::ostringstream errMsg;
-    errMsg << "wrong number of values (" << nread << ") on line " << lineno << " of " << fname
-           << ", expected " << N << " value(s) of type " << typeid(T).name() << std::endl;
-    throw std::runtime_error(errMsg.str());
-  }
-  return vecT;
-}
-//------------------------------------------------------------------------------------------------------
-// Function to read the next content line
-// * skip all comment lines (lines string with a '#')
-// * skip empty
-// * throw exception with informative error message in case of missing data
-std::string ReadNextContentLine( std::istream& input, int& lineno, const std::string& fname ) {
-  while ( input ){
-    std::string line;
-    std::getline(input,line);
-    ++lineno;
-    if (line.empty()) continue;
-    if (line[0]=='#') continue;
-    return line;
-  }
-  throw std::runtime_error(std::string("reached end of file '")+fname+std::string("' unexpectedly."));
-}
-//------------------------------------------------------------------------------------------------------
-// Function to read AND parse the next content line
-// * check that we really get N values of type T from the current line
-template<typename T, int N>
-typename std::vector<T>  ParseNextContentLine( std::istream& input, int& lineno, const std::string& fname ) {
-  std::string line = ReadNextContentLine(input,lineno,fname);
-  return parse_N_values_of_type_T<T,N>(line,lineno,fname);
-}
-//------------------------------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------------------------------
 GateSourceTPSPencilBeam::GateSourceTPSPencilBeam(G4String name ):GateVSource( name ), mPencilBeam(NULL), mDistriGeneral(NULL)


### PR DESCRIPTION
A while ago some text file parsing functions were introduced in the TPS
pencil beam actor. These utilities were recently copied into the dose
actor. When a utility is useful in multiple source files then it's
better to store it in a more central place, such as
general/*/GateMiscfunctions.*, where similar utilities are also kept.

The utilities in question do the following:
- read the "next content line", skipping empty lines and comment lines
- read a content line as a vector of N items of type T, for any number N
  and type T. Raise an error at an unexpected number of items or when
  the input text cannot be streamed into an object of the desired type.