### PR TITLE
Update defining_a_system_scanner_ct_pet_spect_optical.rst

### DIFF
--- a/docs/defining_a_system_scanner_ct_pet_spect_optical.rst
+++ b/docs/defining_a_system_scanner_ct_pet_spect_optical.rst
@@ -76,11 +76,11 @@ where :
    +----------------+--------------------------------+-----------------------------------------------------------------+
    | System         | Components and Shape           | Available Outputs                                               |
    +================+===========+====================+=================================================================+
-   | scanner        | level1    | geometry not fixed | Basic output: ASCII or ROOT, coincidences only for PETscanner   |
-   |                +-----------+                    |                                                                 |
+   | scanner or     | level1    | geometry not fixed | Basic output: ASCII or ROOT. Coincidences are only available    |
+   | PETscanner     +-----------+                    | for the "PETscanner" system                                     |
    |                | level2    |                    |                                                                 |
-   |                +-----------+                    |                                                                 |
-   |                | level3    |                    |                                                                 |
+   |                +-----------+                    | The "level5" key was introduced after Gate v8.2. For Gate v8.2, |
+   |                | level3    |                    | the key layer0 and layer1 were used                             |
    |                +-----------+                    |                                                                 |
    |                | level4    |                    |                                                                 |
    |                +-----------+                    |                                                                 |


### PR DESCRIPTION
Explicit in the system_tab table that "scanner" and "PETscanner" are equivalent system except for the creation of a coincidence. Also added a note about level5 component being not available for Gate v8.2.