### PR TITLE
GateActorManager: Replace previous SD in SetMultiFunctionalDetector

### DIFF
--- a/source/arf/include/GateARFSD.hh
+++ b/source/arf/include/GateARFSD.hh
@@ -70,6 +70,8 @@ public:
   //! Destructor
   ~GateARFSD();
 
+  GateARFSD* Clone() const override;
+
   //! Method overloading the virtual method Initialize() of G4VSensitiveDetector
   void Initialize(G4HCofThisEvent*HCE);
 

--- a/source/arf/src/GateARFSD.cc
+++ b/source/arf/src/GateARFSD.cc
@@ -79,6 +79,46 @@ GateARFSD::~GateARFSD()
   delete mArfTableMgr;
   }
 
+GateARFSD *GateARFSD::Clone() const
+  {
+  auto clone = new GateARFSD(SensitiveDetectorName, mName);
+  clone->thePathName = thePathName;
+  clone->fullPathName = fullPathName;
+  clone->verboseLevel = verboseLevel;
+  clone->active = active;
+  clone->ROgeometry = ROgeometry;
+  clone->filter = filter;
+
+  clone->mSystem = mSystem;
+  clone->mArfHitCollection = mArfHitCollection;
+  clone->mInserter = mInserter;
+  clone->mFile = mFile;
+  clone->mSinglesTree = mSinglesTree;
+  clone->mNbOfPhotonsTree = mNbOfPhotonsTree;
+  clone->mNbOfSourcePhotons = mNbOfSourcePhotons;
+  clone->mNbOfSimuPhotons = mNbOfSimuPhotons;
+  clone->mNbofGoingOutPhotons = mNbofGoingOutPhotons;
+  clone->mNbofGoingInPhotons = mNbofGoingInPhotons;
+  clone->mNbofStraightPhotons = mNbofStraightPhotons;
+  clone->mNbofStoredPhotons = mNbofStoredPhotons;
+  clone->mNbOfGoodPhotons = mNbOfGoodPhotons;
+  clone->mInCamera = mInCamera;
+  clone->mOutCamera = mOutCamera;
+  clone->mNbOfRejectedPhotons = mNbOfRejectedPhotons;
+  clone->mArfData = mArfData;
+  clone->mProjectionSet = mProjectionSet;
+  clone->mHeadID = mHeadID;
+  clone->mNbOfHeads = mNbOfHeads;
+  clone->mDetectorXDepth = mDetectorXDepth;
+  clone->mEnergyWindows = mEnergyWindows;
+  clone->mEnergyWindowsNumberOfPrimaries = mEnergyWindowsNumberOfPrimaries;
+  clone->mEnergyDepositionThreshold = mEnergyDepositionThreshold;
+  clone->mArfStage = mArfStage;
+  clone->mShortcutARF = mShortcutARF;
+
+  return clone;
+  }
+
 /* Method overloading the virtual method Initialize() of G4VSensitiveDetector */
 void GateARFSD::Initialize(G4HCofThisEvent*HCE)
   {

--- a/source/digits_hits/include/GateCrystalSD.hh
+++ b/source/digits_hits/include/GateCrystalSD.hh
@@ -54,6 +54,8 @@ class GateCrystalSD : public G4VSensitiveDetector
       //! Destructor
       ~GateCrystalSD();
 
+      GateCrystalSD* Clone() const override;
+
       //! Method overloading the virtual method Initialize() of G4VSensitiveDetector
       void Initialize(G4HCofThisEvent*HCE);
 
@@ -78,7 +80,6 @@ class GateCrystalSD : public G4VSensitiveDetector
       GateVSystem* FindSystem(G4String& systemName);
 
       G4int PrepareCreatorAttachment(GateVVolume* aCreator);
-
 
   protected:
      GateVSystem* m_system;                           //! System to which the SD is attached //mhadi_obso obsollete, because we use the multi-system approach

--- a/source/digits_hits/include/GatePhantomSD.hh
+++ b/source/digits_hits/include/GatePhantomSD.hh
@@ -22,6 +22,8 @@ class GatePhantomSD : public G4VSensitiveDetector
       GatePhantomSD(const G4String& name);
       ~GatePhantomSD();
 
+      GatePhantomSD* Clone() const override;
+
       void Initialize(G4HCofThisEvent*HCE);
       G4bool ProcessHits(G4Step*aStep,G4TouchableHistory*ROhist);
       void EndOfEvent(G4HCofThisEvent*HCE);

--- a/source/digits_hits/src/GateActorManager.cc
+++ b/source/digits_hits/src/GateActorManager.cc
@@ -270,9 +270,10 @@ void GateActorManager::SetMultiFunctionalDetector(GateVActor * actor, GateVVolum
       G4String detectorName = "MFD_"+ num.str();
       G4String detectorName2 = "MSD_"+ num.str();
 
-      // Deactivate previously attached SD
-      G4String name = volume->GetLogicalVolume()->GetSensitiveDetector()->GetName().prepend("/gate/");
-      G4SDManager::GetSDMpointer()->Activate(name, false);
+      // Remove attached SD by replacing with a deactivated clone SD
+      G4VSensitiveDetector* replacementSD = volume->GetLogicalVolume()->GetSensitiveDetector()->Clone();
+      G4SDManager::GetSDMpointer()->AddNewDetector(replacementSD);
+      replacementSD->Activate(false);
 
       theListOfMultiSensitiveDetector.push_back(new GateMultiSensitiveDetector(detectorName2));
 

--- a/source/digits_hits/src/GateCrystalSD.cc
+++ b/source/digits_hits/src/GateCrystalSD.cc
@@ -53,6 +53,24 @@ GateCrystalSD::~GateCrystalSD()
 
 
 //------------------------------------------------------------------------------
+GateCrystalSD *GateCrystalSD::Clone() const {
+    auto clone = new GateCrystalSD(SensitiveDetectorName);
+    clone->thePathName = thePathName;
+    clone->fullPathName = fullPathName;
+    clone->verboseLevel = verboseLevel;
+    clone->active = active;
+    clone->ROgeometry = ROgeometry;
+    clone->filter = filter;
+
+    clone->m_system = m_system;
+    clone->m_systemList = m_systemList;
+    clone->crystalCollection = crystalCollection;
+
+    return clone;
+}
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
 // Method overloading the virtual method Initialize() of G4VSensitiveDetector
 void GateCrystalSD::Initialize(G4HCofThisEvent*HCE)
 {

--- a/source/digits_hits/src/GatePhantomSD.cc
+++ b/source/digits_hits/src/GatePhantomSD.cc
@@ -42,6 +42,20 @@ GatePhantomSD::GatePhantomSD(const G4String& name)
 */
 GatePhantomSD::~GatePhantomSD(){;}
 
+GatePhantomSD *GatePhantomSD::Clone() const {
+    auto clone = new GatePhantomSD(SensitiveDetectorName);
+    clone->thePathName = thePathName;
+    clone->fullPathName = fullPathName;
+    clone->verboseLevel = verboseLevel;
+    clone->active = active;
+    clone->ROgeometry = ROgeometry;
+    clone->filter = filter;
+
+    clone->phantomCollection = phantomCollection;
+
+    return clone;
+}
+
 void GatePhantomSD::Initialize(G4HCofThisEvent*HCE)
 {
   static int HCID = -1;


### PR DESCRIPTION
Replace the currently attached SD with a cloned and inactive one. The original and active SD is later used in the multi sensitive detector.

For more detailed information see the commit messages.

This is a rather dirty hack relying on implicit Geant4 behavior. If anyone comes up with a better solution, I will very much appreciate it.

Refs #350, #335