### PR TITLE
Issue#347 (number of detector heads for a generic repeater)

### DIFF
--- a/source/digits_hits/src/GateToProjectionSet.cc
+++ b/source/digits_hits/src/GateToProjectionSet.cc
@@ -360,6 +360,19 @@ void GateToProjectionSet::RecordBeginOfAcquisition()
 
   // Retrieve the parameters of the repeater (number of heads)
   m_headNb = baseComponent->GetAngularRepeatNumber();
+  if ((size_t) baseComponent->GetGenericRepeatNumber()> m_headNb){
+        if (m_headNb==1){ //No angular repeater
+          m_headNb=baseComponent->GetGenericRepeatNumber();
+          //Number of heads set to generic repeater number
+        }
+        else{
+            G4Exception("GateToProjectionSet::RecordBeginOfAcquisition()",
+                        "SetVerboseToProjectionSetAndInterfile",
+                        FatalException,
+                        "Both angular and generic repeaters were employed");
+        }
+    }
+
   m_headAngularPitch = baseComponent->GetAngularRepeatPitch();
   if (!m_headAngularPitch)
     m_headAngularPitch = 360. * deg;


### PR DESCRIPTION
In order to obtain projection data, the number of detector heads of a system was set to the number of copies built using an angular repeater. If the angular repeater was not employed, the number of heads was set to one. With this modification, the use of a generic repeater is also considered to get the correct number of detector heads.
https://github.com/OpenGATE/Gate/issues/347