### PR TITLE
clean: convert enum  TrackingMode to enum class TrackingMode

### DIFF
--- a/source/digits_hits/include/GateActions.hh
+++ b/source/digits_hits/include/GateActions.hh
@@ -31,7 +31,7 @@ class GateTrack;
 class GateVVolume;
 class GateUserActions;
 
-enum TrackingMode {
+enum class TrackingMode {
   kUnknown, kBoth,  kTracker,
   kDetector
 };
@@ -171,7 +171,7 @@ protected :
   //
   GateSteppingActionMessenger* m_steppingMessenger;
   std::vector<GateTrack*> *PPTrackVector;
-  TrackingMode TheMode;
+  TrackingMode m_trackingMode;
   G4int Boundary; // if set to 1 stop track on Phantom Boundary
   G4int fKeepOnlyP;
   G4int fKeepOnlyPhotons;

--- a/source/digits_hits/src/GateActions.cc
+++ b/source/digits_hits/src/GateActions.cc
@@ -120,7 +120,7 @@ inline void GateEventAction::BeginOfEventAction(const G4Event* anEvent)
   GateMessage("Core", 2, "Begin Of Event " << anEvent->GetEventID() << "\n");
 
   TrackingMode theMode =( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) )->GetMode();
-  if ( theMode != kTracker )
+  if ( theMode != TrackingMode::kTracker )
     {
 
 
@@ -159,7 +159,7 @@ inline void GateEventAction::EndOfEventAction(const G4Event* anEvent)
   GateSteppingAction* myAction = ( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) );
   TrackingMode theMode = myAction->GetMode();
 
-  if ( theMode == kTracker )
+  if ( theMode == TrackingMode::kTracker )
     {
 
       G4int CHCollID = G4SDManager::GetSDMpointer()->GetCollectionID(GateCrystalSD::GetCrystalCollectionName() ); //"crystalCollection");
@@ -217,7 +217,7 @@ void GateTrackingAction::PreUserTrackingAction(const G4Track* a)
 
   TrackingMode theMode = myAction->GetMode();
 
-  if ( theMode == kDetector )
+  if ( theMode == TrackingMode::kDetector )
     {
       std::vector<GateTrack*>* aTrackVector = myAction->GetPPTrackVector();
       G4int size =  aTrackVector->size() ;
@@ -303,7 +303,7 @@ void GateTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
 
   GateSteppingAction*  myAction = (GateSteppingAction *) (GateRunManager::GetRunManager()->GetUserSteppingAction()) ;
   TrackingMode theMode = myAction->GetMode();
-  if ( theMode == kDetector )
+  if ( theMode == TrackingMode::kDetector )
     {
       //G4int eventID = G4EventManager::GetEventManager()->GetNonconstCurrentEvent()->GetEventID();
       // In Detector Mode : look at trajectories
@@ -510,7 +510,7 @@ GateSteppingAction::GateSteppingAction(GateUserActions * cbm)
   m_verboseLevel = 0;
   /* PY Descourt Tracker/Detector 18/12/2008 */
   m_steppingMessenger = new GateSteppingActionMessenger(this);
-  TheMode = kBoth;
+  m_trackingMode = TrackingMode::kBoth;
   Boundary = 1;
   fStpAKill = fStopAndKill;
   fKeepOnlyP = 0;
@@ -586,11 +586,11 @@ void GateSteppingAction::StopAndKill(G4String aString )
 }
 void GateSteppingAction::SetMode( TrackingMode aMode)
 {
-  TheMode = aMode;
+  m_trackingMode = aMode;
 }
 
 TrackingMode  GateSteppingAction::GetMode()
-{ return TheMode;}
+{ return m_trackingMode;}
 
 //-----------------------------------------------------------------------------
 void GateSteppingAction::UserSteppingAction(const G4Step* theStep)
@@ -763,7 +763,7 @@ void GateSteppingAction::UserSteppingAction(const G4Step* theStep)
         }
     } // generate ARF - Data PY Descourt 08/09/2008
 
-  if ( TheMode == kTracker )
+  if (m_trackingMode == TrackingMode::kTracker )
     {
       G4int EventID = G4EventManager::GetEventManager()->GetNonconstCurrentEvent()->GetEventID();
       G4int RunID   = GateRunManager::GetRunManager()->GetCurrentRun()->GetRunID();
@@ -1225,7 +1225,7 @@ void GateSteppingAction::UserSteppingAction(const GateVVolume *v, const G4Step* 
         }
     } // generate ARF - Data PY Descourt 11/12/2008
 
-  if ( TheMode == kTracker )
+  if (m_trackingMode == TrackingMode::kTracker )
     {
       G4int EventID = G4EventManager::GetEventManager()->GetNonconstCurrentEvent()->GetEventID();
       G4int RunID   = GateRunManager::GetRunManager()->GetCurrentRun()->GetRunID();

--- a/source/digits_hits/src/GateAnalysis.cc
+++ b/source/digits_hits/src/GateAnalysis.cc
@@ -319,7 +319,7 @@ void GateAnalysis::RecordEndOfEvent(const G4Event* event)
           TrackingMode theMode =( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) )->GetMode();
 
 
-          if (  theMode == kTracker ) // in tracker mode we store the infos about the number of compton and rayleigh
+          if (  theMode == TrackingMode::kTracker ) // in tracker mode we store the infos about the number of compton and rayleigh
             { // G4cout << " GateAnalysis eventID "<<eventID<< Gateendl;
               GateToRoot* gateToRoot = (GateToRoot*) (GateOutputMgr::GetInstance()->GetModule("root"));
               ComptonRayleighData aCRData;
@@ -335,7 +335,7 @@ void GateAnalysis::RecordEndOfEvent(const G4Event* event)
               // return;
             }
 
-          if (  theMode == kDetector ) // in tracker mode we store the infos about the number of compton and rayleigh
+          if (  theMode == TrackingMode::kDetector ) // in tracker mode we store the infos about the number of compton and rayleigh
             {
               // we are in detector mode
               GateToRoot* gateToRoot = (GateToRoot*) (GateOutputMgr::GetInstance()->GetModule("root"));

--- a/source/digits_hits/src/GateSteppingActionMessenger.cc
+++ b/source/digits_hits/src/GateSteppingActionMessenger.cc
@@ -105,12 +105,12 @@ void GateSteppingActionMessenger::SetNewValue(G4UIcommand * command,G4String new
   }
   if( command == SetModeCmd )
   {
-    TrackingMode theMode = kUnknown;
-    if ( newValue == "Tracker"  ) { theMode = kTracker;}
-    if ( newValue == "Both"   ) { theMode = kBoth;     }
-    if ( newValue == "Detector" ) { theMode = kDetector;   }
-    if ( theMode  == kUnknown ) {
-         G4cout << " Gate Application Manager WARNING : The Application mode " << newValue <<" is not known. Switching to Normal Mode ...\n";theMode = kBoth;
+    TrackingMode theMode = TrackingMode::kUnknown;
+    if ( newValue == "Tracker"  ) { theMode = TrackingMode::kTracker;}
+    if ( newValue == "Both"   ) { theMode = TrackingMode::kBoth;     }
+    if ( newValue == "Detector" ) { theMode = TrackingMode::kDetector;   }
+    if ( theMode  == TrackingMode::kUnknown ) {
+         G4cout << " Gate Application Manager WARNING : The Application mode " << newValue <<" is not known. Switching to Normal Mode ...\n";theMode = TrackingMode::kBoth;
     }
     myAction->SetMode(theMode);
     return;

--- a/source/digits_hits/src/GateToRoot.cc
+++ b/source/digits_hits/src/GateToRoot.cc
@@ -285,18 +285,18 @@ void GateToRoot::RecordBeginOfAcquisition()
 
   GateSteppingAction* myAction = ( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) );
   TrackingMode theMode = myAction->GetMode();
-  if (nVerboseLevel > 1) G4cout << " GateToRoot::RecordBeginOfAcquisition()  Tracking Mode " << theMode << Gateendl;
+  if (nVerboseLevel > 1) G4cout << " GateToRoot::RecordBeginOfAcquisition()  Tracking Mode " << int(theMode) << Gateendl;
 
   // PY. Descourt 11/12/2008
   // NORMAL OR DETECTOR MODE
-  if ( ( theMode == kBoth ) || ( theMode == kDetector ) )
+  if ( ( theMode == TrackingMode::kBoth ) || ( theMode == TrackingMode::kDetector ) )
     {
       /////////////////////////////////////
       //////////////////////
       //////////
       ////
       //DETECTOR MODE : open the Tracks data Root File
-      if ( theMode == kDetector )
+      if ( theMode == TrackingMode::kDetector )
         {
 
           m_currentGTrack = new GateTrack();
@@ -370,7 +370,7 @@ void GateToRoot::RecordBeginOfAcquisition()
 
       return;
     }
-  if ( theMode == kTracker )
+  if ( theMode == TrackingMode::kTracker )
     {
 
       m_currentGTrack = new GateTrack();
@@ -516,7 +516,7 @@ void GateToRoot::RecordEndOfAcquisition()
 
   GateSteppingAction* myAction = ( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) );
   TrackingMode theMode = myAction->GetMode();
-  if ( theMode == kTracker )
+  if ( theMode == TrackingMode::kTracker )
     {
       G4cout << " ----- ROOT FILE DATA INFORMATIONS ----- \n";
       if ( tracksTuple != 0 ) {tracksTuple->Print();}
@@ -536,7 +536,7 @@ void GateToRoot::RecordEndOfAcquisition()
       if ( m_hfile->IsOpen() ){ m_hfile->Close(); }
     }
 
-  if ( ( theMode == kBoth ) || ( theMode == kDetector ) )
+  if ( ( theMode == TrackingMode::kBoth ) || ( theMode == TrackingMode::kDetector ) )
     {
       //!    IMPORTANT NOTE
       //!    in case we have a lot of data being written, Root automatically
@@ -654,7 +654,7 @@ void GateToRoot::RecordBeginOfEvent(const G4Event* evt )
 
 
   TrackingMode theMode =( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) )->GetMode();
-  if ( (theMode == kDetector) &&   (evt->GetNumberOfPrimaryVertex() > 0) )
+  if ( (theMode == TrackingMode::kDetector) &&   (evt->GetNumberOfPrimaryVertex() > 0) )
     {
 
       // we read the RecStep and number of rayleigh & compton scatterings from the RecStep Data Root file
@@ -697,7 +697,7 @@ void GateToRoot::RecordEndOfEvent(const G4Event* event)
 
   GateSteppingAction* myAction = ( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) );
   TrackingMode theMode = myAction->GetMode();
-  if ( theMode == kTracker )return;
+  if ( theMode == TrackingMode::kTracker )return;
 
   nbPrimaries+=1.;
   latestEventID+=1.;

--- a/source/digits_hits/src/GateTrajectoryNavigator.cc
+++ b/source/digits_hits/src/GateTrajectoryNavigator.cc
@@ -196,7 +196,7 @@ std::vector<G4int> GateTrajectoryNavigator::FindAnnihilationGammasTrackID()
 	    G4ThreeVector vert2 = ((G4TrajectoryPoint*)(trj2->GetPoint(0)))->GetPosition();
 	    // in detector mode the vertex position is stored at the last trajectory point
 	    // not the first one
-	    if (  theMode == kDetector ) // in tracker mode we store the infos about the number of compton and rayleigh
+	    if (  theMode == TrackingMode::kDetector ) // in tracker mode we store the infos about the number of compton and rayleigh
               {
                 G4int n_points =trj1->GetPointEntries();
                 vert1 = ((G4TrajectoryPoint*)(trj1->GetPoint( n_points - 1 )))->GetPosition();

--- a/source/physics/src/GateSourceMgr.cc
+++ b/source/physics/src/GateSourceMgr.cc
@@ -553,7 +553,7 @@ G4int GateSourceMgr::PrepareNextEvent( G4Event* event )
 
   G4int numVertices = 0;
 
-  if ( (theMode == 1)  || (theMode == 2) )
+  if ( (theMode == TrackingMode::kBoth)  || (theMode == TrackingMode::kTracker) )
     {
       GateRTPhantomMgr::GetInstance()->UpdatePhantoms(m_time); /* PY Descourt 11/12/2008 */
 
@@ -616,7 +616,7 @@ G4int GateSourceMgr::PrepareNextEvent( G4Event* event )
       mNbOfParticleInTheCurrentRun++;
     } // normal or Tracker Modes
 
-  if ( theMode == 3 ) // detector mode
+  if ( theMode == TrackingMode::kDetector ) // detector mode
     {
       m_currentSources.push_back(m_fictiveSource);
       //G4cout << "GateSourceMgr::PrepareNextEvent :   m_fictiveSource = " << m_fictiveSource << Gateendl;

--- a/source/physics/src/GateVSource.cc
+++ b/source/physics/src/GateVSource.cc
@@ -455,8 +455,9 @@ G4int GateVSource::GeneratePrimaries( G4Event* event )
 
   TrackingMode theMode =myAction->GetMode();
 
-  G4bool test = (theMode ==1 ) || ( theMode == 2 );
-  if ( test == 1  )
+  G4bool test = (theMode == TrackingMode::kBoth ) || ( theMode == TrackingMode::kTracker );
+  //
+  if ( test ) // replace if ( test == TrackingMode::kBoth  ) // mdupont
     {
       if (GetType() == G4String("backtoback"))    { GeneratePrimariesForBackToBackSource(event); }
       else if (GetType() == G4String("fastI124")) { GeneratePrimariesForFastI124Source(event); }
@@ -496,7 +497,7 @@ G4int GateVSource::GeneratePrimaries( G4Event* event )
       return numVertices;
     }// standard or tracker mode PY Descourt 08/09/2008
 
-  if ( theMode == 3 )// detector mode     here we have a fictive source
+  if ( theMode == TrackingMode::kDetector )// detector mode     here we have a fictive source
     {
       if ( fAbortNow == true ) { fAbortNow= false;
         return 0; }
@@ -672,7 +673,7 @@ void GateVSource::GeneratePrimaryVertex( G4Event* aEvent )
 
   /* PY Descourt 08/09/2009 */
   TrackingMode theMode =( (GateSteppingAction *)(GateRunManager::GetRunManager()->GetUserSteppingAction() ) )->GetMode();
-  if (  theMode == kBoth || theMode == kTracker )
+  if (  theMode == TrackingMode::kBoth || theMode == TrackingMode::kTracker )
     {
       G4ThreeVector particle_position;
       if(mIsUserFluenceActive) { particle_position = UserFluencePosGenerateOne(); }
@@ -747,7 +748,7 @@ G4String nameMaterial = material->GetName();*/
   /////  HERE we are in DETECTOR MODE
   /* PY Descourt 08/09/2009 */
 
-  if ( theMode == kDetector )
+  if ( theMode == TrackingMode::kDetector )
     {
       // create a new vertex
       G4PrimaryVertex* vertex =  new G4PrimaryVertex(G4ThreeVector(0.,0.,0.),GetTime());


### PR DESCRIPTION
Very little changes, in order to clean up a bit the code.

Goal: avoid implicit conversion to int (or bool) and ease to find where TrackingMode is used in code.