### PR TITLE
Update documentation for Gate v9.1

### DIFF
--- a/docs/compilation_instructions.rst
+++ b/docs/compilation_instructions.rst
@@ -1,6 +1,6 @@
 .. _compilation_instructions-label:
 
-Compiling GATE (V9.0)
+Compiling GATE (V9.1)
 =============================
 
 .. contents:: Table of Contents
@@ -12,9 +12,9 @@ Compiling GATE (V9.0)
 Required dependencies
 ----------------
 
-For compiling GATE V9.0, the required dependencies are ::
+For compiling GATE V9.1, the required dependencies are ::
 
-   Geant4 10.06  # including the embedded CLHEP
+   Geant4 10.7.0  # including the embedded CLHEP
    ROOT (ROOT 6.xx) # still required, but it may become optional in the future
    
 
@@ -90,37 +90,37 @@ To download 'libtorch', go to https://pytorch.org at the section QUICK START LOC
 Then, during the installation of Gate (next section) use the following option to set the path to libtorch ::
 
     GATE_USE_TORCH     ON
-    Torch_DIR          /home/YOURNAME/libtorch-1.3.0/share/cmake/Torch
+    Torch_DIR          /home/YOURNAME/libtorch-1.4.0/share/cmake/Torch
     
 In some configuration, the following path should also be set ::
 
     CUDNN_INCLUDE_DIR  /home/YOURNAME/cuda/include
     CUDNN_LIBRARY      /home/YOURNAME/cuda/lib64/libcudnn.so          
 
-We recommend you to use libtorch version 1.4.0 but if you want to use a version greater than 1.7.0, check https://github.com/OpenGATE/Gate/pull/424
+We recommend you to use libtorch version 1.4.0 but if you want to use a version greater than 1.7.0, check https://github.com/OpenGATE/Gate/pull/424 . For example, you can download libtorch with the following links: https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.4.0%2Bcpu.zip or https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.4.0%2Bcpu.zip for Linux systems according to you version of gcc. You can change "1.4.0" in the link by the version you want.
 
-GATE V9.0
+GATE V9.1
 ---------
 
-First, download the GATE sources at this address: https://github.com/OpenGATE/Gate/archive/v9.0.zip
+First, download the GATE sources at this address: https://github.com/OpenGATE/Gate/archive/v9.1.zip
 Unzip the downloaded file::
 
-   unzip Gate-9.0.zip
+   unzip Gate-9.1.zip
 
-Alternatively, if you are familiar with git, then instead of downloading and extracting the tar file, you can also clone the sources from github and check out the *v9.0* release tag.
+Alternatively, if you are familiar with git, then instead of downloading and extracting the tar file, you can also clone the sources from github and check out the *v9.1* release tag.
 
    git clone https://github.com/OpenGATE/Gate.git Gate
    cd Gate
-   git checkout v9.0
+   git checkout v9.1
 
 Create two directories to build and install GATE::
 
-   mkdir gate_v9.0-build
-   mkdir gate_v9.0-install
+   mkdir gate-build
+   mkdir gate-install
 
 Move into the GATE build directory::
 
-   cd gate_v9.0-build
+   cd gate-build
 
 Run ccmake as follows::
 
@@ -158,11 +158,11 @@ Finally, update your environment variables file with the following command lines
 
 * bash or zsh:
 
-   export PATH=/PATH_TO/gate_v9.0-install/bin:$PATH
+   export PATH=/PATH_TO/gate-install/bin:$PATH
 
 * [t]csh
 
-   setenv PATH /PATH_TO/gate_v9.0-install/bin:${PATH}
+   setenv PATH /PATH_TO/gate-install/bin:${PATH}
    
 
 Environment configuration and starting GATE
@@ -175,8 +175,8 @@ This file should be defined as follows:
 * bash or zsh::
 
    source /PATH_TO/root_v6.XX/bin/thisroot.sh
-   source /PATH_TO/geant4.10.06-install/bin/geant4.sh
-   export PATH=$PATH:/PATH_TO/gate_v9.0-install/bin
+   source /PATH_TO/geant4.10.07-install/bin/geant4.sh
+   export PATH=$PATH:/PATH_TO/gate-install/bin
    # the following lines only if you are using an external CLHEP library (and similar for ITK, if you enabled it):
    export PATH=$PATH:/PATH_TO/2.3.4.3/CLHEP/bin
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/PATH_TO/2.3.4.3/CLHEP/lib
@@ -184,19 +184,19 @@ This file should be defined as follows:
 * csh or tcsh::
 
    source /PATH_TO/root_v6.XX/bin/thisroot.csh
-   source /PATH_TO/geant4.10.06-install/bin/geant4.csh
-   setenv PATH ${PATH}:$/PATH_TO/gate_v9.0-install/bin
+   source /PATH_TO/geant4.10.07-install/bin/geant4.csh
+   setenv PATH ${PATH}:$/PATH_TO/gate-install/bin
    # the following lines only if you are using an external CLHEP library (and similar for ITK, if you enabled it):
    setenv PATH ${PATH}:/PATH_TO/2.3.4.3/CLHEP/bin
    setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/PATH_TO/2.3.4.3/CLHEP/lib
 
 Save this file in */PATH_TO/gate_v8.2-install/bin*. Finally, before to start a GATE session::
 
-   source /PATH_TO/gate_v9.0-install/bin/gate_env.sh
+   source /PATH_TO/gate-install/bin/gate_env.sh
 
 In order to save typing, you may want to define an alias for that: include the following line in your *$HOME/.bashrc* or *$HOME/.bash_aliases* file::
 
-   alias gate90='source /PATH_TO/gate_v9.0-install/bin/gate_env.sh'
+   alias gate90='source /PATH_TO/gate-install/bin/gate_env.sh'
 
 (For csh and tcsh the syntax is different but the idea is the same.)
 
@@ -330,14 +330,14 @@ Installation of cluster tools
 jobsplitter
 ~~~~~~~~~~~
 
-Go to /PATH_TO/gate_v9.0/cluster_tools/jobsplitter::
+Go to /PATH_TO/gate_v9.1/cluster_tools/jobsplitter::
 
-   cd /PATH_TO/gate_v9.0/cluster_tools/jobsplitter
+   cd /PATH_TO/gate_v9.1/cluster_tools/jobsplitter
 
 Make sure ROOT and Geant4 environment variables are set::
 
    source /PATH_TO/root_v6.XX/bin/thisroot.sh
-   source /PATH_TO/geant4.10.06-install/bin/geant4.sh
+   source /PATH_TO/geant4.10.07-install/bin/geant4.sh
 
 Compile::
 
@@ -345,16 +345,16 @@ Compile::
 
 Copy the gjs executable file to the correct place::
 
-   cp /PATH_TO/gate_v9.0/cluster_tools/jobsplitter/gjs /PATH_TO/gate_v9.0-install/bin
+   cp /PATH_TO/gate_v9.1/cluster_tools/jobsplitter/gjs /PATH_TO/gate_v9.1-install/bin
 
 filemerger
 ~~~~~~~~~~~
 
-Go to /PATH_TO/gate_v9.0/cluster_tools/filemerger
+Go to /PATH_TO/gate_v9.1/cluster_tools/filemerger
 Make sure ROOT and Geant4 environment variables are set::
 
    source /PATH_TO/root_v6.XX/bin/thisroot.sh
-   source /PATH_TO/geant4.10.06-install/bin/geant4.sh
+   source /PATH_TO/geant4.10.07-install/bin/geant4.sh
 
 Compile::
 
@@ -362,6 +362,6 @@ Compile::
 
 Copy the gjs executable file to the correct place::
 
-   cp /PATH_TO/gate_v9.0/cluster_tools/filemerger/gjm /PATH_TO/gate_v9.0-install/bin
+   cp /PATH_TO/gate_v9.1/cluster_tools/filemerger/gjm /PATH_TO/gate_v9.1-install/bin
 
 

--- a/docs/docker_gate.rst
+++ b/docs/docker_gate.rst
@@ -12,6 +12,16 @@ GATE 9.1 on docker
 
 A docker image for gate version 9.1 is available here: `Click here to download GATE 9.1 on docker <https://hub.docker.com/r/opengatecollaboration/gate>`_
 
+Example to run GATE with Docker on your computer (unix-system):
+--------------------------------------------------------------
+
+We consider you already have the macro in your computer, you can do::
+
+  cd folder/containing/macFolder
+  docker run -i --rm -v $PWD:/APP opengatecollaboration/gate mac/main.mac
+
+You can find more information about the docker image on `github <https://github.com/OpenGATE/Gate/tree/develop/source/docker>`_
+
 Example to install GATE with Docker on Amazon Web Services (AWS) (Amazon Linux machine):
 ---------------------------------------------------------------------------------------
 

--- a/docs/docker_gate.rst
+++ b/docs/docker_gate.rst
@@ -7,10 +7,10 @@ GATE using Docker
    :depth: 15
    :local:
 
-GATE 9.0 on docker
+GATE 9.1 on docker
 ------------------
 
-A docker image for gate version 9.0 is available here: `Click here to download GATE 9.0 on docker <https://hub.docker.com/r/opengatecollaboration/gate>`_
+A docker image for gate version 9.1 is available here: `Click here to download GATE 9.1 on docker <https://hub.docker.com/r/opengatecollaboration/gate>`_
 
 Example to install GATE with Docker on Amazon Web Services (AWS) (Amazon Linux machine):
 ---------------------------------------------------------------------------------------
@@ -31,7 +31,7 @@ Example::
   # log back in
   ssh ec2-user@ec2-"IPv4".eu-west-3.compute.amazonaws.com
   docker info
-  docker run -it opengatecollaboration/gate:8.2
+  docker run -it opengatecollaboration/gate:9.1
   Gate
 
 Example to install GATE with Docker on Amazon Web Services (AWS) (Ubuntu Linux machine):
@@ -49,6 +49,6 @@ Example::
   # to run docker without sudo
   sudo usermod -a -G docker ubuntu # and then log out and back in
   # launch a docker container with GATE
-  docker run -it opengatecollaboration/gate:8.2
+  docker run -it opengatecollaboration/gate:9.1
   Gate
 

--- a/docs/vgate.rst
+++ b/docs/vgate.rst
@@ -21,28 +21,23 @@ vGate stands for Virtual Gate. It is a complete virtual machine running an `Ubun
 
 With vGate you can launch your first GATE simulation in just a few steps! No need to install anything, no need to configure anything, and no time spent to understand compilation and related stuff. A full Linux environment is totally set up to be able to use GATE just by launching a simple command: "Gate".
 
-The following software is installed on this machine:
+The following software is installed on this machine (see this `file <https://github.com/OpenGATE/Gate/blob/develop/source/docker/vGate.sh>`_ for more details):
 
-* Ubuntu LTS 18.04 on Virtual Box (40GB virtual HD)
-* GATE 9.0
-* Geant4 10.06.1
+* Ubuntu LTS 20.04 on Virtual Box (40GB virtual HD)
+* GATE 9.1
+* Geant4 10.7.0
 * GateContrib: a user-oriented public repository of Gate (macros, examples and user contributions)
-* Gate tools
-* Gate exercises
-* Root 6.14.00
-* libtorch cxx11 (cpu) 1.4.0
-* ITK 4.13.1 with Module_RTK=ON (v2.0.0)
+* Root 6.19.02
+* libtorch cxx11 (cpu) 1.7.0
+* ITK with Module_RTK=ON
 * VTK v7.1.0
 * vV 1.4
-* ImageJ (Fiji) 1.52d
-* Visual studio code
-* Jupyter Notebook, Jupyter Lab
-* Python3 libraries: numpy, matplotlib, scipy, pydicom, pandas, SimpleITK, uproot
+* ImageJ (Fiji)
 
 How to get vGATE now?
 ~~~~~~~~~~~~~~~~~~~~~
 
-Go to the `OpenGate collaboration website <http://opengatecollaboration.org/>`_. You will then be able to download the virtual machine under the "Download/vGATE" menu. The direct (google drive) link is `here <https://drive.google.com/file/d/1tbXtq5KU9J8Rn7zo-EXHA6o7TEbcpHUo/view?usp=sharing>`_.
+Go to the `OpenGate collaboration website <http://opengatecollaboration.org/>`_. You will then be able to download the virtual machine under the "Download/vGATE" menu. The direct (google drive) link is `here <https://drive.google.com/file/d/1uM0g6z_VcDv3yQJTKmm641tZTjsbHP85/view?usp=sharing>`_.
 
 Be aware that the file you will download a pretty big (about 10 Gbytes), so if several users are downloading the file at the same time, your download speed will be limited and you will have to be patient.
 
@@ -63,7 +58,7 @@ That's it!
 
 Login credentials are (qwerty keyboard):
 
-* user: gate
+* user: vgate
 * password: virtual
 * ('gate' is sudo)
 


### PR DESCRIPTION
Change Gate version from v9.0 to v9.1
Change Geant4 version from 10.6 to 10.7

Add other information about libtorch

Remaining to do:
- [x] Change version in vgate.rst because the virtual machine version v9.1 is not available yet
- [x] Change version in docker_gate.rst because the docker version v9.1 is not available yet
