### PR TITLE
In GateEnergySpectrumActor.cc, modify edep to edepEvent to fill the histogram

### DIFF
--- a/source/digits_hits/src/GateEnergySpectrumActor.cc
+++ b/source/digits_hits/src/GateEnergySpectrumActor.cc
@@ -382,7 +382,7 @@ void GateEnergySpectrumActor::EndOfEventAction(const G4Event*)
 {
   GateDebugMessage("Actor", 3, "GateEnergySpectrumActor -- End of Event\n");
   
-    if (edep > 0) {
+    if (edepEvent > 0) {
         if (mEnableEdepHistoFlag){
             pEdep->Fill(edepEvent/MeV, 1);
               //G4cout<<"--------------Post Event Action ------------"<<G4endl;


### PR DESCRIPTION
With edep > 0, it was always false because edep is equal to 0 and the histogram is always empty

(cc @narbor)