### PR TITLE
Fix issue #346

### DIFF
--- a/source/physics/include/GateScintillation.hh
+++ b/source/physics/include/GateScintillation.hh
@@ -26,6 +26,10 @@ See LICENSE.md for further details
  * or SLOWSCINTILLATIONRISETIME in MaterialPropertiesTable for the current G4Material
  * and set the FiniteRiseTime flag of G4Scintillation consequently.
  *
+ * 2020/10/21: Implementation of IsApplicable has been changed between geant4 10.05 and geant4 10.06 which
+ * made Scintillation not applicable for gamma. Because gamma has a PDGCharge of 0.0. Here we go back to previous
+ * implementation until we find another solution.
+ *
  *
  */
 
@@ -35,7 +39,12 @@ class GateScintillation : public G4Scintillation
   using G4Scintillation::G4Scintillation;
 
 	G4VParticleChange* PostStepDoIt(const G4Track& aTrack, 
-			                const G4Step&  aStep);
+			                const G4Step&  aStep) override ;
+
+  G4bool IsApplicable(
+      const G4ParticleDefinition& aParticleType) override;
+
+
 
 };
 

--- a/source/physics/src/GateScintillation.cc
+++ b/source/physics/src/GateScintillation.cc
@@ -28,4 +28,12 @@ GateScintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep)
 
   return G4Scintillation::PostStepDoIt(aTrack, aStep);
 }
+
+G4bool GateScintillation::IsApplicable(const G4ParticleDefinition &aParticleType)
+{
+  if (aParticleType.GetParticleName() == "opticalphoton") return false;
+  if (aParticleType.IsShortLived()) return false;
+
+  return true;
+}
 //----------------------------------------------------------------------------------------

--- a/source/physics/src/GateScintillationPB.cc
+++ b/source/physics/src/GateScintillationPB.cc
@@ -56,7 +56,12 @@ G4VProcess* GateScintillationPB::CreateProcess(G4ParticleDefinition *)
 //-----------------------------------------------------------------------------
 void GateScintillationPB::ConstructProcess(G4ProcessManager * manager)
 {
-  manager->AddDiscreteProcess(GetProcess());  
+
+  auto ret = manager->AddDiscreteProcess(GetProcess());
+  if(ret < 0)
+  {
+    GateError("Can not add scintillation to particle '" << manager->GetParticleType()->GetParticleName() << "'."   );
+  }
   manager->SetProcessOrderingToLast(GetProcess(), idxAtRest);
   manager->SetProcessOrderingToLast(GetProcess(), idxPostStep);
 }


### PR DESCRIPTION
This pull request aims to fix issue #346.  

Implementation of IsApplicable in GateScintillation to get back behaviour of geant4 10.05.


 IsApplicable has been changed between geant4 10.05 and geant4 10.06 which made Scintillation not applicable for gamma. Because gamma has a PDGCharge of 0.0. Here we go back to previous implementation until we find another solution (ie without bypassing geant4).

 Code in geant4 10.05:

```
 G4bool G4Scintillation::IsApplicable(const G4ParticleDefinition& aParticleType)
 {
        if (aParticleType.GetParticleName() == "opticalphoton") return false;
        if (aParticleType.IsShortLived()) return false;

        return true;
 }
```

 Code in geant4 10.06:

```
 G4bool G4Scintillation::IsApplicable(const G4ParticleDefinition& aParticleType)
 {
        return (aParticleType.GetPDGCharge() == 0.0 ||
 	       aParticleType.IsShortLived()) ? false : true;
 }
```