### PR TITLE
Update compilation_instructions.rst

### DIFF
--- a/docs/compilation_instructions.rst
+++ b/docs/compilation_instructions.rst
@@ -86,7 +86,7 @@ The goal is here to make Gate use the torch library, an open source machine lear
 
 Pytorch is usually used via a Python module, but here we need an additional library named 'libtorch' that will be used by Gate during compilation.
 
-To download 'libtorch', go to https://pytorch.org at the section QUICK START LOCALLY, and select PyTorch Build stable, Your OS, Package libtorch, Language C++, your CUDA version if you have CUDA installed on your computer or None if you want to use only your CPU (Note: GATE is currently using only CPU with libtorch). Then download the zip file and unziped somewhere on your disk. No compilation required here.
+To download 'libtorch', go to https://pytorch.org at the section QUICK START LOCALLY, and select PyTorch Build stable, Your OS, Package libtorch, Language C++, your CUDA version if you have CUDA installed on your computer or None if you want to use only your CPU (Note: GATE is currently using only CPU with libtorch). Then download the zip file (cxx11 ABI) and unziped somewhere on your disk. No compilation required here.
 
 Then, during the installation of Gate (next section) use the following option to set the path to libtorch ::
 


### PR DESCRIPTION
Tell users to download the cxx11 version of libtorch, otherwise GATE won't compile !