### PR TITLE
Tetrahedral-Mesh Geometry

### DIFF
--- a/source/digits_hits/include/GateTetMeshDoseActor.hh
+++ b/source/digits_hits/include/GateTetMeshDoseActor.hh
@@ -1,0 +1,84 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+#ifndef GATE_TETMESH_DOSE_ACTOR_HH
+#define GATE_TETMESH_DOSE_ACTOR_HH 
+
+#include <memory>
+#include <map>
+
+#include <G4Types.hh>
+#include <G4String.hh>
+#include <G4THitsMap.hh>
+#include <G4HCofThisEvent.hh>
+#include <G4Step.hh>
+#include <G4Run.hh>
+#include <G4Event.hh>
+
+#include "GateVVolume.hh"
+
+#include "GateVActor.hh"
+
+class GateActorMessenger;
+
+
+class GateTetMeshDoseActor : public GateVActor
+{
+  public:
+    struct Estimators
+    {
+      G4double dose;
+      G4double sumOfSquaredDose;
+      G4double relativeUncertainty;
+    };
+
+    void Construct() final;
+    
+    FCT_FOR_AUTO_CREATOR_ACTOR(GateTetMeshDoseActor)
+
+    // user callbacks for this actor, will be invoked in 'GateUserActions'
+    void BeginOfRunAction(const G4Run*) final;
+    void EndOfRunAction(const G4Run*) final;
+    void EndOfEventAction(const G4Event*) final;
+    
+    // Will be called before first run
+    void InitData();
+    
+    // pure virtual from GateVActor:
+    //  - how to save data to disk
+    //  - how to reset data in RAM
+    void SaveData() final;
+    void ResetData() final;
+
+    // Implements the virtual functions of G4PrimitivScorer.
+    void Initialize(G4HCofThisEvent*) final;
+    void EndOfEvent(G4HCofThisEvent*) final;
+    void clear() final;
+
+    // Is linked to 'ProcessHits' in GateVActor's interface. Omits the
+    // usage of a read-out geometry.
+    void UserSteppingAction(const GateVVolume*, const G4Step*) final;
+  
+  protected:
+    GateTetMeshDoseActor(G4String name, G4int depth = 0);
+
+  private:
+    // key = copy number of a tetrahedron's physical volume
+    // value = deposited dose
+    std::map<G4int, G4double> mEvtDoseMap;
+
+    G4int mRunCounter;
+
+    // one entry per tetrahedron
+    std::vector<Estimators> mRunData;
+
+    std::unique_ptr<GateActorMessenger> pMessenger;
+};
+
+MAKE_AUTO_CREATOR_ACTOR(TetMeshDoseActor,GateTetMeshDoseActor)
+
+#endif  // GATE_TETMESH_DOSE_ACTOR_HH

--- a/source/digits_hits/src/GateTetMeshDoseActor.cc
+++ b/source/digits_hits/src/GateTetMeshDoseActor.cc
@@ -1,0 +1,228 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+#include <fstream>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <G4String.hh>
+#include <G4Types.hh>
+#include <G4Run.hh>
+#include <G4VHitsCollection.hh>
+#include <G4THitsMap.hh>
+#include <G4Tet.hh>
+#include <G4LogicalVolume.hh>
+#include <G4AssemblyVolume.hh>
+
+#include "GateMessageManager.hh"
+#include "GateVVolume.hh"
+#include "GateTetMeshBox.hh"
+#include "GateVActor.hh"
+#include "GateActorMessenger.hh"
+
+#include "GateTetMeshDoseActor.hh"
+
+
+//----------------------------------------------------------------------------------------
+
+
+GateTetMeshDoseActor::GateTetMeshDoseActor(G4String name, G4int depth)
+  : GateVActor(name, depth), mEvtDoseMap(), mRunCounter(),
+    mRunData(), pMessenger(new GateActorMessenger(this))
+{
+}
+
+void GateTetMeshDoseActor::Construct()
+{
+  GateMessage("Actor", 1, "Constructing TetMeshDoseActor '" << 
+                          GateNamedObject::GetObjectName() << "'." << Gateendl);
+  
+  // enable callbacks which are implemented
+  EnableBeginOfRunAction(true);
+  EnableEndOfRunAction(true);
+  EnableEndOfEventAction(true);
+  EnableUserSteppingAction(true);
+
+  mRunCounter = 0;
+}
+
+//----------------------------------------------------------------------------------------
+
+void GateTetMeshDoseActor::BeginOfRunAction(const G4Run* run)
+{
+  // before the first run
+  if (mRunCounter == 0)
+  {
+    // check whether the volume is in fact a tetrahedral mesh
+    GateTetMeshBox* tetMeshBox = dynamic_cast<GateTetMeshBox*>(GateVActor::mVolume);
+    if (tetMeshBox == nullptr)
+    {
+      GateError("Actor '" << GateNamedObject::GetObjectName() << "' is attached" <<
+                " to volume of incorrect type. Please attach to TetMeshBox.");
+    }
+
+    // only now init data
+    InitData();
+  }
+    
+  // In general: the default BeginOfRunAction
+  GateVActor::BeginOfRunAction(run);
+}
+
+void GateTetMeshDoseActor::EndOfRunAction(const G4Run* run)
+{
+  // number of events processed in this run, i.e. number of "histories"
+  G4int n = run->GetNumberOfEvent();
+  
+  // Calculate relative uncertainty of dose values
+  for (Estimators& tetEstimators : mRunData)
+  {
+    G4double mean = tetEstimators.dose;
+    G4double squared = tetEstimators.sumOfSquaredDose;
+    
+    if (n > 1 && mean > 0)
+    {
+      // history by history method
+      tetEstimators.relativeUncertainty =
+        std::sqrt( (1.0 / (n - 1)) * (squared  / n - (mean / n) * (mean / n)) ) * n / mean;
+    }
+    else
+    {
+      // if N in {0, 1} or mean = 0, the relative uncertainty is ill-defined
+      tetEstimators.relativeUncertainty = std::numeric_limits<G4double>::infinity();
+    }
+  }
+
+  SaveData();
+  ++mRunCounter;
+}
+
+void GateTetMeshDoseActor::EndOfEventAction(const G4Event*)
+{  
+  // get the TetMeshBox this actor is attached to
+  GateTetMeshBox* tetMeshBox = dynamic_cast<GateTetMeshBox*>(GateVActor::mVolume);
+  
+  // Accumulate event dose in the run's dose map.
+  for (const auto& keyValuePair : mEvtDoseMap)
+  {
+    G4int iTetrahedron = tetMeshBox->GetTetIndex(keyValuePair.first);
+    G4double dose = keyValuePair.second;
+
+    Estimators& tetEstimator = mRunData[iTetrahedron];
+    tetEstimator.dose += dose;
+    tetEstimator.sumOfSquaredDose += dose * dose;
+  }
+}
+
+void GateTetMeshDoseActor::InitData()
+{
+  // get the TetMeshBox this actor is attached to
+  GateTetMeshBox* tetMeshBox = dynamic_cast<GateTetMeshBox*>(GateVActor::mVolume);
+
+  std::size_t nTetrahedra = tetMeshBox->GetNumberOfTetrahedra();
+  Estimators initialEstimates = {
+    .dose = 0.0,
+    .sumOfSquaredDose = 0.0,
+    .relativeUncertainty = std::numeric_limits<G4double>::infinity(),
+  };
+  
+  mRunData.clear();
+  mRunData.resize(nTetrahedra, initialEstimates);
+}
+
+void GateTetMeshDoseActor::SaveData()
+{
+  // get the TetMeshBox this actor is attached to
+  GateTetMeshBox* tetMeshBox = dynamic_cast<GateTetMeshBox*>(GateVActor::mVolume);
+  
+  std::ofstream csvTable(GateVActor::GetSaveFilename(), std::ofstream::out);
+
+  // header of csv file
+  csvTable << "# Tetrahedron-ID, Dose [Gy], Relative Uncertainty, "
+           << "Sum of Squared Dose [Gy^2], Volume [cm^3], "
+           << "Density [g / cm^3], Region Marker" << std::endl;
+
+  for (std::size_t iTet = 0; iTet < tetMeshBox->GetNumberOfTetrahedra(); ++iTet)
+  {
+    const G4LogicalVolume* tetLogical = tetMeshBox->GetTetLogical(iTet);
+
+    G4double dose = mRunData[iTet].dose;
+    G4double relativeUncertainty = mRunData[iTet].relativeUncertainty;
+    G4double sumOfSquaredDose = mRunData[iTet].sumOfSquaredDose;
+    G4double cubicVolume = tetLogical->GetSolid()->GetCubicVolume();
+    G4double density = tetLogical->GetMaterial()->GetDensity();
+    G4int regionMarker = tetMeshBox->GetRegionMarker(iTet);
+
+    csvTable << iTet << ", " << dose / gray << ", " << relativeUncertainty << ", "
+             << sumOfSquaredDose / (gray*gray) << ", " << cubicVolume / (cm*cm*cm) << ", "
+             << density * (cm*cm*cm) / g << ", " << regionMarker << std::endl;
+  }
+
+  GateMessage("Actor", 1, GateNamedObject::GetObjectName() << ": Saving dose to file '" << 
+                          GateVActor::GetSaveFilename() << "'." << Gateendl);
+  csvTable.close();
+}
+
+void GateTetMeshDoseActor::ResetData()
+{
+  Estimators initialEstimates = {
+    .dose = 0.0,
+    .sumOfSquaredDose = 0.0,
+    .relativeUncertainty = std::numeric_limits<G4double>::infinity(),
+  };
+  
+  std::fill(mRunData.begin(), mRunData.end(), initialEstimates);
+}
+
+//----------------------------------------------------------------------------------------
+
+void GateTetMeshDoseActor::Initialize(G4HCofThisEvent*)
+{
+  mEvtDoseMap.clear();
+}
+
+void GateTetMeshDoseActor::EndOfEvent(G4HCofThisEvent*)
+{
+}
+
+void GateTetMeshDoseActor::clear()
+{
+  mEvtDoseMap.clear();
+}
+
+// compare with G4PSDoseScorer
+void GateTetMeshDoseActor::UserSteppingAction(const GateVVolume*, const G4Step* aStep)
+{
+  G4VPhysicalVolume* physVol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+  G4int copyNum = physVol->GetCopyNo();
+
+  G4double edep = aStep->GetTotalEnergyDeposit();
+  G4double weight = aStep->GetPreStepPoint()->GetWeight();
+
+  // discard steps in bounding box volume or without energy deposition
+  if (copyNum == 0 || edep == 0)
+    return;
+
+  G4LogicalVolume* logVol = physVol->GetLogicalVolume();
+  G4double cubicVolume = logVol->GetSolid()->GetCubicVolume();
+  G4double density = logVol->GetMaterial()->GetDensity();
+
+  G4double dose = (edep * weight) / (density * cubicVolume);
+
+  // accumulate or add
+  if (mEvtDoseMap.find(copyNum) == mEvtDoseMap.end())
+  {
+    mEvtDoseMap[copyNum] = dose;
+  }
+  else
+  {
+    mEvtDoseMap[copyNum] += dose;    
+  }
+}

--- a/source/general/include/GateTools.hh
+++ b/source/general/include/GateTools.hh
@@ -10,6 +10,8 @@ See LICENSE.md for further details
 #ifndef GateTools_h
 #define GateTools_h 1
 
+#include <utility>
+
 #include "globals.hh"
 #include "GateConfiguration.h"
 #include "GateMessageManager.hh"
@@ -44,6 +46,30 @@ namespace GateTools
   //! The function returns either the full file path or "" (file not found).
   G4String FindGateFile(const G4String& fileName);
 
+  //! Get directory name from full path.
+  //!
+  //! Examples:
+  //! "/path/to/file.txt" yields  "/path/to/"
+  //! "/path/to/file"     yields  "/path/to/"
+  //! "/path/to/"         yields  "/path/to/"
+  G4String PathDirName(const G4String& path);
+
+  //! Split into directory and file name.
+  //!
+  //! Examples:
+  //! "/path/to/file.txt" yields  ("/path/to/", "file.txt")
+  //! "/path/to/file"     yields  ("/path/to/", "file")
+  //! "/path/to/""        yields  ("/path/to/", "")
+  std::pair<G4String, G4String> PathSplit(const G4String& path);
+
+  //! Split into root and file extension.
+  //!
+  //! Examples:
+  //! "file.txt"      yields  ("file", ".txt")
+  //! ".hidden_file"  yields  (".hidden_file", "")
+  //! "file_no_ext"   yields  ("file_no_ext", "")
+  //! "file.one.two"  yields  ("file.one", ".two")
+  std::pair<G4String, G4String> PathSplitExt(const G4String& fileName);
 }
 
 #endif

--- a/source/general/src/GateTools.cc
+++ b/source/general/src/GateTools.cc
@@ -6,6 +6,8 @@ of the GNU Lesser General  Public Licence (LGPL)
 See LICENSE.md for further details
 ----------------------*/
 
+#include <string>
+#include <utility>
 
 #include "GateTools.hh"
 
@@ -66,5 +68,69 @@ G4String GateTools::FindGateFile(const G4String& fileName)
   else
     return "";
 
+}
+//---------------------------------------------------------------------------
+
+
+//---------------------------------------------------------------------------
+G4String GateTools::PathDirName(const G4String& path)
+{ 
+  G4String dir = "";
+
+  std::size_t found = path.find_last_of("/\\");
+  if (found < std::string::npos)
+  {
+    dir = path.substr(0, found + 1);
+  }
+
+  return dir;
+}
+//---------------------------------------------------------------------------
+
+
+//---------------------------------------------------------------------------
+std::pair<G4String, G4String> GateTools::PathSplit(const G4String& path)
+{
+  G4String dir = "";
+  G4String fileName = "";
+
+  std::size_t found = path.find_last_of("/\\");
+  if (found < std::string::npos)
+  {
+    dir = path.substr(0, found + 1);
+    fileName = path.substr(found + 1, std::string::npos);
+  } 
+  else if (found == std::string::npos)
+  {
+    fileName = path;
+  }
+
+  return std::pair<G4String, G4String>(dir, fileName);
+}
+//---------------------------------------------------------------------------
+
+
+//---------------------------------------------------------------------------
+std::pair<G4String, G4String> GateTools::PathSplitExt(const G4String& path)
+{
+  G4String root = "";
+  G4String ext = "";
+
+  std::pair<G4String, G4String> dirAndFileName = PathSplit(path);
+  const G4String& dir = dirAndFileName.first;
+  const G4String& fileName = dirAndFileName.second;
+
+  std::size_t found = fileName.find_last_of(".");
+  if (found > 0 && found < std::string::npos)
+  {
+    root = dir + fileName.substr(0, found);
+    ext = fileName.substr(found, std::string::npos);
+  }
+  else
+  {
+    root = path;
+  }
+
+  return std::pair<G4String, G4String>(root, ext);
 }
 //---------------------------------------------------------------------------

--- a/source/geometry/include/GateTetMeshBox.hh
+++ b/source/geometry/include/GateTetMeshBox.hh
@@ -1,0 +1,127 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+#ifndef GATE_TET_MESH_BOX_HH
+#define GATE_TET_MESH_BOX_HH
+
+#include <memory>
+#include <map>
+
+#include <G4String.hh>
+#include <G4Types.hh>
+#include <G4LogicalVolume.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4Colour.hh>
+#include <G4Material.hh>
+#include <G4Box.hh>
+#include <G4AssemblyVolume.hh>
+
+#include "GateTetMeshReader.hh"
+#include "GateVVolume.hh"
+#include "GateVolumeManager.hh"
+
+class GateTetMeshBoxMessenger;
+class GateMultiSensitiveDetector;
+
+
+struct GateMeshTetAttributes
+{
+  G4Colour colour;
+  G4bool isVisible;
+  G4Material* material;
+};
+
+// Integer key corresponds to identifier of a tetrahedron, i.e. region-ID.
+typedef std::map<G4int, GateMeshTetAttributes> GateMeshTetAttributeMap;
+
+
+// hosts a tetrahedral-mesh geometry in a box envelope
+class GateTetMeshBox : public GateVVolume
+{
+  public:
+    GateTetMeshBox(const G4String& itsName,
+                   G4bool acceptsChildren = false,
+                   G4int depth = 0);
+
+    FCT_FOR_AUTO_CREATOR_VOLUME(GateTetMeshBox)
+    
+    // implementation of GateVVolume's interface
+    G4LogicalVolume* ConstructOwnSolidAndLogicalVolume(G4Material*, G4bool) final;
+    void DestroyOwnSolidAndLogicalVolume() final;
+    G4double GetHalfDimension(std::size_t) final;
+    void PropagateSensitiveDetectorToChild(GateMultiSensitiveDetector*) final;
+    void PropagateGlobalSensitiveDetector() final;
+
+  public:
+    // setters for the messenger
+    void SetPathToELEFile(const G4String& path) { mPath = path; }
+    void SetPathToAttributeMap(const G4String& path) { mAttributeMapPath = path; }
+    void SetUnitOfLength(G4double unitOfLength) { mUnitOfLength = unitOfLength; }
+
+    // getters for attached actors (be aware, that there is no bound checking):
+    //
+    std::size_t GetNumberOfTetrahedra()
+    {
+      return mRegionIDs.size();
+    }
+
+    // The tetrahedra are imprinted in order, as physical volumes with consecutive copy numbers.
+    // However, these copy numbers may start at values > 0. This is a convenience function
+    // to subtract this offset and get the tetrahedron index.
+    G4int GetTetIndex(G4int physVolCopyNum) const
+    {
+      return physVolCopyNum - mPhysVolCopyNumOffset;
+    }
+
+    G4int GetRegionMarker(std::size_t tetIndex) const
+    {
+      return mRegionIDs[tetIndex];
+    }
+
+    const G4LogicalVolume* GetTetLogical(std::size_t tetIndex) const
+    {
+      G4VPhysicalVolume* physVol = *(pTetAssembly->GetVolumesIterator() + tetIndex);
+      return physVol->GetLogicalVolume();
+    }
+
+  private:
+    // implementation specifics
+    void DescribeMyself(size_t);
+    void ReadAttributeMap();
+
+  private:
+    G4String mPath;
+    G4double mUnitOfLength;
+    G4String mAttributeMapPath;
+    GateMeshTetAttributeMap mAttributeMap;
+
+    std::unique_ptr<GateTetMeshBoxMessenger> pMessenger;
+
+    // box as mother volume containing the tetrahedra
+    G4Box* pEnvelopeSolid;
+    G4LogicalVolume* pEnvelopeLogical;
+
+    // data corresponding to the actual tetrahedral mesh:
+    //
+    // one per tetrahedron
+    std::vector<G4int> mRegionIDs;
+
+    // extent of the tetrahedral mesh
+    G4double mXmin, mXmax, mYmin, mYmax, mZmin, mZmax;
+
+    // assembly which facilitates the imprint
+    std::unique_ptr<G4AssemblyVolume> pTetAssembly;
+
+    // copy number of the 0th tetrahedron's physical volume
+    G4int mPhysVolCopyNumOffset;
+};
+
+
+MAKE_AUTO_CREATOR_VOLUME(TetMeshBox,GateTetMeshBox)
+
+
+#endif  // GATE_TET_MESH_BOX_HH

--- a/source/geometry/include/GateTetMeshBoxMessenger.hh
+++ b/source/geometry/include/GateTetMeshBoxMessenger.hh
@@ -1,0 +1,37 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+----------------------*/
+
+#ifndef GATE_TET_MESH_BOX_MESSENGER_HH
+#define GATE_TET_MESH_BOX_MESSENGER_HH
+
+#include <G4String.hh>
+#include <G4UIcommand.hh>
+#include <G4UIcmdWithAString.hh>
+#include <G4UIcmdWithADoubleAndUnit.hh>
+#include <G4UIcmdWith3VectorAndUnit.hh>
+
+#include "GateVolumeMessenger.hh"
+
+class GateTetMeshBox;
+
+
+class GateTetMeshBoxMessenger : public GateVolumeMessenger
+{
+  public:
+    explicit GateTetMeshBoxMessenger(GateTetMeshBox* itsCreator);
+    ~GateTetMeshBoxMessenger() final;
+
+    void SetNewValue(G4UIcommand*, G4String) final;
+
+  private:
+    G4UIcmdWithAString* pSetPathToAttributeMapCmd;
+    G4UIcmdWithAString* pSetPathToELEFileCmd;
+    G4UIcmdWithADoubleAndUnit* pSetUnitOfLengthCmd;
+};
+
+#endif  // GATE_TET_MESH_BOX_MESSENGER_HH

--- a/source/geometry/include/GateTetMeshReader.hh
+++ b/source/geometry/include/GateTetMeshReader.hh
@@ -1,0 +1,56 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+#ifndef GATE_TET_MESH_READER
+#define GATE_TET_MESH_READER
+
+#include <vector>
+
+#include <G4String.hh>
+#include <G4Types.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4ThreeVector.hh>
+#include <G4Tet.hh>
+
+
+struct GateMeshTet
+{
+  G4Tet* solid;
+
+  // ELE file associate an integer attribute to each tetrahedron
+  // to define to which region, i.e. "meta-shape", it belongs.
+  G4int regionID;
+  static constexpr G4int DEFAULT_REGION_ID = -666;
+};
+
+
+class GateTetMeshReader
+{
+  public:
+    explicit GateTetMeshReader(G4double unitOfLength = mm);
+
+    // Reads a tetrahedral mesh from a file. 
+    // ELE (TetGen) is the only supported file type so far.
+    std::vector<GateMeshTet> Read(const G4String& filePath);
+
+    void SetUnitOfLength(G4double unitOfLength) { fUnitOfLength = unitOfLength; }
+    G4double GetUnitOfLength() { return fUnitOfLength; }
+
+  private:
+    // implementation specifics
+    std::vector<GateMeshTet> ReadELE(const G4String& filePath);
+    std::vector<G4ThreeVector> ReadNODE(const G4String& filePath);
+    // possible extensions, e.g.:
+    // std::vecor<GateMeshTet> ReadVTKLegacy(const G4String& filePath);
+
+  private:
+    // Geant4 internal unit, used to interpret the length scale of the meshes.
+    G4double fUnitOfLength;
+};
+
+
+#endif  // GATE_TET_MESH_READER

--- a/source/geometry/src/GateTetMeshBox.cc
+++ b/source/geometry/src/GateTetMeshBox.cc
@@ -1,0 +1,338 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+----------------------*/
+#include <memory>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <cmath>
+#include <utility>
+
+#include <G4String.hh>
+#include <G4Types.hh>
+#include <G4LogicalVolume.hh>
+#include <G4Material.hh>
+#include <G4Box.hh>
+#include <G4NistManager.hh>
+#include <G4ThreeVector.hh>
+#include <G4VisExtent.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4VSolid.hh>
+#include <G4Colour.hh>
+#include <G4VisAttributes.hh>
+
+#include "GateVVolume.hh"
+#include "GateTools.hh"
+#include "GateTetMeshReader.hh"
+#include "GateMessageManager.hh"
+#include "GateDetectorConstruction.hh"  // <-- contains "theMaterialDatabase"
+#include "GateMultiSensitiveDetector.hh"
+#include "GateTetMeshBoxMessenger.hh"
+
+#include "GateTetMeshBox.hh"
+
+
+//----------------------------------------------------------------------------------------
+
+GateTetMeshBox::GateTetMeshBox(const G4String& itsName,
+                               G4bool acceptsChildren,
+                               G4int depth)
+  : GateVVolume(itsName, false, depth),
+    mPath(""), mUnitOfLength(mm), mAttributeMapPath(""), mAttributeMap(),
+    pMessenger(new GateTetMeshBoxMessenger(this)),
+    pEnvelopeSolid(nullptr), pEnvelopeLogical(nullptr), mRegionIDs(),
+    mXmin(), mXmax(), mYmin(), mYmax(), mZmin(), mZmax(),
+    pTetAssembly(), mPhysVolCopyNumOffset()
+{
+  // for now, don't accept children, to avoid overlaps with the tetrahedra
+  if (acceptsChildren == true)
+    GateWarning("The current TetMeshBox implementation "   \
+                "doesn't support additional child volumes.");
+  
+  // set default material name
+  GateVVolume::SetMaterialName("Vacuum");
+}
+
+//----------------------------------------------------------------------------------------
+
+G4LogicalVolume* GateTetMeshBox::ConstructOwnSolidAndLogicalVolume(G4Material* material,
+                                                                   G4bool flagUpdateOnly)
+{
+  // Update: Occurs when clock has changed, to trigger movement. Movement is implemented
+  //         on the GateVVolume level, therefore we don't need to do anything.
+  if (flagUpdateOnly == true && pEnvelopeLogical)
+    return pEnvelopeLogical;
+
+  GateMessage("Geometry", 1, "Building tetrahedral mesh..." << Gateendl);
+  
+  // upon construction or rebuild: read region attributes from file
+  ReadAttributeMap();
+  
+  //-----------------------------------------------------
+  // MESH CONSTRUCTION
+  //-----------------------------------------------------
+
+  // read tetrahedra from ELE file
+  GateTetMeshReader fileReader(mUnitOfLength);
+  std::vector<GateMeshTet> tetrahedra = fileReader.Read(mPath);
+
+  pTetAssembly.reset(new G4AssemblyVolume);
+
+  for (const auto& tet : tetrahedra)
+  {
+    G4Material* material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+    G4Colour colour = G4Colour::White();
+    G4bool isVisible = true;
+    
+    // find attributes and set colour and material accordingly
+    if (mAttributeMap.find(tet.regionID) != mAttributeMap.end())
+    {
+      material = mAttributeMap[tet.regionID].material;
+      colour = mAttributeMap[tet.regionID].colour;
+      isVisible = mAttributeMap[tet.regionID].isVisible;
+    }
+    else
+    {
+      GateWarning("Unknown region '" << tet.regionID << "', setting material to 'G4_AIR'.");
+    }
+
+    // create corresponding logical volume
+    G4String logicalName = tet.solid->GetName() + "_logical"; 
+    G4LogicalVolume* tetLogical = new G4LogicalVolume(tet.solid, material, logicalName);
+
+    if (isVisible)
+    {
+      tetLogical->SetVisAttributes(colour);
+    }
+    else
+    {
+      tetLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
+    }
+
+    // cache region marker of tetrahedron
+    mRegionIDs.push_back(tet.regionID);
+
+    // update extent of tetrahedral mesh
+    const G4VisExtent& tetExtent = tet.solid->GetExtent();
+    if(GetNumberOfTetrahedra() > 0)
+    {
+      // update
+      mXmin = std::min(mXmin, tetExtent.GetXmin());
+      mXmax = std::max(mXmax, tetExtent.GetXmax());
+      mYmin = std::min(mYmin, tetExtent.GetYmin());
+      mYmax = std::max(mYmax, tetExtent.GetYmax());
+      mZmin = std::min(mZmin, tetExtent.GetZmin());
+      mZmax = std::max(mZmax, tetExtent.GetZmax());
+    }
+    else
+    {
+      // init
+      mXmin = tetExtent.GetXmin();
+      mXmax = tetExtent.GetXmax();
+      mYmin = tetExtent.GetYmin();
+      mYmax = tetExtent.GetYmax();
+      mZmin = tetExtent.GetZmin();
+      mZmax = tetExtent.GetZmax();
+    }
+
+    // add tetrahedron to assembly, placement is trivial
+    G4ThreeVector nullVector = G4ThreeVector();
+    pTetAssembly->AddPlacedVolume(tetLogical, nullVector, nullptr);
+  }
+
+  //-----------------------------------------------------
+  // ADAPT BOUNDING BOX & IMPRINT
+  //-----------------------------------------------------
+
+  // Create a bounding box, size is the tetrahedral mesh's extent
+  G4double xHalfLength = 0.5 * (mXmax - mXmin);
+  G4double yHalfLength = 0.5 * (mYmax - mYmin);
+  G4double zHalfLength = 0.5 * (mZmax - mZmin);
+  
+  pEnvelopeSolid = new G4Box(GateVVolume::GetSolidName(),
+                             xHalfLength, yHalfLength, zHalfLength);
+  pEnvelopeLogical = new G4LogicalVolume(pEnvelopeSolid, material,
+                                         GateVVolume::GetLogicalVolumeName());
+
+  // place center of tetrahedral mesh at the center of the bounding box
+  G4double xMean = 0.5 * (mXmax + mXmin);
+  G4double yMean = 0.5 * (mYmax + mYmin);
+  G4double zMean = 0.5 * (mZmax + mZmin);
+
+  G4ThreeVector translation(-xMean, -yMean, -zMean);
+  pTetAssembly->MakeImprint(pEnvelopeLogical, translation, nullptr);
+  
+  // ----call after imprint!!!----
+  // The physical volume copy number of the first tetrahedron
+  const G4VPhysicalVolume* firstPV = *(pTetAssembly->GetVolumesIterator());
+  mPhysVolCopyNumOffset = firstPV->GetCopyNo();
+
+  GateMessage("Geometry", 1, "... done building tetrahedral mesh." << Gateendl);
+  return pEnvelopeLogical;
+}
+
+//----------------------------------------------------------------------------------------
+
+void GateTetMeshBox::DestroyOwnSolidAndLogicalVolume()
+{  
+  // delete subtree
+  if (pTetAssembly)
+  {
+    // manually delete logical and solid of the tetrahedra
+    for(unsigned i = 0; i < pTetAssembly->TotalImprintedVolumes(); ++i)
+    {
+      const G4VPhysicalVolume* tetPhysical = *(pTetAssembly->GetVolumesIterator() + i);
+      G4LogicalVolume* tetLogical = tetPhysical->GetLogicalVolume();
+      G4VSolid* tetSolid = tetLogical->GetSolid();
+
+      delete tetLogical;
+      delete tetSolid;
+    }
+
+    // Invokes destruction of the tetrahedra's physical volumes & rotation.
+    // They are owned by the assembly.
+    pTetAssembly.reset(nullptr);
+  }
+
+  // delete envelope box
+  if (pEnvelopeSolid)
+  {
+    delete pEnvelopeSolid;
+    pEnvelopeSolid = nullptr;
+  }
+  if (pEnvelopeLogical)
+  {
+    delete pEnvelopeLogical;
+    pEnvelopeLogical = nullptr;
+  }
+}
+
+//----------------------------------------------------------------------------------------
+
+G4double GateTetMeshBox::GetHalfDimension(size_t axis)
+{
+  if (pEnvelopeSolid)
+  {
+    const G4VisExtent extent = pEnvelopeSolid->GetExtent();
+    if (axis == 0)
+    {
+      return 0.5 * (extent.GetXmax() - extent.GetXmin());
+    } 
+    else if (axis == 1)
+    {
+      return 0.5 * (extent.GetYmax() - extent.GetYmin());
+    } 
+    else if (axis == 2)
+    {
+      return 0.5 * (extent.GetZmax() - extent.GetZmin());
+    } else
+    {
+      return 0.0;
+    }
+  }
+  return 0.0;
+}
+
+//----------------------------------------------------------------------------------------
+
+void GateTetMeshBox::PropagateSensitiveDetectorToChild(GateMultiSensitiveDetector* msd)
+{
+  // set sensitive detector for all daughters of the envelope box, i.e. all tetrahedra
+  for (G4int i = 0; i < pEnvelopeLogical->GetNoDaughters(); ++i)
+  {
+    pEnvelopeLogical->GetDaughter(i)->GetLogicalVolume()->SetSensitiveDetector(msd);
+  }
+}
+
+void GateTetMeshBox::PropagateGlobalSensitiveDetector()
+{
+  // in case no global SD was assigned to this volume
+  if (GateVVolume::m_sensitiveDetector == nullptr)
+    return;
+
+  // otherwise check for phantom SD
+  GatePhantomSD* phantomSD = \
+    GateDetectorConstruction::GetGateDetectorConstruction()->GetPhantomSD();
+  if (phantomSD)
+  {
+    // set for all tetrahedra
+    for (G4int i = 0; i < pEnvelopeLogical->GetNoDaughters(); ++i)
+    {
+      pEnvelopeLogical->GetDaughter(i)->GetLogicalVolume()->SetSensitiveDetector(phantomSD);
+    }
+  }
+}
+
+void GateTetMeshBox::DescribeMyself(size_t level)
+{
+  G4cout << GateTools::Indent(level)
+         << "From ELE file: '" << mPath << "'" << Gateendl;
+  G4cout << GateTools::Indent(level)
+         << "Extent: " << pEnvelopeSolid->GetExtent() << Gateendl;
+  G4cout << GateTools::Indent(level)
+         << "#tetrahedra: " << GetNumberOfTetrahedra() << Gateendl;
+}
+
+void GateTetMeshBox::ReadAttributeMap()
+{
+  GateMessage("Geometry", 2, "Reading tet attributes from file: '" <<
+                              mAttributeMapPath << "'." << Gateendl);
+  std::ifstream inputFileStream(mAttributeMapPath);
+  if (inputFileStream.is_open() == false)
+  {
+    GateError("Cannot open material map: '" << mAttributeMapPath << "'");
+    return;
+  }
+
+  G4String line;
+  while (std::getline(inputFileStream, line))
+  {
+    // skip comments & empty lines
+    if (line.front() == '#' || line.empty())
+      continue;
+    
+    // columns
+    G4int regionIDstart;
+    G4int regionIDend;
+    G4String materialName;
+    G4bool isVisible;
+    G4double r, g, b, alpha;
+    
+    std::istringstream lineStream(line);
+
+    // read columns
+    if(lineStream >> regionIDstart >> regionIDend)
+      if (lineStream >> materialName)
+        if (lineStream >> std::boolalpha >> isVisible)
+          lineStream >> r >> g >> b >> alpha;
+
+    if (lineStream.fail())
+      GateError("Failed to read line '" << line << "' in attribute map.");
+
+    for (G4int rID = regionIDstart; rID <= regionIDend; ++rID)
+    {
+      GateMeshTetAttributes attributes;
+      attributes.material = theMaterialDatabase.GetMaterial(materialName);
+      attributes.colour = G4Colour(r, g, b, alpha);
+      attributes.isVisible = isVisible;
+
+      mAttributeMap[rID] = attributes;
+    }
+  }
+
+  // print as table
+  GateMessage("Geometry", 3, Gateendl);
+  for (const auto& pair : mAttributeMap)
+  {
+    G4int regionID = pair.first;
+    const GateMeshTetAttributes& attributes = pair.second;
+    GateMessage("Geometry", 3, "Region " << regionID << ":\t" <<
+                               attributes.material->GetName() << "\t" <<
+                               attributes.colour << Gateendl);
+  }
+  GateMessage("Geometry", 3, Gateendl);  
+}

--- a/source/geometry/src/GateTetMeshBoxMessenger.cc
+++ b/source/geometry/src/GateTetMeshBoxMessenger.cc
@@ -1,0 +1,67 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+----------------------*/
+#include <G4String.hh>
+#include <G4UIcommand.hh>
+#include <G4UIcmdWithAString.hh>
+#include <G4UIcmdWithADoubleAndUnit.hh>
+#include <G4UIcmdWith3VectorAndUnit.hh>
+
+#include "GateVVolume.hh"
+#include "GateTetMeshBox.hh"
+#include "GateVolumeMessenger.hh"
+
+#include "GateTetMeshBoxMessenger.hh"
+
+
+GateTetMeshBoxMessenger::GateTetMeshBoxMessenger(GateTetMeshBox* itsCreator)
+  : GateVolumeMessenger(itsCreator)
+{
+  const G4String& dir = GateMessenger::GetDirectoryName();
+  G4String pathCmdName = dir + "reader/setPathToELEFile";
+  G4String regionAttributeMapCmdName = dir + "setPathToAttributeMap";
+  G4String unitOfLengthCmdName = dir + "reader/setUnitOfLength";
+
+  pSetPathToELEFileCmd = new G4UIcmdWithAString(pathCmdName, this);
+  pSetPathToELEFileCmd->SetGuidance("Set path to ELE file.");
+  pSetPathToAttributeMapCmd = new G4UIcmdWithAString(regionAttributeMapCmdName, this);
+  pSetPathToAttributeMapCmd->SetGuidance("Set path to material map (ASCII file).");
+  pSetUnitOfLengthCmd = new G4UIcmdWithADoubleAndUnit(unitOfLengthCmdName, this);
+  pSetUnitOfLengthCmd->SetGuidance("Unit of length to interpret the coordinates.");
+}
+
+
+GateTetMeshBoxMessenger::~GateTetMeshBoxMessenger()
+{
+  delete pSetPathToELEFileCmd;
+  delete pSetPathToAttributeMapCmd;
+  delete pSetUnitOfLengthCmd;
+}
+
+
+void GateTetMeshBoxMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
+{
+  GateVVolume* creatorBase = GateVolumeMessenger::GetVolumeCreator();
+  GateTetMeshBox* creator = dynamic_cast<GateTetMeshBox*>(creatorBase);
+  
+  if(command == pSetPathToELEFileCmd)
+  {
+    creator->SetPathToELEFile(newValue);
+  }
+  else if (command == pSetPathToAttributeMapCmd)
+  {
+    creator->SetPathToAttributeMap(newValue);
+  }
+  else if (command == pSetUnitOfLengthCmd)
+  {
+    creator->SetUnitOfLength(pSetUnitOfLengthCmd->GetNewDoubleValue(newValue));
+  }
+  else
+  {
+    GateVolumeMessenger::SetNewValue(command, newValue);
+  }
+}

--- a/source/geometry/src/GateTetMeshReader.cc
+++ b/source/geometry/src/GateTetMeshReader.cc
@@ -1,0 +1,250 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <array>
+#include <vector>
+
+#include <G4String.hh>
+#include <G4Types.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4ThreeVector.hh>
+#include <G4Tet.hh>
+
+#include "GateTools.hh"
+#include "GateMessageManager.hh"
+
+#include "GateTetMeshReader.hh"
+
+
+//----------------------------------------------------------------------------------------
+
+GateTetMeshReader::GateTetMeshReader(G4double unitOfLength)
+  : fUnitOfLength(unitOfLength)
+{
+}
+
+//----------------------------------------------------------------------------------------
+
+std::vector<GateMeshTet> GateTetMeshReader::Read(const G4String& filePath)
+{
+  std::vector<GateMeshTet> tetrahedra;
+
+  const G4String& extension = GateTools::PathSplitExt(filePath).second;
+  if (extension == ".ele")
+  {
+    tetrahedra = ReadELE(filePath);
+  }
+  else
+  {
+    GateError("File format not supported: '" << extension << "'. Could not load tetrahedral mesh.");
+  }
+
+  return tetrahedra;
+}
+
+//----------------------------------------------------------------------------------------
+
+std::vector<GateMeshTet> GateTetMeshReader::ReadELE(const G4String& filePath)
+{
+  // ELE files are accompanied by seperate NODE files which define all mesh nodes.
+  // E.g. for "<filePath>.ele" there should be "<filePath>.node".
+  G4String nodeFilePath = GateTools::PathSplitExt(filePath).first + ".node";
+  std::vector<G4ThreeVector> nodes = ReadNODE(nodeFilePath);
+
+  // Only after successfully reading the nodes, the ELE file is looked into.
+  GateMessage("Geometry", 2, "Reading tetrahedra from '" << filePath << "'." << Gateendl);
+  std::ifstream eleFileStream(filePath);
+  if (eleFileStream.is_open() == false)
+  {
+    GateError("Cannot open file: '" << filePath << "'.");
+    return std::vector<GateMeshTet>();
+  }
+
+  // The first non-comment line should be the header, containing:
+  //
+  //    <# of tetrahedra> <nodes per tet. (4 or 10)> <region attribute (0 or 1)>
+  //
+  std::size_t nTetrahedra = 0;
+  std::size_t nNodesPerTet = 0;
+  G4bool hasRegionID = false;
+
+  G4String line;
+  while (std::getline(eleFileStream, line))
+  {
+    // skip comments & emtpy lines
+    if (line.front() == '#' || line.empty())
+      continue;
+    
+    std::istringstream lineParser(line);
+
+    // <# of tetrahedra> <nodes per tet. (4 or 10)> <region attribute (0 or 1)>
+    if (lineParser >> nTetrahedra >> nNodesPerTet)
+      lineParser >> hasRegionID;
+
+    if (lineParser.fail())
+    {
+      GateError("Failed to parse ELE section header: '" << line << "'.");
+      return std::vector<GateMeshTet>();
+    }
+
+    break;
+  }
+
+  // If generated with the '-o2' flag, TetGen's ELE file might define tetrahedra
+  // consisting of 10 points, i.e. the corners and each edge's midpoint.
+  // For now, abort when encountering these files.
+  if (nNodesPerTet != 4)
+  {
+    GateError("Cannot read tetrahedral mesh generated with '-o2' flag.");
+    return std::vector<GateMeshTet>();
+  }
+
+  // strings we'll need to name the solids later on
+  const G4String& fileName = GateTools::PathSplit(filePath).second;
+  const G4String& fileNameRoot = GateTools::PathSplitExt(fileName).first;
+
+  // After the header, each row of the ELE file defines one tetrahedron, 
+  // via the indices of specific nodes: 
+  //    ...
+  //    <tetrahedron #> <node> <node> ... <node> [attribute]
+  //    ...
+  std::vector<GateMeshTet> tetrahedra;
+  std::size_t counter = 0;
+  while (std::getline(eleFileStream, line) && counter < nTetrahedra)
+  {
+    // skip comments & emtpy lines
+    if (line.front() == '#' || line.empty())
+      continue;
+
+    std::istringstream lineParser(line);
+
+    // <tetrahedron #>
+    std::size_t tetNumber = 0;
+    lineParser >> tetNumber;
+
+    // <node> <node> ... <node>
+    std::array<G4ThreeVector, 4> cornerNodes;
+    for (auto& cornerNode : cornerNodes)
+    {
+      G4int index;
+      lineParser >> index;
+      cornerNode = nodes[index];
+    }
+
+    // [attribute] aka. regionID
+    G4int regionID = GateMeshTet::DEFAULT_REGION_ID;
+    if (hasRegionID)
+      lineParser >> regionID;
+
+    // check, if parsing any of the integers has failed
+    if (lineParser.fail())
+    {
+      GateError("Failed to read tetrahedron: '" << line << "'.");
+      return std::vector<GateMeshTet>();
+    }
+
+    G4String tetSolidName = fileNameRoot + "_tet" + std::to_string(counter);
+    G4Tet* tetSolid = new G4Tet(tetSolidName, cornerNodes[0], cornerNodes[1],
+                                              cornerNodes[2], cornerNodes[3]);
+
+    tetrahedra.push_back(GateMeshTet{tetSolid, regionID});
+    ++counter;
+  }
+
+  GateMessage("Geometry", 2, "Obtained mesh containting "
+                             << tetrahedra.size() <<
+                             " tetrahedra." << Gateendl);
+  return tetrahedra;
+}
+
+//----------------------------------------------------------------------------------------
+
+std::vector<G4ThreeVector> GateTetMeshReader::ReadNODE(const G4String& filePath)
+{
+  GateMessage("Geometry", 2, "Reading nodes from '" << filePath << "'." << Gateendl);
+  std::ifstream nodeFileStream(filePath);
+  if (nodeFileStream.is_open() == false)
+  {
+    GateError("Cannot open file: '" << filePath << "'.");
+    return std::vector<G4ThreeVector>();
+  }
+  
+  // header of node section:
+  //    <# of nodes> <dimension (3)> <# of attributes> <boundary markers (0 or 1)>
+  std::size_t nNodes = 0;
+  std::size_t dimension = 0;
+
+  G4String line;
+  while (std::getline(nodeFileStream, line))
+  {
+    // skip comments & emtpy lines
+    if (line.front() == '#' || line.empty())
+      continue;
+
+    std::istringstream lineParser(line);
+
+    // read first entry: <# of points>
+    lineParser >> nNodes;
+    if (lineParser.fail())
+    {
+      GateError("Failed to parse node section header: '" << line << "'.");
+      return std::vector<G4ThreeVector>();
+    }
+
+    if (nNodes > 0)
+    {
+      // read second entry: <dimension (3)>
+      lineParser >> dimension;
+      if (lineParser.fail() || dimension != 3)
+      {
+        GateError("Failed to parse node section header: '" << line << "'.");
+        return std::vector<G4ThreeVector>();
+      }
+    }
+    else
+    {
+      GateError("NODE file is emtpy or #nodes is set to zero.");
+      return std::vector<G4ThreeVector>();
+    }
+
+    // ignore the rest of the header line, 
+    // i.e. ... <# of attributes> <boundary markers (0 or 1)>
+    break;
+  }
+
+  //  remaining lines list nodes: 
+  //    <node #> <x> <y> <z> [attributes] [boundary marker]
+  std::vector<G4ThreeVector> nodes;
+  while (std::getline(nodeFileStream, line) && nodes.size() < nNodes)
+  {
+    // skip comments & emtpy lines
+    if (line.front() == '#' || line.empty())
+      continue;
+
+    std::istringstream lineParser(line);
+
+    std::size_t nodeCount;
+    G4double x, y, z;
+
+    // read node: <point #> <x> <y> <z>
+    if (lineParser >> nodeCount)
+      lineParser >> x >> y >> z;
+    
+    if (lineParser.fail())
+    {
+      GateError("Failed to read node: '" << line << "'.");
+      return std::vector<G4ThreeVector>();
+    }
+
+    nodes.push_back(G4ThreeVector(x, y, z) * fUnitOfLength);
+  }
+
+  return nodes;
+}


### PR DESCRIPTION
The first commits contain a new `GateVVolume` descendent, the `GateTetMeshBox`, which is able to load tetrahedral-mesh geometries from ASCII files (`.ele`) which can be produced using a tool called [TetGen](www.tetgen.org). Here, some visualisations from GATE simulations I ran:

![tetmeshbox](https://user-images.githubusercontent.com/4160681/33625407-c29622ce-d9f7-11e7-98c2-447f984eca84.png)

![tetmeshboxrun](https://user-images.githubusercontent.com/4160681/33625446-e8d486c4-d9f7-11e7-88a4-79a3448ab7e4.png)

----

The last commit introduces the `GateTetMeshDoseActor`, an actor, that can only be attached to `GateTetMeshBox` volumes. This is an interface similar to the `GateDoseActor`. It scores dose (and rel. uncertainty) deposited in each tetrahedron. The output file is a simple csv-table:

```
# Tetrahedron-ID, Dose [Gy], Relative Uncertainty, Sum of Squared Dose [Gy^2], Volume [cm^3], Density [g / cm^3], Region Marker
0, 1.3e-08, 1.3e-01, 3.0e-18, 1.9e-02, 9.5e-01, 1
1, ...
...
```
