### PR TITLE
Export the voxelized activity image

### DIFF
--- a/source/physics/include/GateVSourceVoxelReader.hh
+++ b/source/physics/include/GateVSourceVoxelReader.hh
@@ -76,6 +76,7 @@ public:
   void RemoveTranslator();
 
   virtual void Dump(G4int level);
+  void ExportSourceActivityImage(G4String activityImageFileName);
 
   typedef std::vector<G4double> GateSourceActivityMap;
 

--- a/source/physics/include/GateVSourceVoxelReaderMessenger.hh
+++ b/source/physics/include/GateVSourceVoxelReaderMessenger.hh
@@ -40,6 +40,7 @@ protected:
   G4UIcmdWithoutParameter*            RemoveTranslatorCmd;
   G4UIcmdWithAnInteger*               VerboseCmd;
   G4UIcmdWithAString*                 TimeActivTablesCmd;
+  G4UIcmdWithAString*                 ActivityImageCmd;
   G4UIcmdWithADoubleAndUnit*          SetTimeSamplingCmd;
 };
 //-----------------------------------------------------------------------------

--- a/source/physics/src/GateVSourceVoxelReader.cc
+++ b/source/physics/src/GateVSourceVoxelReader.cc
@@ -11,6 +11,7 @@
 #include "GateSourceVoxelLinearTranslator.hh"
 #include "GateSourceVoxelRangeTranslator.hh"
 #include "GateSourceMgr.hh"
+#include "GateImage.hh"
 
 //-------------------------------------------------------------------------------------------------
 GateVSourceVoxelReader::GateVSourceVoxelReader(GateVSource* source)
@@ -72,6 +73,31 @@ void GateVSourceVoxelReader::Dump(G4int level)
 //-------------------------------------------------------------------------------------------------
 
 
+//-------------------------------------------------------------------------------------------------
+void GateVSourceVoxelReader::ExportSourceActivityImage(G4String activityImageFileName)
+{
+    if(!activityImageFileName.empty() && m_sourceVoxelActivities.size()!=0)
+    {
+        GateImage output;
+        output.SetResolutionAndVoxelSize(G4ThreeVector(m_voxelNx,m_voxelNy,m_voxelNz),m_voxelSize);
+        output.SetOrigin(m_image_origin);
+        output.Allocate();
+
+        GateImage::iterator po;
+        po = output.begin();
+        for(size_t i =0;i<m_sourceVoxelActivities.size();i++)
+        {
+            if(po != output.end()) {
+                    *po = m_sourceVoxelActivities[i] / becquerel;
+                    ++po;
+            }
+        }
+        // Write image
+        output.Write(activityImageFileName);
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 G4int GateVSourceVoxelReader::GetNextSource()
 {

--- a/source/physics/src/GateVSourceVoxelReaderMessenger.cc
+++ b/source/physics/src/GateVSourceVoxelReaderMessenger.cc
@@ -62,6 +62,10 @@ GateVSourceVoxelReaderMessenger::GateVSourceVoxelReaderMessenger(GateVSourceVoxe
   cmdName = GetDirectoryName()+"SetTimeActivityTablesFrom";
   TimeActivTablesCmd = new G4UIcmdWithAString(cmdName,this);
 
+  cmdName = GetDirectoryName()+"exportActivityImage";
+  ActivityImageCmd = new G4UIcmdWithAString(cmdName,this);
+  ActivityImageCmd->SetGuidance("Export the activity Image");
+
   cmdName = GetDirectoryName()+"SetTimeSampling";
   SetTimeSamplingCmd = new G4UIcmdWithADoubleAndUnit(cmdName,this);
 }
@@ -76,6 +80,7 @@ GateVSourceVoxelReaderMessenger::~GateVSourceVoxelReaderMessenger()
   delete VoxelSizeCmd;
   delete PositionCmd;
   delete VerboseCmd;
+  delete ActivityImageCmd;
   delete TimeActivTablesCmd;
   delete SetTimeSamplingCmd;
 }
@@ -92,6 +97,7 @@ void GateVSourceVoxelReaderMessenger::SetNewValue(G4UIcommand* command,G4String 
   if (command == InsertTranslatorCmd) m_voxelReader->InsertTranslator(InsertTranslatorCmd->GetNewVectorValue(newValue)[0]);
   if (command == RemoveTranslatorCmd) m_voxelReader->RemoveTranslator();
   if (command == VerboseCmd) m_voxelReader->SetVerboseLevel(VerboseCmd->GetNewIntValue(newValue));
+  if (command == ActivityImageCmd) m_voxelReader->ExportSourceActivityImage(newValue);
   GateMessenger::SetNewValue(command, newValue);
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
After import the voxelized source,  can export an image to see the distribution of activity by imageJ:
 commands : 
`/gate/source/<source_name>/imageReader/readFile  <your_voxelized_source.mhd>`
`/gate/source/<source_name>/imageReader/exportActivityImage <export_image.mhd>`