### PR TITLE
Remove RPATH for Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ MACRO (DD in)
 ENDMACRO(DD)
 
 #=========================================================
+# Do not use RPATH for Mac, it fails to run Gate when install it
+IF (APPLE)
+  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+ENDIF()
+
+#=========================================================
 # Default build type
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Release CACHE STRING

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,8 +203,10 @@ jobs:
               -DGATE_USE_RTK=$GATE_USE_RTK \
               -DITK_DIR=$(Pipeline.Workspace)/rtk/bin/ \
               -DGATE_USE_OPTICAL=$GATE_USE_OPTICAL \
+              -DBUILD_TESTING=ON \
+              -DBUILDNAME=azure_$(STRATEGY_NAME) \
               ../s
-        make -j4
+        make -j4 test ARGS="-D Nightly"
       else
         echo "Just store cache now"
         echo "Run the CI again to compile Gate"


### PR DESCRIPTION
With make install on MacOS, Gate could not work. Removing RPATH, it works.

According to the answer:
https://stackoverflow.com/a/47699417