### PR TITLE
"Rayleigh"->"Rayl" to ensure compatibility with physic lists

### DIFF
--- a/source/digits_hits/src/GateAnalysis.cc
+++ b/source/digits_hits/src/GateAnalysis.cc
@@ -287,7 +287,7 @@ void GateAnalysis::RecordEndOfEvent(const G4Event* event)
                 }
 
               // Counting Rayleigh scatter in phantom
-              if (processName.find("Rayleigh") != G4String::npos)
+              if (processName.find("Rayl") != G4String::npos)
                 {
                   if ((phantomTrackID == photon1ID)||(phantomTrackID == photon2ID))
                     {
@@ -385,7 +385,7 @@ void GateAnalysis::RecordEndOfEvent(const G4Event* event)
                 }
 
               // Counting Rayleigh scatter in crystal
-              if (processName.find("Rayleigh") != G4String::npos)
+              if (processName.find("Rayl") != G4String::npos)
                 {
 
                   if (crystalTrackID == photon1ID) photon1_crystal_Rayleigh++;


### PR DESCRIPTION
Hi,
As recommended for Gate 8.0., I'm using the new physics list mechanism to setting up the physics. However, in the Root output, I found that the leaves nPhantomRayleigh and nCrystalRayleigh are not registering any count. My guess is that while the Geant4 lists uses the alias "Rayl" for Rayleigh processes, Gate looks for "Rayleigh" strings in order to fill these leaves. See, for reference, the emstandard_opt3 constructor:

[http://geant4.web.cern.ch/geant4/UserDocumentation/UsersGuides/PhysicsListGuide/html/electromagnetic/tables_by_constructor/opt3.html](url)

or, specifically:

[http://www-geant4.kek.jp/lxr/source/processes/electromagnetic/lowenergy/include/G4RayleighScattering.hh](url)

This commit solves the problem.
