### PR TITLE
use G4String rather than G4SubString with in GateTokenizer.hh for compatibility with Geant4 10.04

### DIFF
--- a/source/digits_hits/include/GateTokenizer.hh
+++ b/source/digits_hits/include/GateTokenizer.hh
@@ -39,7 +39,7 @@ public:
   static BrokenString BreakString(const G4String& stringToBreak,char separator);
 
 public:
-  G4SubString operator()(const char* str=" \t\n",size_t l=0)
+  G4String operator()(const char* str=" \t\n",size_t l=0)
     {
       return G4Tokenizer::operator()(str,l);
     }


### PR DESCRIPTION
Although not clearly mentioned in the Geant4 10.04 release notes at http://geant4.web.cern.ch/geant4/support/ReleaseNotes4.10.4.html, `G4SubString` is no longer provided.

It seems like this was considered something only to be used internally, cfr. mention of it in the release notes of Geant4 10.03-p01 available at http://geant4.web.cern.ch/geant4/support/Patch4.10.3-1.txt:

```
Removed obsolete G4SubString code used internally in G4String, as no
longer necessary and also including unnecessary and buggy operators.
```

I should mention I'm not 100% sure this is the right fix for this problem, but I was able to compile GATE 8.0 on top of Geant4 10.04 with this change.

Without this change, I ran into compilation errors like:

```
In file included from /tmp/gate_v8.0/source/general/include/GateUIcmdWithAVector.hh(15),
                 from /tmp/gate_v8.0/source/arf/include/GateARFTableMgrMessenger.hh(25),
                 from /tmp/gate_v8.0/source/arf/src/GateARFTableMgr.cc(16):
/tmp/gate_v8.0/source/digits_hits/include/GateTokenizer.hh(42): error: identifier "G4SubString" is undefined
    G4SubString operator()(const char* str=" \t\n",size_t l=0)
    ^

compilation aborted for /tmp/gate_v8.0/source/arf/src/GateARFTableMgr.cc (code 2)
make[2]: *** [CMakeFiles/Gate.dir/source/arf/src/GateARFTableMgr.cc.o] Error 2
```