### PR TITLE
added fluence calculation EnergySpectrum

### DIFF
--- a/source/digits_hits/include/GateEnergySpectrumActor.hh
+++ b/source/digits_hits/include/GateEnergySpectrumActor.hh
@@ -3,7 +3,7 @@
 
   This software is distributed under the terms
   of the GNU Lesser General  Public Licence (LGPL)
-  See LICENSE.md for further details
+  See GATE/LICENSE.txt for further details
   ----------------------*/
 
 #include "GateConfiguration.h"
@@ -15,6 +15,7 @@
   laurent.guigues@creatis.insa-lyon.fr
   david.sarrut@creatis.insa-lyon.fr
   pierre.gueth@creatis.insa-lyon.fr
+  andreas.resch@meduniwien.ac.at
 */
 
 #ifndef GATEENERGYSPECTRUMACTOR_HH
@@ -28,6 +29,7 @@
 #include <TFile.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TMath.h>
 
 class G4EmCalculator;
 //-----------------------------------------------------------------------------
@@ -75,6 +77,13 @@ public:
   void SetLETmin(double v) {mLETmin = v;}
   void SetLETmax(double v) {mLETmax = v;}
   void SetNLETBins(double v) {mLETBins = v;}
+  
+  G4double GetQmin() {return mQmin; }
+  G4double GetQmax() {return mQmax; }
+  int GetNQBins() {return mQBins; }
+  void SetQmin(double v) {mQmin = v;}
+  void SetQmax(double v) {mQmax = v;}
+  void SetNQBins(double v) {mQBins = v;}
 
   void SetEmin(double v) {mEmin = v;}
   void SetEmax(double v) {mEmax = v;}
@@ -88,9 +97,22 @@ public:
   void SetEdepmax(double v) {mEdepmax = v;}
   void SetEdepNBins(int v) {mEdepNBins = v;}
   void SetLETSpectrumCalc(bool b) {mEnableLETSpectrumFlag = b; }
+  void SetQSpectrumCalc(bool b) {mEnableQSpectrumFlag = b; }
   void SetSaveAsTextFlag(bool b) { mSaveAsTextFlag = b; }
   void SetSaveAsTextDiscreteEnergySpectrumFlag(bool b) { mSaveAsDiscreteSpectrumTextFlag = b; if (b) SetSaveAsTextFlag(b); }
 
+  void SetESpectrumNbPartCalc(bool b) {mEnableEnergySpectrumNbPartFlag = b; }
+  void SetESpectrumFluenceCosCalc(bool b) {mEnableEnergySpectrumFluenceCosFlag = b; }
+  void SetESpectrumFluenceTrackCalc(bool b) {mEnableEnergySpectrumFluenceTrackFlag = b; }
+  void SetESpectrumEdepCalc(bool b) {mEnableEnergySpectrumEdepFlag = b; }
+
+  void SetEdepHistoCalc(bool b) {mEnableEdepHistoFlag = b; }
+  void SetEdepTimeHistoCalc(bool b) {mEnableEdepTimeHistoFlag= b; }
+  void SetEdepTrackHistoCalc(bool b) {mEnableEdepTrackHistoFlag = b; }
+  void SetElossHistoCalc(bool b) {mEnableElossHistoFlag = b; }
+  
+  
+  void SetLogBinning(bool b) {mEnableLogBinning = b; }
 protected:
   GateEnergySpectrumActor(G4String name, G4int depth=0);
 
@@ -98,6 +120,18 @@ protected:
   G4String mHistName;
 
   TH1D * pEnergySpectrum;
+  TH1D * pEnergySpectrumFluence;
+  TH1D * pEnergySpectrumTrack;
+  //TH1D * ;
+  //TH1D * ;
+  //TH1D * ;
+  TH1D * pEnergySpectrumNbPart;
+  TH1D * pEnergySpectrumFluenceCos;
+  TH1D * pEnergySpectrumFluenceTrack;
+  TH1D * pEnergySpectrumLET;
+  TH1D * pEnergySpectrumLETdoseWeighted;
+  
+  TH1D * pEnergyEdepSpectrum;
   TH1D * pDeltaEc;
   TH1D * pEdep;
   TH2D * pEdepTime;
@@ -107,6 +141,15 @@ protected:
   G4double mLETmin;
   G4double mLETmax;
   int mLETBins;
+  G4double pEnergySpectrumTrackNorm;
+
+  TH1D * pQSpectrum;
+  G4double mQmin;
+  G4double mQmax;
+  int mQBins;
+  
+  double * eBinV;
+  double dEn;
   
   double mEmin;
   double mEmax;
@@ -138,6 +181,17 @@ protected:
   bool mSaveAsTextFlag;
   bool mSaveAsDiscreteSpectrumTextFlag;
   bool mEnableLETSpectrumFlag;
+  bool mEnableQSpectrumFlag;
+  bool mEnableEnergySpectrumNbPartFlag;
+  bool mEnableEnergySpectrumFluenceCosFlag;
+  bool mEnableEnergySpectrumFluenceTrackFlag;
+  bool mEnableEnergySpectrumEdepFlag;
+  bool mEnableEdepHistoFlag;
+  bool mEnableEdepTimeHistoFlag;
+  bool mEnableEdepTrackHistoFlag;
+  bool mEnableElossHistoFlag;
+  bool mEnableLogBinning;
+  
   
   G4EmCalculator * emcalc;
 };

--- a/source/digits_hits/include/GateEnergySpectrumActorMessenger.hh
+++ b/source/digits_hits/include/GateEnergySpectrumActorMessenger.hh
@@ -3,7 +3,7 @@
 
   This software is distributed under the terms
   of the GNU Lesser General  Public Licence (LGPL)
-  See LICENSE.md for further details
+  See GATE/LICENSE.txt for further details
   ----------------------*/
 
 #include "GateConfiguration.h"
@@ -14,6 +14,7 @@
   \author thibault.frisson@creatis.insa-lyon.fr
   laurent.guigues@creatis.insa-lyon.fr
   david.sarrut@creatis.insa-lyon.fr
+  andreas.resch@meduniwien.ac.at
 */
 
 #ifndef GATEENERGYSPECTRUMACTORMESSENGER_HH
@@ -54,13 +55,28 @@ protected:
   G4UIcmdWithADoubleAndUnit * pLETminCmd;
   G4UIcmdWithADoubleAndUnit * pLETmaxCmd;
   G4UIcmdWithAnInteger      * pNLETBinsCmd;
+  G4UIcmdWithADoubleAndUnit * pQminCmd;
+  G4UIcmdWithADoubleAndUnit * pQmaxCmd;
+  G4UIcmdWithAnInteger      * pNQBinsCmd;
   G4UIcmdWithAnInteger      * pNBinsCmd;
   G4UIcmdWithADoubleAndUnit * pEdepmaxCmd;
-  G4UIcmdWithADoubleAndUnit * pEdepminCmd;
+  G4UIcmdWithADoubleAndUnit * pEdepminCmd; 
   G4UIcmdWithAnInteger      * pEdepNBinsCmd;
   G4UIcmdWithABool          * pSaveAsText;
   G4UIcmdWithABool          * pSaveAsTextDiscreteEnergySpectrum;
   G4UIcmdWithABool          * pEnableLETSpectrumCmd;
+  G4UIcmdWithABool          * pEnableQSpectrumCmd;
+  G4UIcmdWithABool          * pEnableEnergySpectrumNbPartCmd;
+  G4UIcmdWithABool          * pEnableEnergySpectrumFluenceCosCmd;
+  G4UIcmdWithABool          * pEnableEnergySpectrumFluenceTrackCmd;
+  G4UIcmdWithABool          * pEnableeEnergySpectrumEdepCmd;
+  G4UIcmdWithABool          * pEnableEdepHistoCmd;
+  G4UIcmdWithABool          * pEnableEdepTimeHistoCmd;
+  G4UIcmdWithABool          * pEnableEdepTrackHistoCmd;
+  G4UIcmdWithABool          * pEnableElossHistoCmd;
+  
+  G4UIcmdWithABool          * pEnableLogBinningCMD;
+  
 
 }; // end class GateEnergySpectrumActorMessenger
 //-----------------------------------------------------------------------------

--- a/source/digits_hits/src/GateEnergySpectrumActor.cc
+++ b/source/digits_hits/src/GateEnergySpectrumActor.cc
@@ -3,7 +3,7 @@
 
   This software is distributed under the terms
   of the GNU Lesser General  Public Licence (LGPL)
-  See LICENSE.md for further details
+  See GATE/LICENSE.txt for further details
   ----------------------*/
 
 #include "GateEnergySpectrumActor.hh"
@@ -33,7 +33,11 @@ GateEnergySpectrumActor::GateEnergySpectrumActor(G4String name, G4int depth):
   
   mLETmin = 0.;
   mLETmax = 100.;
-  mLETBins = 200;
+  mLETBins = 1000;
+
+  mQmin = 0.;
+  mQmax = 10.;
+  mQBins = 2000;
 
   mEdepmin = 0.;
   mEdepmax = 50.;
@@ -49,10 +53,25 @@ GateEnergySpectrumActor::GateEnergySpectrumActor(G4String name, G4int depth):
   sumM2=0.;
   sumM3=0.;
   edep = 0.;
-
-  mSaveAsTextFlag = true;
+  
+  mSaveAsTextFlag = false;
   mSaveAsDiscreteSpectrumTextFlag = false;
-  mEnableLETSpectrumFlag = true;
+  
+  mEnableLETSpectrumFlag = false;
+  mEnableQSpectrumFlag = false;
+  mEnableEnergySpectrumNbPartFlag = false;
+  mEnableEnergySpectrumFluenceCosFlag = false;
+  mEnableEnergySpectrumFluenceTrackFlag = true;
+  
+  mEnableEnergySpectrumEdepFlag = true;
+  
+  mEnableEdepHistoFlag = false;
+  mEnableEdepTimeHistoFlag = false;
+  mEnableEdepTrackHistoFlag = false;
+  mEnableElossHistoFlag = false;
+  
+  mEnableLogBinning = false;  
+  
   emcalc = new G4EmCalculator;
 
   pMessenger = new GateEnergySpectrumActorMessenger(this);
@@ -84,29 +103,90 @@ void GateEnergySpectrumActor::Construct()
   EnablePostUserTrackingAction(true);
   EnableUserSteppingAction(true);
   EnableEndOfEventAction(true); // for save every n
-
-  pTfile = new TFile(mSaveFilename,"RECREATE");
-
-  pEnergySpectrum = new TH1D("energySpectrum","Energy Spectrum",GetENBins(),GetEmin() ,GetEmax() );
-  pEnergySpectrum->SetXTitle("Energy (MeV)");
   
-  pLETSpectrum = new TH1D("LETSpectrum","LET Spectrum",GetNLETBins(),GetLETmin() ,GetLETmax() );
-  pLETSpectrum->SetXTitle("LET (keV/um)");
 
-  pEdep  = new TH1D("edepHisto","Energy deposited per event",GetEdepNBins(),GetEdepmin() ,GetEdepmax() );
-  pEdep->SetXTitle("E_{dep} (MeV)");
+  
+  if (mEnableLogBinning){
+      double mEminLog = mEmin;
+      if (mEminLog < 0.000001) mEminLog = 0.000001;
+      double energyLogBinV_LB = TMath::Log10(mEminLog);
+      double energyLogBinV_UB = TMath::Log10(mEmax); 
+      dEn = (energyLogBinV_UB - energyLogBinV_LB)/((double)mENBins );
+      eBinV = new double[mENBins+1];
+      for (int j = 0; j < (mENBins+1); j++) {
+          
+          double linSpacedV = energyLogBinV_LB + (double)j   * dEn;
+          eBinV[j] = TMath::Power(10,  linSpacedV);
+      }
+  }
+  
+  pTfile = new TFile(mSaveFilename,"RECREATE");
+  if (!mEnableLogBinning){
+      if (mEnableEnergySpectrumNbPartFlag){
+          pEnergySpectrumNbPart = new TH1D("energySpectrumNbPart","Energy Spectrum Number of particles",GetENBins(),GetEmin() ,GetEmax() );
+          pEnergySpectrumNbPart->SetXTitle("Energy (MeV)");  
+      }
+      if (mEnableEnergySpectrumFluenceCosFlag){
+          pEnergySpectrumFluenceCos = new TH1D("energySpectrumFluenceCos","Energy Spectrum fluence 1/cos",GetENBins(),GetEmin() ,GetEmax() );
+          pEnergySpectrumFluenceCos->SetXTitle("Energy (MeV)");  
+      }
 
-  pEdepTime  = new TH2D("edepHistoTime","Energy deposited with time per event",
-                        GetEdepNBins(),0,20,GetEdepNBins(),GetEdepmin(),GetEdepmax());
-  pEdepTime->SetXTitle("t (ns)");
-  pEdepTime->SetYTitle("E_{dep} (MeV)");
+      if (mEnableEnergySpectrumFluenceTrackFlag){
+          pEnergySpectrumFluenceTrack = new TH1D("energySpectrumFluenceTrack","Energy Spectrum fluence Track",GetENBins(),GetEmin() ,GetEmax() );
+          pEnergySpectrumFluenceTrack->SetXTitle("Energy (MeV)");
+      } 
+  }
+  else
+  {
+      if (mEnableEnergySpectrumNbPartFlag){
+          pEnergySpectrumNbPart = new TH1D("energySpectrumNbPart","Energy Spectrum Number of particles",mENBins,eBinV);
+          pEnergySpectrumNbPart->SetXTitle("Energy (MeV)");  
+          }
+      if (mEnableEnergySpectrumFluenceCosFlag){
+          pEnergySpectrumFluenceCos = new TH1D("energySpectrumFluenceCos","Energy Spectrum fluence 1/cos", mENBins,eBinV );
+          pEnergySpectrumFluenceCos->SetXTitle("Energy (MeV)");        
+          }
+      if (mEnableEnergySpectrumFluenceTrackFlag){
+          pEnergySpectrumFluenceTrack = new TH1D("energySpectrumFluenceTrack","Energy Spectrum fluence Track", mENBins,eBinV );
+          pEnergySpectrumFluenceTrack->SetXTitle("Energy (MeV)");
+          } 
+  }
 
-  pEdepTrack  = new TH1D("edepTrackHisto","Energy deposited per track",GetEdepNBins(),GetEdepmin() ,GetEdepmax() );
-  pEdepTrack->SetXTitle("E_{dep} (MeV)");
+  
+  if (mEnableEnergySpectrumEdepFlag){
+      pEnergyEdepSpectrum = new TH1D("energyEdepSpectrum","Energy Edep Spectrum",GetENBins(),GetEmin() ,GetEmax() );
+      pEnergyEdepSpectrum->SetXTitle("Energy (MeV)");
+  } 
+  if (mEnableLETSpectrumFlag) {
+      pLETSpectrum = new TH1D("LETSpectrum","LET Spectrum",GetNLETBins(),GetLETmin() ,GetLETmax() );
+      pLETSpectrum->SetXTitle("LET (keV/um)");
+  }
+  if (mEnableQSpectrumFlag) {
+      pQSpectrum = new TH1D("QSpectrum","Q Spectrum",GetNQBins(),GetQmin() ,GetQmax() );
+      pQSpectrum->SetXTitle("Q (qq/MeV)");
+  }
+  
+  if (mEnableEdepHistoFlag){
+      pEdep  = new TH1D("edepHisto","Energy deposited per event",GetEdepNBins(),GetEdepmin() ,GetEdepmax() );
+      pEdep->SetXTitle("E_{dep} (MeV)");
+  } 
 
-  pDeltaEc = new TH1D("eLossHisto","Energy loss",GetEdepNBins(),GetEdepmin() ,GetEdepmax() );
-  pDeltaEc ->SetXTitle("E_{loss} (MeV)");
+  if (mEnableEdepTimeHistoFlag){
+      pEdepTime  = new TH2D("edepHistoTime","Energy deposited with time per event",
+                            GetEdepNBins(),0,20,GetEdepNBins(),GetEdepmin(),GetEdepmax());
+      pEdepTime->SetXTitle("t (ns)");
+      pEdepTime->SetYTitle("E_{dep} (MeV)");
+  } 
 
+  if (mEnableEdepTrackHistoFlag){
+      pEdepTrack  = new TH1D("edepTrackHisto","Energy deposited per track",GetEdepNBins(),GetEdepmin() ,GetEdepmax() );
+      pEdepTrack->SetXTitle("E_{dep} (MeV)");
+  } 
+
+  if (mEnableElossHistoFlag){
+      pDeltaEc = new TH1D("eLossHisto","Energy loss",GetEdepNBins(),GetEdepmin() ,GetEdepmax() );
+      pDeltaEc ->SetXTitle("E_{loss} (MeV)");
+  } 
   ResetData();
 }
 //-----------------------------------------------------------------------------
@@ -116,13 +196,17 @@ void GateEnergySpectrumActor::Construct()
 /// Save data
 void GateEnergySpectrumActor::SaveData()
 {
+    
   GateVActor::SaveData();
   pTfile->Write();
-  //pTfile->Close();
-
-  // Also output data as txt if enabled
+  pTfile->Close();
+  
+   //Also output data as txt if enabled
   if (mSaveAsTextFlag) {
-    SaveAsText(pEnergySpectrum, mSaveFilename);
+    SaveAsText(pEnergySpectrumNbPart, mSaveFilename);
+    SaveAsText(pEnergySpectrumFluenceCos, mSaveFilename);
+    SaveAsText(pEnergySpectrumFluenceTrack, mSaveFilename);
+    SaveAsText(pEnergyEdepSpectrum, mSaveFilename);
     SaveAsText(pEdep, mSaveFilename);
     // SaveAsText(pEdepTime, mSaveFilename); no TH2D
     SaveAsText(pEdepTrack, mSaveFilename);
@@ -135,12 +219,43 @@ void GateEnergySpectrumActor::SaveData()
 //-----------------------------------------------------------------------------
 void GateEnergySpectrumActor::ResetData()
 {
-  pEnergySpectrum->Reset();
-  pEdep->Reset();
-  pLETSpectrum->Reset();
-  pEdepTime->Reset();
-  pEdepTrack->Reset();
-  pDeltaEc->Reset();
+  if (mEnableEnergySpectrumNbPartFlag){
+    pEnergySpectrumNbPart->Reset();
+  }
+  
+  if (mEnableEnergySpectrumFluenceCosFlag){
+      pEnergySpectrumFluenceCos->Reset();
+  }
+  
+  if (mEnableEnergySpectrumFluenceTrackFlag){
+      pEnergySpectrumFluenceTrack->Reset();
+  }
+  if (mEnableEnergySpectrumEdepFlag){
+      pEnergyEdepSpectrum->Reset();
+  }
+   
+
+  if (mEnableLETSpectrumFlag) {
+      pLETSpectrum->Reset();
+  }
+  if (mEnableQSpectrumFlag){
+      pQSpectrum->Reset();
+  }
+  
+  if (mEnableEdepHistoFlag){
+      pEdep->Reset();
+  }
+  if (mEnableEdepTimeHistoFlag){
+      pEdepTime->Reset();
+  }
+  
+  if (mEnableEdepTrackHistoFlag){
+      pEdepTrack->Reset();
+  }
+  
+  if (mEnableElossHistoFlag){
+      pDeltaEc->Reset();
+  }
   nEvent = 0;
 }
 //-----------------------------------------------------------------------------
@@ -170,10 +285,19 @@ void GateEnergySpectrumActor::BeginOfEventAction(const G4Event*)
 void GateEnergySpectrumActor::EndOfEventAction(const G4Event*)
 {
   GateDebugMessage("Actor", 3, "GateEnergySpectrumActor -- End of Event\n");
-  if (edep > 0) {
-    pEdep->Fill(edep/MeV);
-    pEdepTime->Fill(tof/ns,edep/MeV);
-  }
+  
+    if (edep > 0) {
+        if (mEnableEdepHistoFlag){
+            pEdep->Fill(edep/MeV);
+        }
+        if (mEnableEdepTimeHistoFlag){
+            pEdepTime->Fill(tof/ns,edep/MeV);
+        }
+      }
+  
+  
+  
+      
   nEvent++;
 }
 //-----------------------------------------------------------------------------
@@ -195,8 +319,9 @@ void GateEnergySpectrumActor::PostUserTrackingAction(const GateVVolume *, const 
 {
   GateDebugMessage("Actor", 3, "GateEnergySpectrumActor -- End of Track\n");
   double eloss = Ei-Ef;
-  if (eloss > 0) pDeltaEc->Fill(eloss/MeV,t->GetWeight() );
-  if (edepTrack > 0)  pEdepTrack->Fill(edepTrack/MeV,t->GetWeight() );
+  if (mEnableElossHistoFlag && eloss > 0) pDeltaEc->Fill(eloss/MeV,t->GetWeight() );
+  
+  if (mEnableEdepTrackHistoFlag && edepTrack > 0)  pEdepTrack->Fill(edepTrack/MeV,t->GetWeight() );
 }
 //-----------------------------------------------------------------------------
 
@@ -213,7 +338,6 @@ void GateEnergySpectrumActor::UserSteppingAction(const GateVVolume *, const G4St
   edep += step->GetTotalEnergyDeposit();
   edepTrack += step->GetTotalEnergyDeposit();
 
-  //cout << "--- " << step->GetTrack()->GetTrackID() << " " << step->GetTrack()->GetParentID() << endl;
   if (newEvt) {
     double pretof = step->GetPreStepPoint()->GetGlobalTime();
     double posttof = step->GetPostStepPoint()->GetGlobalTime();
@@ -232,21 +356,60 @@ void GateEnergySpectrumActor::UserSteppingAction(const GateVVolume *, const G4St
   Ef=step->GetPostStepPoint()->GetKineticEnergy();
   if(newTrack){
     Ei=step->GetPreStepPoint()->GetKineticEnergy();
-    pEnergySpectrum->Fill(Ei/MeV,step->GetTrack()->GetWeight());
-    if (mSaveAsDiscreteSpectrumTextFlag) {
-      mDiscreteSpectrum.Fill(Ei/MeV, step->GetTrack()->GetWeight());
+     
+    if (mEnableEnergySpectrumNbPartFlag){
+        pEnergySpectrumNbPart->Fill((Ei+Ef)/2/MeV,step->GetTrack()->GetWeight());
     }
+    
+    G4ThreeVector momentumDir = step->GetTrack()->GetMomentumDirection(); 
+    
+    if (mEnableEnergySpectrumFluenceCosFlag){
+        double dz = TMath::Abs( momentumDir.z());
+        if (dz > 0){
+            double Emean = (Ei+Ef)/2/MeV;
+            double invAngle = 1/dz;
+            //if (invAngle > 10) invAngle = 10;
+            pEnergySpectrumFluenceCos->Fill(Emean,step->GetTrack()->GetWeight()*invAngle);
+        }
+    }
+    // uncommented A.Resch 30.Nov 2018
+    //if (mSaveAsDiscreteSpectrumTextFlag) {
+      //mDiscreteSpectrum.Fill(Ei/MeV, step->GetTrack()->GetWeight());
+    //}
     newTrack=false;
   }
+  
+   if (mEnableEnergySpectrumFluenceTrackFlag){
+       G4double stepLength = step->GetStepLength();
+       pEnergySpectrumFluenceTrack->Fill((Ei+Ef)/2/MeV,step->GetTrack()->GetWeight()*stepLength);
+       
+   }
+   if (mEnableEnergySpectrumEdepFlag){
+       pEnergyEdepSpectrum->Fill((Ei+Ef)/2/MeV,step->GetTrack()->GetWeight()*step->GetTotalEnergyDeposit()/MeV);
+   }
   if(mEnableLETSpectrumFlag) {
-  //G4double density = step->GetPreStepPoint()->GetMaterial()->GetDensity();
-  G4Material* material = step->GetPreStepPoint()->GetMaterial();//->GetName();
-  G4double energy1 = step->GetPreStepPoint()->GetKineticEnergy();
-  G4double energy2 = step->GetPostStepPoint()->GetKineticEnergy();
-  G4double energy=(energy1+energy2)/2;
-  G4ParticleDefinition* partname = step->GetTrack()->GetDefinition();//->GetParticleName();
-  G4double dedx = emcalc->ComputeElectronicDEDX(energy, partname, material);
-  pLETSpectrum->Fill(dedx/(keV/um));
+      G4Material* material = step->GetPreStepPoint()->GetMaterial();//->GetName(); 
+      G4double energy1 = step->GetPreStepPoint()->GetKineticEnergy();
+      G4double energy2 = step->GetPostStepPoint()->GetKineticEnergy();
+      G4double energy=(energy1+energy2)/2;
+      G4ParticleDefinition* partname = step->GetTrack()->GetDefinition();//->GetParticleName();
+      G4double dedx;
+      dedx = emcalc->ComputeElectronicDEDX(energy, partname, material);
+      pLETSpectrum->Fill(dedx/(keV/um),step->GetTrack()->GetWeight()*edep/MeV);
+            
+  }  
+  
+  if(mEnableQSpectrumFlag) {
+     
+      G4double energy1Q = step->GetPreStepPoint()->GetKineticEnergy();
+      G4double energy2Q = step->GetPostStepPoint()->GetKineticEnergy();
+      G4double energyQ=(energy1Q+energy2Q)/2;
+      G4int chargeQ = step->GetTrack()->GetDefinition()->GetAtomicNumber();
+      
+      G4double Q =chargeQ; // to convert Int to Double
+      Q*=Q; // now chargeQ is squared
+      Q/=(energyQ/MeV); // now we divide chargeQ^2 / energyQ
+      pQSpectrum->Fill(Q,step->GetTrack()->GetWeight()*step->GetTotalEnergyDeposit()/MeV);
   }
 }
 //-----------------------------------------------------------------------------

--- a/source/digits_hits/src/GateEnergySpectrumActorMessenger.cc
+++ b/source/digits_hits/src/GateEnergySpectrumActorMessenger.cc
@@ -3,7 +3,7 @@
 
   This software is distributed under the terms
   of the GNU Lesser General  Public Licence (LGPL)
-  See LICENSE.md for further details
+  See GATE/LICENSE.txt for further details
   ----------------------*/
 
 #include "GateEnergySpectrumActorMessenger.hh"
@@ -32,6 +32,9 @@ GateEnergySpectrumActorMessenger::~GateEnergySpectrumActorMessenger()
   delete pLETminCmd;
   delete pLETmaxCmd;
   delete pNLETBinsCmd;
+  delete pQminCmd;
+  delete pQmaxCmd;
+  delete pNQBinsCmd;
   delete pNBinsCmd;
   delete pEdepmaxCmd;
   delete pEdepminCmd;
@@ -122,6 +125,78 @@ void GateEnergySpectrumActorMessenger::BuildCommands(G4String base)
   guidance = G4String("Set number of bins of the energy spectrum");
   pNLETBinsCmd->SetGuidance(guidance);
   pNLETBinsCmd->SetParameterName("NLETbins", false);
+  
+  
+  bb = base+"/enableQSpectrum";
+  pEnableQSpectrumCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable Q spectrum");
+  pEnableQSpectrumCmd->SetGuidance(guidance);
+  
+    bb = base+"/QSpectrum/setQmin";
+  pQminCmd = new G4UIcmdWithADoubleAndUnit(bb, this);
+  guidance = G4String("Set minimum Q of the Q spectrum");
+  pQminCmd->SetGuidance(guidance);
+  pQminCmd->SetParameterName("Qmin", false);
+  pQminCmd->SetDefaultUnit("keV/um");
+  
+  bb = base+"/QSpectrum/setQmax";
+  pQmaxCmd = new G4UIcmdWithADoubleAndUnit(bb, this);
+  guidance = G4String("Set maximum Q of the Q spectrum");
+  pQmaxCmd->SetGuidance(guidance);
+  pQmaxCmd->SetParameterName("Qmax", false);
+  pQmaxCmd->SetDefaultUnit("keV/um");
+  
+  bb = base+"/QSpectrum/setNumberOfBins";
+  pNQBinsCmd = new G4UIcmdWithAnInteger(bb, this);
+  guidance = G4String("Set number of bins of the energy spectrum");
+  pNQBinsCmd->SetGuidance(guidance);
+  pNQBinsCmd->SetParameterName("NQbins", false);
+  
+  
+  bb = base+"/enableNbPartSpectrum";
+  pEnableEnergySpectrumNbPartCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable Number of Particle spectrum");
+  pEnableEnergySpectrumNbPartCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableFluenceCosSpectrum";
+  pEnableEnergySpectrumFluenceCosCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable fluence spectrum from momentum direction");
+  pEnableEnergySpectrumFluenceCosCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableFluenceTrackSpectrum";
+  pEnableEnergySpectrumFluenceTrackCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable fluence spectrum from track length in volume");
+  pEnableEnergySpectrumFluenceTrackCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableEdepSpectrum";
+  pEnableeEnergySpectrumEdepCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable energy deposition spectrum");
+  pEnableeEnergySpectrumEdepCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableEdepHisto";
+  pEnableEdepHistoCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable edep histogram");
+  pEnableEdepHistoCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableEdepTimeHisto";
+  pEnableEdepTimeHistoCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable edep time histogram");
+  pEnableEdepTimeHistoCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableEdepTrackHisto";
+  pEnableEdepTrackHistoCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable edep track histogram");
+  pEnableEdepTrackHistoCmd->SetGuidance(guidance);
+  
+  bb = base+"/enableElossHisto";
+  pEnableElossHistoCmd = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Enable energy loss histogram");
+  pEnableElossHistoCmd->SetGuidance(guidance);
+  
+  bb = base+"/setLogBinWidth";
+  pEnableLogBinningCMD = new G4UIcmdWithABool(bb, this);
+  guidance = G4String("Set logarithmic binning in energy");
+  pEnableLogBinningCMD->SetGuidance(guidance);
 }
 //-----------------------------------------------------------------------------
 
@@ -139,6 +214,10 @@ void GateEnergySpectrumActorMessenger::SetNewValue(G4UIcommand* cmd, G4String ne
   if(cmd == pLETmaxCmd) pActor->SetLETmax(  pLETmaxCmd->GetNewDoubleValue(newValue)  ) ;
   if(cmd == pNLETBinsCmd) pActor->SetNLETBins(  pNLETBinsCmd->GetNewIntValue(newValue)  ) ;
   
+  if(cmd == pQminCmd){  pActor->SetQmin(  pQminCmd->GetNewDoubleValue(newValue)  ) ;   }
+  if(cmd == pQmaxCmd) pActor->SetQmax(  pQmaxCmd->GetNewDoubleValue(newValue)  ) ;
+  if(cmd == pNQBinsCmd) pActor->SetNQBins(  pNQBinsCmd->GetNewIntValue(newValue)  ) ;
+  
   if(cmd == pNBinsCmd) pActor->SetENBins(  pNBinsCmd->GetNewIntValue(newValue)  ) ;
   if(cmd == pEdepminCmd) pActor->SetEdepmin(  pEdepminCmd->GetNewDoubleValue(newValue)  ) ;
   if(cmd == pEdepmaxCmd) pActor->SetEdepmax(  pEdepmaxCmd->GetNewDoubleValue(newValue)  ) ;
@@ -146,6 +225,19 @@ void GateEnergySpectrumActorMessenger::SetNewValue(G4UIcommand* cmd, G4String ne
   if(cmd == pSaveAsText) pActor->SetSaveAsTextFlag(  pSaveAsText->GetNewBoolValue(newValue)  ) ;
   if(cmd == pSaveAsTextDiscreteEnergySpectrum) pActor->SetSaveAsTextDiscreteEnergySpectrumFlag(  pSaveAsTextDiscreteEnergySpectrum->GetNewBoolValue(newValue)  ) ;
   if(cmd == pEnableLETSpectrumCmd) pActor->SetLETSpectrumCalc(  pEnableLETSpectrumCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableQSpectrumCmd) pActor->SetQSpectrumCalc(  pEnableQSpectrumCmd->GetNewBoolValue(newValue)  ) ;
+  
+  if(cmd == pEnableEnergySpectrumNbPartCmd) pActor->SetESpectrumNbPartCalc(  pEnableEnergySpectrumNbPartCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableEnergySpectrumFluenceCosCmd) pActor->SetESpectrumFluenceCosCalc(  pEnableEnergySpectrumFluenceCosCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableEnergySpectrumFluenceTrackCmd) pActor->SetESpectrumFluenceTrackCalc(  pEnableEnergySpectrumFluenceTrackCmd->GetNewBoolValue(newValue)  ) ;
+  
+  if(cmd == pEnableeEnergySpectrumEdepCmd) pActor->SetESpectrumEdepCalc(  pEnableeEnergySpectrumEdepCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableEdepHistoCmd) pActor->SetEdepHistoCalc (  pEnableEdepHistoCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableEdepTimeHistoCmd) pActor->SetEdepTimeHistoCalc(  pEnableEdepTimeHistoCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableEdepTrackHistoCmd) pActor->SetEdepTrackHistoCalc(  pEnableEdepTrackHistoCmd->GetNewBoolValue(newValue)  ) ;
+  if(cmd == pEnableElossHistoCmd) pActor->SetElossHistoCalc(  pEnableElossHistoCmd->GetNewBoolValue(newValue)  ) ;
+  
+  if(cmd == pEnableLogBinningCMD) pActor->SetLogBinning(  pEnableLogBinningCMD->GetNewBoolValue(newValue)  ) ;
   GateActorMessenger::SetNewValue(cmd,newValue);
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
changed:
- by default not all spectra are generated
- new: fluence calculation from the track length and 1/cos(dz) approximation. The latter is only valid for certain beam angles. 