### PR TITLE
fixed bug: energy was only updated if new track

### DIFF
--- a/source/digits_hits/src/GateEnergySpectrumActor.cc
+++ b/source/digits_hits/src/GateEnergySpectrumActor.cc
@@ -403,8 +403,9 @@ void GateEnergySpectrumActor::UserSteppingAction(const GateVVolume *, const G4St
         atomicMassScaleFactor = (double)(step->GetTrack()->GetParticleDefinition()->GetAtomicMass());
     }
   Ef=step->GetPostStepPoint()->GetKineticEnergy();
+  Ei=step->GetPreStepPoint()->GetKineticEnergy();
   if(newTrack){
-    Ei=step->GetPreStepPoint()->GetKineticEnergy();
+    
 
     
     if (mEnableEnergySpectrumNbPartFlag){


### PR DESCRIPTION
Energy of particles was only updated when a new track was found. Now it always updates the energy at any step.