### PR TITLE
Debug PhaseSpace writting for multiple slice time

### DIFF
--- a/source/digits_hits/src/GatePhaseSpaceActor.cc
+++ b/source/digits_hits/src/GatePhaseSpaceActor.cc
@@ -111,6 +111,7 @@ GatePhaseSpaceActor::~GatePhaseSpaceActor()
   free(pIAEARecordType);
   pIAEAheader = 0;
   pIAEARecordType = 0;
+  mFile.close();
   delete pMessenger;
   GateDebugMessageDec("Actor", 4, "~GatePhaseSpaceActor() -- end\n");
 }
@@ -693,7 +694,7 @@ void GatePhaseSpaceActor::SaveData()
     fclose(pIAEARecordType->p_file);
   }
   else {
-    mFile.close();
+    mFile.write();
   }
 }
 // --------------------------------------------------------------------

--- a/source/io/include/GateAsciiFile.hh
+++ b/source/io/include/GateAsciiFile.hh
@@ -137,6 +137,7 @@ class GateOutputAsciiTreeFile: public GateAsciiTree, public GateOutputTreeFile
   }
 
   void write_header() override;
+  void write() override;
   void fill() override;
 
 private:

--- a/source/io/include/GateNumpyFile.hh
+++ b/source/io/include/GateNumpyFile.hh
@@ -110,6 +110,7 @@ public:
   void close() override;
 
   void write_header() override ;
+  void write() override ;
   virtual void fill() override;
 
   void write_variable(const std::string &name, const void *p, std::type_index t_index) override;

--- a/source/io/include/GateRootTreeFile.hh
+++ b/source/io/include/GateRootTreeFile.hh
@@ -64,6 +64,7 @@ class GateOutputRootTreeFile: public GateRootTree, public GateOutputTreeFile
   void close() override ;
 
   void write_header() override ;
+  void write() override ;
   virtual void fill() override;
 
 

--- a/source/io/include/GateTreeFile.hh
+++ b/source/io/include/GateTreeFile.hh
@@ -90,6 +90,7 @@ public:
 
   virtual void open(const std::string& s) = 0;
   virtual void write_header() = 0;
+  virtual void write() = 0;
   virtual void fill() = 0;
 
 

--- a/source/io/include/GateTreeFileManager.hh
+++ b/source/io/include/GateTreeFileManager.hh
@@ -61,6 +61,7 @@ public:
   void fill();
   void close();
   void write_header();
+  void write();
 
 
 

--- a/source/io/src/GateAsciiFile.cc
+++ b/source/io/src/GateAsciiFile.cc
@@ -195,6 +195,9 @@ void GateOutputAsciiTreeFile::open(const std::string& s)
   m_file << std::setprecision(10);
 }
 
+void GateOutputAsciiTreeFile::write()
+{ }
+
 void GateOutputAsciiTreeFile::close()
 {
   m_file.close();

--- a/source/io/src/GateNumpyFile.cc
+++ b/source/io/src/GateNumpyFile.cc
@@ -270,8 +270,7 @@ void GateOutputNumpyTreeFile::fill()
   //  cout << "\n";
 }
 
-
-void GateOutputNumpyTreeFile::close()
+void GateOutputNumpyTreeFile::write()
 {
 
   if(!m_file.is_open())
@@ -293,6 +292,15 @@ void GateOutputNumpyTreeFile::close()
       }
     //    throw std::runtime_error("NumpyTreeFile::close: no se");
   }
+}
+
+void GateOutputNumpyTreeFile::close()
+{
+
+  if(!m_file.is_open())
+    return;
+
+  GateOutputNumpyTreeFile::write();
 
   m_file.close();
 }

--- a/source/io/src/GateRootTreeFile.cc
+++ b/source/io/src/GateRootTreeFile.cc
@@ -102,6 +102,11 @@ void GateInputRootTreeFile::open(const std::string& s)
 
 }
 
+void GateOutputRootTreeFile::write()
+{
+  m_file->Write();
+}
+
 void GateRootTree::close()
 {
   m_file->Close();
@@ -110,7 +115,7 @@ void GateRootTree::close()
 
 void GateOutputRootTreeFile::close()
 {
-  m_file->Write();
+  GateOutputRootTreeFile::write();
   GateRootTree::close();
 }
 

--- a/source/io/src/GateTreeFileManager.cc
+++ b/source/io/src/GateTreeFileManager.cc
@@ -85,6 +85,14 @@ void GateOutputTreeFileManager::write_variable(const std::string &name, const in
   }
 }
 
+void GateOutputTreeFileManager::write()
+{
+  for(auto&& f : m_listOfTreeFile)
+  {
+    f->write();
+  }
+}
+
 void GateOutputTreeFileManager::close()
 {
   for(auto&& f : m_listOfTreeFile)


### PR DESCRIPTION
With multiple time slice, the mFile in GatePhaseSpaceActor was close at the end of one time slice instead of write.
So I close the mFile in the destructor and create a write function in GateTreeFile classes

Debug https://github.com/OpenGATE/Gate/issues/341

@fkhellaf , can you run simulation to be sure it works?
@wrzof , are you agree with that PR?

Thank you
