### PR TITLE
efficiency by Z, well defined voxel volume

### DIFF
--- a/source/digits_hits/include/GateDoseActor.hh
+++ b/source/digits_hits/include/GateDoseActor.hh
@@ -57,6 +57,7 @@ public:
   void EnableDoseNormalisationToMax(bool b);
   void EnableDoseNormalisationToIntegral(bool b);
   void SetEfficiencyFile(G4String b);
+  void SetEfficiencyFileByZ(G4String b);
   //DoseToWater
   void EnableDoseToWaterImage(bool b) { mIsDoseToWaterImageEnabled = b; }
   void EnableDoseToWaterSquaredImage(bool b) { mIsDoseToWaterSquaredImageEnabled = b; }
@@ -118,6 +119,7 @@ protected:
   bool mIsDoseUncertaintyImageEnabled;
   bool mIsDoseNormalisationEnabled;
   bool mIsDoseEfficiencyEnabled;
+  bool mIsDoseEfficiencyByZEnabled;
   //DoseToWater
   bool mIsDoseToWaterImageEnabled;
   bool mIsDoseToWaterSquaredImageEnabled;
@@ -139,9 +141,15 @@ protected:
   //Dose
   G4String mDoseFilename;
   GateImageWithStatistic mDoseImage;
+    //Efficiency option
   G4String mDoseEfficiencyFile;
   std::vector<double> mDoseEnergy;
   std::vector<double> mDoseEfficiency;
+    //Efficiency option by Z (by ion atomic number)
+  std::vector<G4String> mDoseEfficiencyFileByZ;
+  std::vector<G4int> mDoseZByZ;
+  std::vector<std::vector<double>> mDoseEnergyByZ;
+  std::vector<std::vector<double>> mDoseEfficiencyByZ;
   //DoseToWater
   G4String mDoseToWaterFilename;
   GateImageWithStatistic mDoseToWaterImage;

--- a/source/digits_hits/include/GateDoseActorMessenger.hh
+++ b/source/digits_hits/include/GateDoseActorMessenger.hh
@@ -42,7 +42,10 @@ protected:
   G4UIcmdWithABool * pEnableDoseUncertaintyCmd;
   G4UIcmdWithABool * pEnableDoseNormToMaxCmd;
   G4UIcmdWithABool * pEnableDoseNormToIntegralCmd;
+    //Efficiency option
   G4UIcmdWithAString * pSetDoseEfficiencyCmd;
+    //Efficiency option by Z (by ion atomic number)
+  G4UIcmdWithAString * pSetDoseEfficiencyByZCmd;
   //DoseToWater
   G4UIcmdWithABool * pEnableDoseToWaterCmd;
   G4UIcmdWithABool * pEnableDoseToWaterSquaredCmd;

--- a/source/digits_hits/src/GateDoseActorMessenger.cc
+++ b/source/digits_hits/src/GateDoseActorMessenger.cc
@@ -29,6 +29,7 @@ GateDoseActorMessenger::GateDoseActorMessenger(GateDoseActor* sensor)
   pEnableDoseSquaredCmd= 0;
   pEnableDoseUncertaintyCmd= 0;
   pSetDoseEfficiencyCmd= 0;
+  pSetDoseEfficiencyByZCmd= 0;
   //DoseToWater
   pEnableDoseToWaterCmd = 0;
   pEnableDoseToWaterNormToMaxCmd= 0;
@@ -73,6 +74,7 @@ GateDoseActorMessenger::~GateDoseActorMessenger()
   if(pEnableDoseSquaredCmd) delete pEnableDoseSquaredCmd;
   if(pEnableDoseUncertaintyCmd) delete pEnableDoseUncertaintyCmd;
   if(pSetDoseEfficiencyCmd) delete pSetDoseEfficiencyCmd;
+  if(pSetDoseEfficiencyByZCmd) delete pSetDoseEfficiencyByZCmd;
   //DoseToWater
   if(pEnableDoseToWaterCmd) delete pEnableDoseToWaterCmd;
   if(pEnableDoseToWaterNormToMaxCmd) delete pEnableDoseToWaterNormToMaxCmd;
@@ -144,10 +146,16 @@ void GateDoseActorMessenger::BuildCommands(G4String base)
   pEnableDoseUncertaintyCmd = new G4UIcmdWithABool(n, this);
   guid = G4String("Enable uncertainty dose computation");
   pEnableDoseUncertaintyCmd->SetGuidance(guid);
+    //Efficiency option
   n = base+"/setDoseEfficiencyFile";
   pSetDoseEfficiencyCmd = new G4UIcmdWithAString(n, this);
-  guid = G4String("set dose scoring efficiency as a function of energy");
+  guid = G4String("set dose scoring efficiency as a function of energy (independently of particle atomic number)");
   pSetDoseEfficiencyCmd->SetGuidance(guid);
+    //Efficiency option by Z (by ion atomic number)
+  n = base+"/setDoseEfficiencyFileAndAtomicNumber";
+  pSetDoseEfficiencyByZCmd = new G4UIcmdWithAString(n, this);
+  guid = G4String("set dose scoring efficiency as a function of energy, depending on particle atomic number");
+  pSetDoseEfficiencyByZCmd->SetGuidance(guid);
 
   //DoseToWater
   n = base+"/enableDoseToWater";
@@ -274,7 +282,11 @@ void GateDoseActorMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue)
   if (cmd == pEnableDoseUncertaintyCmd) pDoseActor->EnableDoseUncertaintyImage(pEnableDoseUncertaintyCmd->GetNewBoolValue(newValue));
   if (cmd == pEnableDoseNormToMaxCmd) pDoseActor->EnableDoseNormalisationToMax(pEnableDoseNormToMaxCmd->GetNewBoolValue(newValue));
   if (cmd == pEnableDoseNormToIntegralCmd) pDoseActor->EnableDoseNormalisationToIntegral(pEnableDoseNormToIntegralCmd->GetNewBoolValue(newValue));
+	//Efficiency option
   if (cmd == pSetDoseEfficiencyCmd) pDoseActor->SetEfficiencyFile(newValue);
+    //Efficiency option by Z (by ion atomic number)
+  if (cmd == pSetDoseEfficiencyByZCmd) pDoseActor->SetEfficiencyFileByZ(newValue);
+ 
   //DoseToWater
   if (cmd == pEnableDoseToWaterCmd) pDoseActor->EnableDoseToWaterImage(pEnableDoseToWaterCmd->GetNewBoolValue(newValue));
   if (cmd == pEnableDoseToWaterSquaredCmd) pDoseActor->EnableDoseToWaterSquaredImage(pEnableDoseToWaterSquaredCmd->GetNewBoolValue(newValue));


### PR DESCRIPTION
Two years ago the efficiency was introduced, but it was the same for all
particles. Now you can provide different efficiency tables depending on
the Z of the particles (including Z=-1 for electrons).

The voxel volume used to be undefined for some combinations of
enabled-ness of output images. Now it should always be well defined, for
example if only "dose to water" is requested but not the normal dose.