### PR TITLE
Fixed: twice saved trees to root output file

### DIFF
--- a/source/digits_hits/src/GateToRoot.cc
+++ b/source/digits_hits/src/GateToRoot.cc
@@ -528,7 +528,7 @@ void GateToRoot::RecordEndOfAcquisition() {
                << m_hfile << " named " << m_hfile->GetName() << Gateendl;
         //  if (m_verboseLevel > 0)
         G4cout << "GateToRoot: ROOT: files writing...\n";
-        m_hfile->Write();
+        m_hfile->Write(0,TObject::kOverwrite);
         //  if (m_verboseLevel > 0)
         G4cout << "GateToRoot: ROOT: files closing...\n";
         if (m_hfile->IsOpen()) { m_hfile->Close(); }
@@ -548,7 +548,7 @@ void GateToRoot::RecordEndOfAcquisition() {
         if (nVerboseLevel > 0)
             G4cout << "GateToRoot: ROOT: files writing...\n";
         //GateMessage("Output", 1, " GateToRoot: ROOT: files writing...\n";);
-        m_hfile->Write();
+        m_hfile->Write(0,TObject::kOverwrite);
 
         if (nVerboseLevel > 0)
             G4cout << "GateToRoot: ROOT: files closing...\n";
@@ -1098,7 +1098,7 @@ void GateToRoot::RecordVoxels(GateVGeometryVoxelStore *voxelStore) {
             }
         }
 
-        voxelsFile->Write();
+        voxelsFile->Write(0,TObject::kOverwrite);
         voxelsFile->Close();
 
         if (m_hfile) m_hfile->cd();


### PR DESCRIPTION
**Problem:**
An output generated by GateToRoot class generates doubled trees.
![doubled_trees_gate_to_root](https://user-images.githubusercontent.com/52705790/109981341-1b379980-7d01-11eb-8b10-7dd6aed858ac.png)


**Solution:**
Set an overwrite option enable by replacing _Write()_ with _Write(0,TObject::kOverwrite)_

This solution solves described problem for all output channels implemented in the GateToRoot.hh file.