### PR TITLE
Commented out /gate/physics/addProcess Fictitious

### DIFF
--- a/benchmarks/benchVoxelRegular25x25x25/physicsFGATE.mac
+++ b/benchmarks/benchVoxelRegular25x25x25/physicsFGATE.mac
@@ -1,7 +1,7 @@
 #############
 #  Physics  #
 #############
-/gate/physics/addProcess Fictitious
+#/gate/physics/addProcess Fictitious ### BROKEN AS OF 20171029 - DO NOT USE ###
 
 /gate/physics/addProcess PhotoElectric
 /gate/physics/addProcess Compton


### PR DESCRIPTION
When /gate/physics/addProcess Fictitious is enabled, Geant4 will produce an error that will either cause GATE to either crash or get stuck. In my case, it was stuck in GATE v8.0 and crashed in GATE v7.2 develop (pull request #66).

Below is an example of the error:

*** G4Exception : GeomNav0003
      issued by : G4PhantomParameterisation::GetReplicaNo()
Point outside voxels!
        localPoint - (-nan,-nan,-nan) - is outside container solid: mat25_solid

*** This is just a warning message. ***

Commenting out the command fixed the crash, although I do not know if it will affect more than just computational time. Perhaps the command is simply broken in the newer versions of GATE? From what I understand, the example does use the interfile format already:

http://wiki.opengatecollaboration.org/index.php/Users_Guide_V8.0:Voxelized_Source_and_Phantom#Fictitious_interaction

On a side note, the example is 4+ years old. GATE wiki currently recommends the use of voxelized phantom descriptions such as ImageRegularParametrisedVolume instead of fictitiousVoxelMap as provided in the example. An update of the example would be very helpful for beginners like myself. I will play around with the example to see if I can get it running with the "new" commands but if someone who knows this stuff can quickly provide an updated example it would be highly appreciated :)