### PR TITLE
add MuMapActor for exporting MuMap and SourceMap

### DIFF
--- a/source/digits_hits/include/GateMuMapActor.hh
+++ b/source/digits_hits/include/GateMuMapActor.hh
@@ -45,6 +45,7 @@ public:
   virtual void ResetData();
 
   void SetEnergy(G4double energy);
+  void SetMuUnit(G4double unit);
 
 protected:
 
@@ -55,6 +56,7 @@ protected:
   GateImageInt mSourceMapImage;
 
   G4double  mEnergy;
+  G4double  mMuUnit;
   G4String mMuMapFilename;
   G4String mSourceMapFilename;
 };

--- a/source/digits_hits/include/GateMuMapActor.hh
+++ b/source/digits_hits/include/GateMuMapActor.hh
@@ -1,0 +1,64 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms
+  of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+
+/*
+  \class GateMuMapActor
+  \author gsizeg@gmail.com
+  \brief Class GateMuMapActor : This actor produces voxelised images of the Mu Map.
+
+*/
+
+#ifndef GATEMUMAPACTOR_HH
+#define GATEMUMAPACTOR_HH
+
+#include "GateVImageActor.hh"
+
+class GateMuMapActorMessenger;
+class GateMuMapActor : public GateVImageActor
+{
+public:
+
+  //-----------------------------------------------------------------------------
+  // Actor name
+  virtual ~GateMuMapActor();
+
+  FCT_FOR_AUTO_CREATOR_ACTOR(GateMuMapActor)
+
+  //-----------------------------------------------------------------------------
+  // Constructs the sensor
+  virtual void Construct();
+
+  virtual void BeginOfRunAction(const G4Run*r);
+  virtual void EndOfRunAction(const G4Run*); // default action (save)
+  virtual void BeginOfEventAction(const G4Event * event);
+  virtual void UserSteppingActionInVoxel(const int /*index*/, const G4Step* /*step*/);
+  virtual void UserPreTrackActionInVoxel(const int /*index*/, const G4Track* /*track*/);
+  virtual void UserPostTrackActionInVoxel(const int /*index*/, const G4Track* /*t*/) {}
+
+  //  Saves the data collected to the file
+  virtual void SaveData();
+  virtual void ResetData();
+
+  void SetEnergy(G4double energy);
+
+protected:
+
+  GateMuMapActor(G4String name, G4int depth=0);
+  GateMuMapActorMessenger * pMessenger;
+
+  GateImage mMuMapImage;
+  GateImageInt mSourceMapImage;
+
+  G4double  mEnergy;
+  G4String mMuMapFilename;
+  G4String mSourceMapFilename;
+};
+
+MAKE_AUTO_CREATOR_ACTOR(MuMapActor,GateMuMapActor)
+
+#endif /* end #define GATEMUMAPACTOR_HH*/

--- a/source/digits_hits/include/GateMuMapActorMessenger.hh
+++ b/source/digits_hits/include/GateMuMapActorMessenger.hh
@@ -32,6 +32,7 @@ protected:
   GateMuMapActor * pMuMapActor;
 
   G4UIcmdWithADoubleAndUnit* pSetEnergyCmd;
+  G4UIcmdWithADoubleAndUnit* pSetMuUnitCmd;
 };
 
 #endif /* end #define GATEMUMAPACTORMESSENGER_HH*/

--- a/source/digits_hits/include/GateMuMapActorMessenger.hh
+++ b/source/digits_hits/include/GateMuMapActorMessenger.hh
@@ -1,0 +1,37 @@
+/*----------------------
+   Copyright (C): OpenGATE Collaboration
+
+This software is distributed under the terms
+of the GNU Lesser General  Public Licence (LGPL)
+See LICENSE.md for further details
+----------------------*/
+
+/*
+  \class  GateMuMapActorMessenger
+  \author gsizeg@gmail.com
+*/
+
+#ifndef GATEMUMAPACTORMESSENGER_HH
+#define GATEMUMAPACTORMESSENGER_HH
+
+#include "GateImageActorMessenger.hh"
+
+class G4UIcmdWithADoubleAndUnit;
+class GateMuMapActor;
+
+class GateMuMapActorMessenger : public GateImageActorMessenger
+{
+public:
+  GateMuMapActorMessenger(GateMuMapActor* sensor);
+  virtual ~GateMuMapActorMessenger();
+
+  void BuildCommands(G4String base);
+  void SetNewValue(G4UIcommand*, G4String);
+
+protected:
+  GateMuMapActor * pMuMapActor;
+
+  G4UIcmdWithADoubleAndUnit* pSetEnergyCmd;
+};
+
+#endif /* end #define GATEMUMAPACTORMESSENGER_HH*/

--- a/source/digits_hits/src/GateMuMapActor.cc
+++ b/source/digits_hits/src/GateMuMapActor.cc
@@ -22,7 +22,7 @@
 
 #include "G4TransportationManager.hh"
 #include "G4Navigator.hh"
-
+#include "G4UnitsTable.hh"
 //-----------------------------------------------------------------------------
 
 GateMuMapActor::GateMuMapActor(G4String name, G4int depth):
@@ -30,6 +30,7 @@ GateMuMapActor::GateMuMapActor(G4String name, G4int depth):
         GateDebugMessageInc("Actor",4,"GateMuMapActor() -- begin"<<G4endl);
 
         mEnergy = 0.511*MeV;
+        mMuUnit= 1.0*(1.0/cm);
         pMessenger = new GateMuMapActorMessenger(this);
         GateDebugMessageDec("Actor",4,"GateMuMapActor() -- end"<<G4endl);
     }
@@ -46,6 +47,12 @@ GateMuMapActor::~GateMuMapActor()  {
 void GateMuMapActor::SetEnergy(G4double energy)
 {
     mEnergy=energy;
+}
+//-----------------------------------------------------------------------------
+
+void GateMuMapActor::SetMuUnit(G4double unit)
+{
+    mMuUnit=unit;
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -124,8 +131,8 @@ void GateMuMapActor::BeginOfRunAction(const G4Run * r) {
         {
         G4LogicalVolume* lVolume= pVolume->GetLogicalVolume();
 
-        // Get the Mu value ,unit(cm-1)
-        double mu= GateMaterialMuHandler::GetInstance()->GetMu(lVolume->GetMaterialCutsCouple(),mEnergy);
+        // Get the Mu value ,default unit(cm-1)
+        double mu= GateMaterialMuHandler::GetInstance()->GetMu(lVolume->GetMaterialCutsCouple(),mEnergy)*(1/cm)/mMuUnit;
 
         mMuMapImage.SetValue(index,(float)mu);
         }

--- a/source/digits_hits/src/GateMuMapActor.cc
+++ b/source/digits_hits/src/GateMuMapActor.cc
@@ -1,0 +1,174 @@
+/*----------------------
+  Copyright (C): OpenGATE Collaboration
+
+  This software is distributed under the terms of the GNU Lesser General  Public Licence (LGPL)
+  See LICENSE.md for further details
+  ----------------------*/
+
+//#include "GateConfiguration.h"
+
+/*
+   \class GateMuMapActor
+   \author gsizeg@gmail.com
+   \brief Class GateMuMapActor : This actor produces voxelised images of the heat diffusion in tissue.
+
+   Parameters of the simulation given by the User in the macro:
+   - setEnergy: Set energy
+   */
+
+#include "GateMuMapActor.hh"
+#include "GateMuMapActorMessenger.hh"
+#include "GateMaterialMuHandler.hh"
+
+#include "G4TransportationManager.hh"
+#include "G4Navigator.hh"
+
+//-----------------------------------------------------------------------------
+
+GateMuMapActor::GateMuMapActor(G4String name, G4int depth):
+    GateVImageActor(name,depth) {
+        GateDebugMessageInc("Actor",4,"GateMuMapActor() -- begin"<<G4endl);
+
+        mEnergy = 0.511*MeV;
+        pMessenger = new GateMuMapActorMessenger(this);
+        GateDebugMessageDec("Actor",4,"GateMuMapActor() -- end"<<G4endl);
+    }
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+/// Destructor
+GateMuMapActor::~GateMuMapActor()  {
+    delete pMessenger;
+}
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+void GateMuMapActor::SetEnergy(G4double energy)
+{
+    mEnergy=energy;
+}
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+/// Constructor
+void GateMuMapActor::Construct() {
+
+    GateDebugMessageInc("Actor", 4, "GateMuMapActor -- Construct - begin" << G4endl);
+
+    GateVImageActor::Construct();
+
+    // Enable callbacks
+    EnableBeginOfRunAction(true);
+    EnableEndOfRunAction(true); // for save
+    EnableBeginOfEventAction(true);
+    EnableEndOfEventAction(false);
+    EnablePreUserTrackingAction(false);
+    EnableUserSteppingAction(false);
+
+    // Output Filenames
+    mMuMapFilename = G4String(removeExtension(mSaveFilename))+"-MuMap."+G4String(getExtension(mSaveFilename));
+    mSourceMapFilename = G4String(removeExtension(mSaveFilename))+"-SourceMap."+G4String(getExtension(mSaveFilename));
+
+    // Set origin, transform, flag
+    SetOriginTransformAndFlagToImage(mMuMapImage);
+    SetOriginTransformAndFlagToImage(mSourceMapImage);
+
+    // Resize and allocate images
+    mMuMapImage.SetResolutionAndHalfSize(mResolution, mHalfSize, mPosition);
+    mMuMapImage.Allocate();
+
+    mSourceMapImage.SetResolutionAndHalfSize(mResolution, mHalfSize, mPosition);
+    mSourceMapImage.Allocate();
+
+    // Print information
+    GateMessage("Actor", 1,
+            "\tMuMapActor    = '" << GetObjectName() << "'" << G4endl <<
+            "\tMuMapFilename      = " << mMuMapFilename<< G4endl);
+
+    ResetData();
+    GateMessageDec("Actor", 4, "GateMuMapActor -- Construct - end" << G4endl);
+
+}
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+/// Save data
+void GateMuMapActor::SaveData() {
+
+    mMuMapImage.Write(mMuMapFilename);
+    mSourceMapImage.Write(mSourceMapFilename);
+}
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+void GateMuMapActor::ResetData() {
+
+    mMuMapImage.Fill(0.0f);
+    mSourceMapImage.Fill(0);
+
+}
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+void GateMuMapActor::BeginOfRunAction(const G4Run * r) {
+    GateVActor::BeginOfRunAction(r);
+
+    GateDebugMessage("Actor", 3, "GateMuMapActor -- Begin of Run" << G4endl);
+
+    G4Navigator* theNavigator =G4TransportationManager::GetTransportationManager()
+        ->GetNavigatorForTracking();
+    for(int index=0; index<mMuMapImage.GetNumberOfValues(); index++)
+    {
+        G4ThreeVector myPosition=mMuMapImage.GetVoxelCenterFromIndex(index);
+        G4VPhysicalVolume* pVolume = theNavigator->LocateGlobalPointAndSetup(myPosition);
+        if(pVolume)
+        {
+        G4LogicalVolume* lVolume= pVolume->GetLogicalVolume();
+
+        // Get the Mu value ,unit(cm-1)
+        double mu= GateMaterialMuHandler::GetInstance()->GetMu(lVolume->GetMaterialCutsCouple(),mEnergy);
+
+        mMuMapImage.SetValue(index,(float)mu);
+        }
+    }
+    // Save MuMap voxel 
+    SaveData();
+}
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+void GateMuMapActor::EndOfRunAction(const G4Run* r)
+{
+    GateVActor::EndOfRunAction(r);
+    SaveData();
+}
+
+//-----------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------
+void GateMuMapActor::BeginOfEventAction(const G4Event * e) {
+    GateVActor::BeginOfEventAction(e);
+
+    GateDebugMessage("Actor", 3, "GateMuMapActor -- Begin of Event: "<<mCurrentEvent << G4endl);
+   G4ThreeVector primaryPosition = e->GetPrimaryVertex()->GetPosition();
+   int index = mSourceMapImage.GetIndexFromPosition(primaryPosition);
+   if(index>=0)
+   {
+       int count = mSourceMapImage.GetValue(index);
+        mSourceMapImage.SetValue(index,count+1);
+   }
+}
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+void GateMuMapActor::UserPreTrackActionInVoxel(const int /*index*/, const G4Track* /*track*/) {
+}
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+void GateMuMapActor::UserSteppingActionInVoxel(const int /*index*/, const G4Step* /*step*/) {
+
+}
+//-----------------------------------------------------------------------------
+
+

--- a/source/digits_hits/src/GateMuMapActorMessenger.cc
+++ b/source/digits_hits/src/GateMuMapActorMessenger.cc
@@ -17,7 +17,13 @@ GateMuMapActorMessenger::GateMuMapActorMessenger(GateMuMapActor* sensor)
   :GateImageActorMessenger(sensor),
   pMuMapActor(sensor)
 {
+  //add Mu Unit
+  new G4UnitDefinition("1/cm","1/cm","Mu",1.0/centimeter);
+  new G4UnitDefinition("1/m","1/m","Mu",1.0/meter);
+  new G4UnitDefinition("1/mm","1/mm","Mu",1.0/mm);
+
   pSetEnergyCmd= 0;
+  pSetMuUnitCmd= 0;
 
   BuildCommands(baseName+sensor->GetObjectName());
 }
@@ -28,6 +34,7 @@ GateMuMapActorMessenger::GateMuMapActorMessenger(GateMuMapActor* sensor)
 GateMuMapActorMessenger::~GateMuMapActorMessenger()
 {
   if(pSetEnergyCmd) delete pSetEnergyCmd;
+  if(pSetMuUnitCmd) delete pSetMuUnitCmd;
 }
 //-----------------------------------------------------------------------------
 
@@ -41,6 +48,11 @@ void GateMuMapActorMessenger::BuildCommands(G4String base)
   pSetEnergyCmd->SetParameterName("energy",false);
   pSetEnergyCmd->SetDefaultUnit("MeV");
 
+  n = base+"/setMuUnit";
+  pSetMuUnitCmd= new G4UIcmdWithADoubleAndUnit(n, this);
+  pSetMuUnitCmd->SetGuidance("Set Mu Unit");
+  pSetMuUnitCmd->SetParameterName("MuUnit",false);
+  pSetMuUnitCmd->SetDefaultUnit("1/cm");
 }
 //-----------------------------------------------------------------------------
 
@@ -49,6 +61,7 @@ void GateMuMapActorMessenger::BuildCommands(G4String base)
 void GateMuMapActorMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue)
 {
   if (cmd == pSetEnergyCmd)  pMuMapActor->SetEnergy(G4UIcmdWithADoubleAndUnit::GetNewDoubleValue(newValue));
+  if (cmd == pSetMuUnitCmd)  pMuMapActor->SetMuUnit(G4UIcmdWithADoubleAndUnit::GetNewDoubleValue(newValue));
 
   GateImageActorMessenger::SetNewValue( cmd, newValue);
 }

--- a/source/digits_hits/src/GateMuMapActorMessenger.cc
+++ b/source/digits_hits/src/GateMuMapActorMessenger.cc
@@ -1,0 +1,56 @@
+/*----------------------
+   Copyright (C): OpenGATE Collaboration
+
+This software is distributed under the terms
+of the GNU Lesser General  Public Licence (LGPL)
+See LICENSE.md for further details
+----------------------*/
+
+
+#include "GateMuMapActorMessenger.hh"
+#include "GateMuMapActor.hh"
+#include "GateImageActorMessenger.hh"
+#include "G4UIcmdWithADoubleAndUnit.hh"
+
+//-----------------------------------------------------------------------------
+GateMuMapActorMessenger::GateMuMapActorMessenger(GateMuMapActor* sensor)
+  :GateImageActorMessenger(sensor),
+  pMuMapActor(sensor)
+{
+  pSetEnergyCmd= 0;
+
+  BuildCommands(baseName+sensor->GetObjectName());
+}
+//-----------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------
+GateMuMapActorMessenger::~GateMuMapActorMessenger()
+{
+  if(pSetEnergyCmd) delete pSetEnergyCmd;
+}
+//-----------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------
+void GateMuMapActorMessenger::BuildCommands(G4String base)
+{
+  G4String  n = base+"/setEnergy";
+  pSetEnergyCmd= new G4UIcmdWithADoubleAndUnit(n, this);
+  pSetEnergyCmd->SetGuidance("Set energy value");
+  pSetEnergyCmd->SetParameterName("energy",false);
+  pSetEnergyCmd->SetDefaultUnit("MeV");
+
+}
+//-----------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------
+void GateMuMapActorMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue)
+{
+  if (cmd == pSetEnergyCmd)  pMuMapActor->SetEnergy(G4UIcmdWithADoubleAndUnit::GetNewDoubleValue(newValue));
+
+  GateImageActorMessenger::SetNewValue( cmd, newValue);
+}
+//-----------------------------------------------------------------------------
+


### PR DESCRIPTION
In PET recon, it need MuMap to attenuation correction,people  can use the MuMapActor to get MuMap and sourceMap.
Note: voxel Mu  Uint is cm-1.

`
/gate/actor/addActor  MuMapActor getMuMap
/gatt/actor/getMuMap/attachTo world
/gate/actor/getMuMap/save yourMapFileName.mhd
/gate/actor/getMuMap/setVoxelSize 2  2 2 mm
/gate/actor/getMuMap/setResolution 128 128  100 
/gate/actor/getMuMap/setEnergy 511 keV 

`
