### PR TITLE
Compilation error fix

### DIFF
--- a/source/general/include/GateMiscFunctions.hh
+++ b/source/general/include/GateMiscFunctions.hh
@@ -22,6 +22,7 @@ See GATE/LICENSE.txt for further details
 #include <sstream>
 #include <iterator>
 #include <exception>
+#include <typeinfo>
 
 #include "G4UIcommand.hh"
 #include "G4VSolid.hh"


### PR DESCRIPTION
 Adding missing `#include <typeinfo>` to correct the following compilation error (happening with g++ 4.9.2):

      Gate/source/general/include/GateMiscFunctions.icc: In function ‘std::vector<_RealType> parse_N_values_of_type_T(std::string, int, const string&)’:
      Gate/source/general/include/GateMiscFunctions.icc:40:69: error: must #include <typeinfo> before using typeid
         << ", expected " << N << " value(s) of type " << typeid(T).name() << std::endl;