### PR TITLE
Fix crash when digitizer noise module used with GateToTree/Singles.

### DIFF
--- a/source/digits_hits/src/GateToTree.cc
+++ b/source/digits_hits/src/GateToTree.cc
@@ -610,8 +610,15 @@ void GateToTree::RecordEndOfEvent(const G4Event *event)
       if(system_id == -1)
       {
         auto mother = static_cast<const GateCrystalHit*>(digi->GetPulse().GetMother());
-        assert(mother);
-        system_id = mother->GetSystemID();
+        if(!mother)
+        {
+          // for example pulse created by GateNoise.cc (l67).
+          system_id = 0;
+        } else
+        {
+          system_id = mother->GetSystemID();
+        }
+
       }
 
       retrieve(digi, system_id);
@@ -660,8 +667,12 @@ void GateToTree::RecordEndOfEvent(const G4Event *event)
       if(system_id == -1)
       {
         auto mother = static_cast<const GateCrystalHit*>(digi->GetPulse(0).GetMother());
-        assert(mother);
-        system_id = mother->GetSystemID();
+        if(!mother) {
+          // for example pulse created by GateNoise.cc (l67).
+          system_id = 0;
+        } else {
+          system_id = mother->GetSystemID();
+        }
       }
 
       const auto &pulse = digi->GetPulse(0);


### PR DESCRIPTION
Code relied on "mother" feature of GateHit and GatePulse in order to detect in which systemID pulse or hit are created. But in case of some digitizer module (like GateNoise, pulses are created from scratch, and does not belong to a system). In this case, I choose default system_id = 0.

Maybe, we have to check GateNoise, in order to see if it is correct to create pulses without mother system.