### PR TITLE
Add link directories in CMakeList for MacOs and HomeBrew

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,12 @@ ELSE()
 ENDIF()
 
 #=========================================================
+#Link lfreetype with Homebrew and Mac
+if(APPLE AND NOT CMAKE_CROSSCOMPILING AND NOT DEFINED ENV{LDFLAGS} AND EXISTS "/usr/local/lib")
+  link_directories("/usr/local/lib")
+endif()
+
+#=========================================================
 # Add the executable, and link it to the Geant4/ROOT/CLHEP/ITK libraries
 ADD_LIBRARY(GateLib OBJECT ${sources} ${headers})
 TARGET_LINK_LIBRARIES(GateLib ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} ${CLHEP_LIBRARIES} ${LIBXML2_LIBRARIES} ${LIBXRL_LIBRARIES} ${LMF_LIBRARY} ${ECAT7_LIBRARY} ${TORCH_LIBRARIES} ${ITK_LIBRARIES} pthread)


### PR DESCRIPTION
Link to lfreetype

With MacOS 11 Big Sur, the link during the compilation of Gate failed with:
```
[100%] Building CXX object CMakeFiles/Gate.dir/Gate.cc.o
[100%] Linking CXX executable Gate
ld: library not found for -lfreetype
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Gate] Error 1
make[1]: *** [CMakeFiles/Gate.dir/all] Error 2
make: *** [all] Error 2
```
libfreetype is installed by Homebrew in /usr/local/lib and detected by Cmake during configuration.
I proposed the solution you can find here https://github.com/opencv/opencv_contrib/issues/1446 and https://github.com/opencv/opencv/blob/3.3.1/cmake/OpenCVCompilerOptions.cmake#L343-L345
Can someone test is with previous version of MacOs, please?
