### PR TITLE
GateActorManager: Deactivate previous SD in SetMultiFunctionalDetector

### DIFF
--- a/source/digits_hits/src/GateActorManager.cc
+++ b/source/digits_hits/src/GateActorManager.cc
@@ -270,6 +270,10 @@ void GateActorManager::SetMultiFunctionalDetector(GateVActor * actor, GateVVolum
       G4String detectorName = "MFD_"+ num.str();
       G4String detectorName2 = "MSD_"+ num.str();
 
+      // Deactivate previously attached SD
+      G4String name = volume->GetLogicalVolume()->GetSensitiveDetector()->GetName().prepend("/gate/");
+      G4SDManager::GetSDMpointer()->Activate(name, false);
+
       theListOfMultiSensitiveDetector.push_back(new GateMultiSensitiveDetector(detectorName2));
 
       theListOfMultiSensitiveDetector[nActor]->SetSensitiveDetector(volume->GetLogicalVolume()->GetSensitiveDetector());


### PR DESCRIPTION
In case a SD is already attached to the logical volume, the SD should be
replaced by a MSD in SetMultiFunctionalDetector. The previously missing
deactivation of the SD could result in a memory leak (see #257).

Since Geant4 doesn't seem to offer a way to remove a SD from the
G4SDManager, we have to deactivate the SD.

Closes #257