### PR TITLE
Allow storing empty (not null!) pulse lists in the pulse list vector

### DIFF
--- a/source/digits_hits/src/GateDigitizer.cc
+++ b/source/digits_hits/src/GateDigitizer.cc
@@ -169,9 +169,7 @@ void GateDigitizer::StorePulseList(GatePulseList* newPulseList)
   if (newPulseList) {
     if (nVerboseLevel>1)
       G4cout << "[GateDigitizer::StorePulseList]: Storing new pulse-list '" << newPulseList->GetListName() << "'\n";
-       if(newPulseList->size()>0){
     m_pulseListVector.push_back(newPulseList);
-       }
   }
 }
 //-----------------------------------------------------------------


### PR DESCRIPTION
This is to prevent a memory leak, since only stored pulse lists will be
deleted later.

Closes #356

This change works well in my tests, but the line preventing the storage of empty pulse lists was only recently added in commit 3c03c2bc0, so maybe there is some corner case in which empty pulse lists in the pulse list vector lead to problems? Maybe @etxebest has some insight here?