### PR TITLE
optimise compilation for unix platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,20 @@ IF(NOT CMAKE_BUILD_TYPE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
 #=========================================================
+# Native compilation
+OPTION(GATE_COMPILE_WITH_NATIVE "Build with -march=native (works if build type is Release)" OFF)
+IF(UNIX AND GATE_COMPILE_WITH_NATIVE)
+  string(FIND ${CMAKE_CXX_FLAGS_RELEASE} -march=native pos_march_cxx)
+  string(FIND ${CMAKE_C_FLAGS_RELEASE} -march=native pos_march_c)
+  IF(${pos_march_cxx} EQUAL -1)
+    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
+  ENDIF() 
+  IF(${pos_march_c} EQUAL -1)
+    SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=native")
+  ENDIF()
+ENDIF(UNIX AND GATE_COMPILE_WITH_NATIVE)
+
+#=========================================================
 # Option to use visualisation feature of G4
 OPTION(GATE_USE_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
 IF(GATE_USE_GEANT4_UIVIS)
@@ -295,16 +309,6 @@ ENDIF(GATE_DOWNLOAD_BENCHMARKS_DATA)
 # such warning related to clhep/g4 system of units. Additionally,
 # we force the c++11 std. This is mandatory for Geant4 >= 10.2.
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-shadow")
-IF(UNIX)
-  string(FIND ${CMAKE_CXX_FLAGS_RELEASE} -march=native pos_march_cxx)
-  string(FIND ${CMAKE_C_FLAGS_RELEASE} -march=native pos_march_c)
-  IF(${pos_march_cxx} EQUAL -1)
-    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
-  ENDIF() 
-  IF(${pos_march_c} EQUAL -1)
-    SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=native")
-  ENDIF() 
-ENDIF(UNIX)
 #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(CMAKE_CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,16 @@ ENDIF(GATE_DOWNLOAD_BENCHMARKS_DATA)
 # such warning related to clhep/g4 system of units. Additionally,
 # we force the c++11 std. This is mandatory for Geant4 >= 10.2.
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-shadow")
+IF(UNIX)
+  string(FIND ${CMAKE_CXX_FLAGS_RELEASE} -march=native pos_march_cxx)
+  string(FIND ${CMAKE_C_FLAGS_RELEASE} -march=native pos_march_c)
+  IF(${pos_march_cxx} EQUAL -1)
+    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
+  ENDIF() 
+  IF(${pos_march_c} EQUAL -1)
+    SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=native")
+  ENDIF() 
+ENDIF(UNIX)
 #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
I added the -march=native flag option to CMAKE_CXX_FLAGS_RELEASE and CMAKE_C_FLAGS_RELEASE to optimise the compilation.

Best regards,
Ben
