### PR TITLE
Read number of primaries per run in a file

### DIFF
--- a/source/general/include/GateApplicationMgr.hh
+++ b/source/general/include/GateApplicationMgr.hh
@@ -51,10 +51,18 @@ public:
   void SetVerboseLevel(G4int value) { nVerboseLevel = value; }
 
   void SetTimeInterval(G4double v);
+
   void SetTotalNumberOfPrimaries(double n);
   long int GetTotalNumberOfPrimaries(){return mRequestedAmountOfPrimaries;}
+  
   void SetNumberOfPrimariesPerRun(double n);
   long int GetNumberOfPrimariesPerRun(){return mRequestedAmountOfPrimariesPerRun;}
+
+  //LSLS
+  void ReadNumberOfPrimariesInAFile(G4String filename);
+  bool IsReadNumberOfPrimariesInAFileModeEnabled(){return mReadNumberOfPrimariesInAFileIsUsed;}
+
+
 
   void SetNoOutputMode();
   bool GetOutputMode(){return mOutputMode;}
@@ -89,6 +97,12 @@ protected:
 
   G4double mTimeSliceDuration;
   std::vector<G4double> mTimeSlices;
+  
+  //LSLS
+  std::vector<G4int> mNumberOfPrimariesPerRun;
+  bool mReadNumberOfPrimariesInAFileIsUsed;
+
+
 
   bool mOutputMode;
   bool mTimeSliceIsSetUsingAddSlice;

--- a/source/general/include/GateApplicationMgrMessenger.hh
+++ b/source/general/include/GateApplicationMgrMessenger.hh
@@ -60,6 +60,10 @@ private:
   G4UIcmdWithADouble *      SetTotalNumberOfPrimariesCmd;
   G4UIcmdWithADouble *      SetNumberOfPrimariesPerRunCmd;
   G4UIcmdWithADouble *      SetNumberOfPrimariesPerRunCmd2;
+
+//LSLS
+  G4UIcmdWithAString *      ReadNumberOfPrimariesInAFileCmd;
+
 };
 
 #endif

--- a/source/general/src/GateApplicationMgrMessenger.cc
+++ b/source/general/src/GateApplicationMgrMessenger.cc
@@ -115,6 +115,11 @@ GateApplicationMgrMessenger::GateApplicationMgrMessenger()
   SetNumberOfPrimariesPerRunCmd2 = new G4UIcmdWithADouble("/gate/application/SetNumberOfPrimariesPerRun", this);
   SetNumberOfPrimariesPerRunCmd2->SetGuidance("Set the number of primaries to generate per per run.");
 
+  //LSLS
+  ReadNumberOfPrimariesInAFileCmd = new G4UIcmdWithAString("/gate/application/readNumberOfPrimariesInAFile", this);
+  ReadNumberOfPrimariesInAFileCmd->SetGuidance("Read the number of primaries per run in a file.");
+
+
   TimeStudyCmd = new G4UIcmdWithAString("/gate/application/enableTrackTimeStudy", this);
   TimeStudyCmd->SetGuidance("Activate the time measurement of tracks (Slow down the simulation).");
   TimeStudyCmd->SetParameterName("File name",false);
@@ -151,6 +156,10 @@ GateApplicationMgrMessenger::~GateApplicationMgrMessenger()
   delete AddSliceCmd;
   delete TimeStudyCmd;
   delete TimeStudyForStepsCmd;
+
+  //LSLS
+  delete ReadNumberOfPrimariesInAFileCmd;
+
 }
 //-------------------------------------------------------------------------------------------------------------------
 
@@ -229,6 +238,9 @@ void GateApplicationMgrMessenger::SetNewValue(G4UIcommand* command, G4String new
   }
   else if (command == SetNumberOfPrimariesPerRunCmd2) {
     appMgr->SetNumberOfPrimariesPerRun(SetNumberOfPrimariesPerRunCmd2->GetNewDoubleValue(newValue));
+  }
+  else if (command == ReadNumberOfPrimariesInAFileCmd) {
+  appMgr->ReadNumberOfPrimariesInAFile(newValue);
   }
   else if (command == TimeStudyCmd) {
     appMgr->EnableTimeStudy(newValue);

--- a/source/physics/src/GateSourceMgr.cc
+++ b/source/physics/src/GateSourceMgr.cc
@@ -582,7 +582,7 @@ G4int GateSourceMgr::PrepareNextEvent( G4Event* event )
           G4cout << "GateSourceMgr::PrepareNextEvent :  m_time (s) " << m_time/s
                  << "  m_timeLimit (s) " << m_timeLimit/s << Gateendl;
 
-        if( m_time <= m_timeLimit || appMgr->IsTotalAmountOfPrimariesModeEnabled())
+        if( m_time <= m_timeLimit || appMgr->IsTotalAmountOfPrimariesModeEnabled() || appMgr->IsReadNumberOfPrimariesInAFileModeEnabled() )
           {
             if( mVerboseLevel > 1 )
               G4cout << "GateSourceMgr::PrepareNextEvent : source selected <"


### PR DESCRIPTION
This can be useful for VMAT Radiotherapy with dose rate changes
This has been tested with startDAQ but not startDAQcluster
The new command is 
/gate/application/readNumberOfPrimariesInAFile data/<filename>

The file must be in the followin format

```
# Comment
n
j
k
l
u
```
where n, j, k, l, u... are the number (int) of primaries for each run
