### PR TITLE
Add missing initialization which triggered warnings when using

### DIFF
--- a/source/digits_hits/src/GatePhaseSpaceActor.cc
+++ b/source/digits_hits/src/GatePhaseSpaceActor.cc
@@ -56,6 +56,7 @@ GatePhaseSpaceActor::GatePhaseSpaceActor(G4String name, G4int depth):
   EnableLocalTime = false;
   EnableMass = true;
   EnableSec = false;
+  EnableNuclearFlag = false;
   mIsFistStep = true;
   mUseVolFrame = false;
   mStoreOutPart = false;


### PR DESCRIPTION
PhaseSpaceActor.