### PR TITLE
Add assert include

### DIFF
--- a/source/io/src/GateRootTreeFile.cc
+++ b/source/io/src/GateRootTreeFile.cc
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <iostream>
 #include <fstream>
+#include <assert.h>
 
 #include "TLeaf.h"
 #include "TROOT.h"


### PR DESCRIPTION
@wrzof 

Without the include, the assert statements failed during compilation with:
gcc (SUSE Linux) 7.4.1 20190424