### PR TITLE
Commit to fix #352.

### DIFF
--- a/source/digits_hits/include/GateDeadTime.hh
+++ b/source/digits_hits/include/GateDeadTime.hh
@@ -94,6 +94,7 @@ private:
   G4double m_bufferSize;  //!< contains the rebirth time.
   std::vector<double> m_bufferCurrentSize;  //!< contains the buffers sizes
   G4int m_bufferMode; //! 0 : DT during writing, 1 : DT if writing AND buffer full
+  G4int m_init_done_run_id;
   GateDeadTimeMessenger *m_messenger;    //!< Messenger
 };
 

--- a/source/digits_hits/src/GateDeadTime.cc
+++ b/source/digits_hits/src/GateDeadTime.cc
@@ -29,6 +29,7 @@ GateDeadTime::GateDeadTime(GatePulseProcessorChain* itsChain, const G4String& it
   m_isParalysable = false;
   m_deadTime = 0;
   m_messenger = new GateDeadTimeMessenger(this);
+  m_init_done_run_id = -1;
 }
 
 
@@ -44,7 +45,7 @@ GateDeadTime::~GateDeadTime()
 
 void GateDeadTime::ProcessOnePulse(const GatePulse* inputPulse, GatePulseList& outputPulseList)
 {
-  static G4int m_init_done_run_id = -1;
+
 
   if (!inputPulse) return;
 


### PR DESCRIPTION
The flag `m_init_done_run_id` was defined as static and did not work for multi system. In this case, one GateDeadTime is created for each system, they can not share the same `m_init_done_run_id`. If they share, `FindLevelsParams` is called only once (for the system which occurs in first pulse).