### PR TITLE
In the Dose By Region output, the number of hits and event_hits were …

### DIFF
--- a/source/digits_hits/src/GateDoseActor.cc
+++ b/source/digits_hits/src/GateDoseActor.cc
@@ -409,8 +409,8 @@ void GateDoseActor::SaveData() {
          << dose << "\t"
          << std_dose << "\t"
          << sq_dose << "\t"
-         << region->nb_hits << "\t"
-         << region->nb_event_hits << std::endl;
+         << region->nb_hits-1 << "\t"
+         << region->nb_event_hits-1 << std::endl;
     }
     os.close();
   }


### PR DESCRIPTION
…+1 wrong because of the last update method invoked to finish the squared dose calculation. I have corrected the output with nb_hits-1 and nb_event_hits-1.