### PR TITLE
Fix compilation error

### DIFF
--- a/source/general/include/GateMiscFunctions.icc
+++ b/source/general/include/GateMiscFunctions.icc
@@ -14,13 +14,16 @@ See GATE/LICENSE.txt for further details
 #define GATEMISCFUNCTIONS_ICC
 
 
+#include <typeinfo>
+
+
 template<typename T>
 bool ConvertFromString( const std::string & Str, T & Dest )
 {
   // http://c.developpez.com/faq/cpp/?page=strings#STRINGS_convert_to
-  // créer un flux à partir de la chaîne donnée
+  // create a stream from string
   std::istringstream iss( Str );
-  // tenter la conversion vers Dest
+  // attempt to convert into Dest
   return iss >> Dest != 0;
 }
 


### PR DESCRIPTION
- The header <typeinfo> must be included before using typeid (error introduced by ed50b00fda3403145d20917c0e2e62fffa6672c4)
- translation into english of some comments (which also resolve encoding problem)