### PR TITLE
Enable coincidence sorting with generic repeater

### DIFF
--- a/source/digits_hits/src/GateCoincidenceSorter.cc
+++ b/source/digits_hits/src/GateCoincidenceSorter.cc
@@ -512,7 +512,12 @@ G4int GateCoincidenceSorter::ComputeSectorID(const GatePulse& pulse)
     	GateSystemComponent* comp = m_system->GetBaseComponent();
 	G4int depth=0;
 	while (comp){
-	    gkSectorNumber.push_back(comp->GetAngularRepeatNumber());
+	    G4int rep_num = comp->GetAngularRepeatNumber();
+	    if (rep_num == 1)
+	        // Check for generic repeater
+	        rep_num = comp->GetGenericRepeatNumber();
+	    gkSectorNumber.push_back(rep_num);
+
 	    if ( (depth<m_depth) && ( comp->GetChildNumber() == 1)   ){
 	    	comp = comp->GetChildComponent(0);
 		depth++;

--- a/source/geometry/include/GateGenericRepeater.hh
+++ b/source/geometry/include/GateGenericRepeater.hh
@@ -35,6 +35,7 @@ public:
   void SetPlacementsFilename(std::string filename);
   void EnableRelativeTranslation(bool b) { mUseRelativeTranslation = b; }
   void SetPlacementList(std::vector<GatePlacement> l);
+  G4int GetRepeatNumber() { return (G4int)mPlacementsList.size(); };
 
 protected:
   GateGenericRepeaterMessenger* mMessenger; 

--- a/source/geometry/include/GateSystemComponent.hh
+++ b/source/geometry/include/GateSystemComponent.hh
@@ -27,6 +27,7 @@ class G4VPhysicalVolume;
 class GateVolumePlacement;
 class GateLinearRepeater;
 class GateAngularRepeater;
+class GateGenericRepeater;
 class GateSphereRepeater;
 class GateOrbitingMove;
 class GateEccentRotMove;
@@ -292,6 +293,16 @@ class GateSystemComponent  : public GateClockDependent
 
     //@}
 
+
+    //@}
+
+    //! \name Access to the generic repeater properties (if any)
+    //@{
+
+    //! Finds the first generic repeater in the creator's repeater list
+    GateGenericRepeater* FindGenericRepeater();
+    //! Finds the first generic repeater's repeat number
+    G4int GetGenericRepeatNumber();
 
     //@}
 

--- a/source/geometry/src/GateSystemComponent.cc
+++ b/source/geometry/src/GateSystemComponent.cc
@@ -22,6 +22,7 @@
 #include "GateObjectChildList.hh"
 #include "GateLinearRepeater.hh"
 #include "GateAngularRepeater.hh"
+#include "GateGenericRepeater.hh"
 #include "GateSphereRepeater.hh"
 #include "GateSystemComponentList.hh"
 #include "GateObjectRepeaterList.hh"
@@ -659,6 +660,29 @@ G4double GateSystemComponent::GetSphereRadius()
   return repeater ? repeater->GetRadius() : 0.;
 }
 //-------------------------------------------------------------------------------------------
+
+
+
+//-------------------------------------------------------------------------------------------
+// Finds the first generic repeater in the creator's repeater list
+GateGenericRepeater* GateSystemComponent::FindGenericRepeater()
+{
+  return FindRepeater<GateGenericRepeater>();
+}
+//-------------------------------------------------------------------------------------------
+
+
+
+//-------------------------------------------------------------------------------------------
+// Finds the first linear-repeater's repeat number
+G4int GateSystemComponent::GetGenericRepeatNumber()
+{
+  GateGenericRepeater* repeater = FindGenericRepeater();
+  return repeater ? repeater->GetRepeatNumber() : 1;
+}
+//-------------------------------------------------------------------------------------------
+
+
 
 void GateSystemComponent::setInCoincidenceWith(G4String aRsectorName )
 {


### PR DESCRIPTION
Enable sorting coincidences when genericRepeater is used.

Note that the coincidence sorter does not work for combinations of
angularRepeater and genericRepeater for now.

refs #296