### PR TITLE
Change RadioactiveDecay (Deprecated) to Radioactivation

### DIFF
--- a/source/physics/include/GateRadioactiveDecayPB.hh
+++ b/source/physics/include/GateRadioactiveDecayPB.hh
@@ -14,6 +14,7 @@ See LICENSE.md for further details
 #include "GateVProcess.hh"
 
 #include "G4RadioactiveDecay.hh"
+#include "G4Radioactivation.hh"
 
 MAKE_PROCESS_AUTO_CREATOR(GateRadioactiveDecayPB)
 

--- a/source/physics/src/GateRadioactiveDecayPB.cc
+++ b/source/physics/src/GateRadioactiveDecayPB.cc
@@ -25,7 +25,8 @@ GateRadioactiveDecayPB::GateRadioactiveDecayPB():GateVProcess("RadioactiveDecay"
 //-----------------------------------------------------------------------------
 G4VProcess* GateRadioactiveDecayPB::CreateProcess(G4ParticleDefinition *)
 {
-  return new G4RadioactiveDecay(GetG4ProcessName());
+  //return new G4RadioactiveDecay(GetG4ProcessName());
+  return new G4Radioactivation(GetG4ProcessName());
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
G4RadioactiveDecay is deprecated and will be removed in next version of Geant4

It is recommended to use G4Radioactivation to replace the deprecated code while keeping the old behaviour.