### PR TITLE
Update data_output_management.rst

### DIFF
--- a/docs/data_output_management.rst
+++ b/docs/data_output_management.rst
@@ -874,7 +874,7 @@ The LMF format was originally designed for the development of small animal PET s
 Image CT output
 ---------------
 
-The *imageCT* output is a binary matrix of float numbers that stores the simulated CT image and is produced for each time slice::
+The *imageCT* output is a binary matrix of float numbers which stores the *number of Singles per pixel*, and is produced for each time slice::
  
    /gate/output/imageCT/enable
    /gate/output/imageCT/setFileName     test


### PR DESCRIPTION
Adding more detailed description of how the image CT output is created, as discussed in issue #399 