### PR TITLE
Fix optical simulation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ GPATH
 GRTAGS
 GTAGS
 .DS_Store
-/.idea/
-/cmake-build-debug/
+-/.idea/
+cmake-build-*
 

--- a/docs/generating_and_tracking_optical_photons.rst
+++ b/docs/generating_and_tracking_optical_photons.rst
@@ -7,12 +7,65 @@ Generating and tracking optical photons
    :depth: 15
    :local:
 
+
+
+
+Important note for Geant4 10.7 and newer
+----------------------------------------
+
+If you compile GATE with Geant4 10.7 or newer, PDG code for optical photon has changed `from 0 (zéro) to -22 <https://geant4.kek.jp/lxr/diff/particles/bosons/src/G4OpticalPhoton.cc?v=10.6.p3;diffval=10.7;diffvar=v>`_
+.
+
+
 Introduction
 ------------
 
-To use the optical photon capabilities of GATE, the **GATE_USE_OPTICAL** variable has to be set to **ON** in the configuration process using ccmake. 
+To use the optical photon capabilities of GATE, the **GATE_USE_OPTICAL** variable has to be set to **ON** in the configuration process using ccmake.
+
+
 
 Before discussing how to use the optical photon tracking, it has to be mentioned that there are a few disadvantages in using optical transport. First, the simulation time will increase dramatically. For example, most scintillators used in PET generate in the order of 10,000 optical photons at 511 keV, which means that approximately 10,000 more particles have to be tracked for each annihilation photon that is detected. Although the tracking of optical photons is relatively fast, a simulation with optical photon tracking can easily be a factor thousand slower than one without. Finally, in order to perform optical simulations, many parameters are needed for the materials and surfaces, some of which may be difficult to determine.
+
+Enabling optical processes in GATE
+----------------------------------
+
+There are two ways to add optical processes in GATE :
+
+Adding manually each processes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The de facto manner to add optical processes on GATE is to manually add each of wanted optical processes, like this::
+
+    /gate/physics/addPhysicsList emlivermore #Standard physics
+    /gate/physics/addProcess OpticalAbsorption
+    /gate/physics/addProcess OpticalRayleigh
+    /gate/physics/addProcess OpticalBoundary
+    /gate/physics/addProcess OpticalMie
+    /gate/physics/addProcess OpticalWLS
+    /gate/physics/addProcess Scintillation
+
+This manner is used in the rest of the documentation.
+
+
+The ``G4OpticalPhysics`` physics list from geant4:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Or you can use the `predefined list ``G4OpticalPhysics`` `list <https://gitlab.cern.ch/geant4/geant4/-/blob/e2d2f9810a9c69a246ddee17ae224bf9d5ac3453/source/physics_lists/builders/include/G4OpticalPhysics.hh>`_ of Geant4::
+
+    /gate/physics/addPhysicsList emlivermore
+    /gate/physics/addPhysicsList optical
+
+This will add all optical processes define in G4OpticalPhysics.
+
+Be careful, GATE also redefined some processes to make them more easy to use or to keep. For example the G4Scintillation process is nore more appliable for gamma in Geant4 10.6, so one have to use GateScintillation version, which is of course not used with the G4OpticalPhysics. To circumvent this, the G4Scintillation can be replaced::
+
+    /gate/physics/addPhysicsList emlivermore
+    /gate/physics/addPhysicsList optical
+    /gate/physics/addProcess  Scintillation
+
+
+
+
 
 Optical Photon Generation
 -------------------------

--- a/source/general/include/GateRunManager.hh
+++ b/source/general/include/GateRunManager.hh
@@ -28,7 +28,6 @@
 #define GateRunManager_h 1
 
 #include "G4RunManager.hh"
-#include "G4VModularPhysicsList.hh"
 #include "GateHounsfieldToMaterialsBuilder.hh"
 
 class GateRunManagerMessenger;
@@ -54,8 +53,6 @@ public:
   //! Initialise only the geometry, to allow the building of the GATE geometry
   void InitGeometryOnly();
 
-  void EnableDecay(bool b) { mEnableDecay = b; }
-
   void InitPhysics();
 
   //! Overload of G4RunManager()::RunInitialisation() that resets the geometry navigator
@@ -67,7 +64,7 @@ public:
 
   bool GetGlobalOutputFlag() { return mGlobalOutputFlag; }
   void EnableGlobalOutput(bool b) { mGlobalOutputFlag = b; }
-  void SetUserPhysicList(G4VModularPhysicsList * m) { mUserPhysicList = m; }
+  void SetUserPhysicList(G4VUserPhysicsList * m) { mUserPhysicList = m; }
   void SetUserPhysicListName(G4String m) { mUserPhysicListName = m; }
 
 private :
@@ -78,9 +75,8 @@ private :
   bool mIsGateInitializationCalled;
   GateHounsfieldToMaterialsBuilder * mHounsfieldToMaterialsBuilder;
   bool mGlobalOutputFlag;
-  G4VModularPhysicsList * mUserPhysicList;
+  G4VUserPhysicsList * mUserPhysicList;
   G4String mUserPhysicListName;
-  bool mEnableDecay;
 };
 //----------------------------------------------------------------------------------------
 

--- a/source/general/src/GateRunManager.cc
+++ b/source/general/src/GateRunManager.cc
@@ -110,6 +110,9 @@ void GateRunManager::InitializeAll() {
                               << " emlivermore_polar"
                               << " empenelope"
                               << " emDNAphysics"
+#ifdef GATE_USE_OPTICAL
+                              << " optical"
+#endif
                               << GatePhysicsList::GetInstance()->GetListOfPhysicsLists());
         }
 

--- a/source/general/src/GateRunManager.cc
+++ b/source/general/src/GateRunManager.cc
@@ -19,20 +19,15 @@
 #include "G4VUserPhysicsList.hh"
 #include "G4VModularPhysicsList.hh"
 #include "G4RegionStore.hh"
+#include "G4Region.hh"
 #include "G4LossTableManager.hh"
 #include "G4EmStandardPhysics.hh"
-#include "G4RadioactiveDecayPhysics.hh"
-#include "G4EmStandardPhysics_option1.hh"
-#include "G4EmStandardPhysics_option2.hh"
-#include "G4EmStandardPhysics_option3.hh"
-#include "G4EmStandardPhysics_option4.hh"
-#include "G4EmStandardPhysicsSS.hh"
-#include "G4EmLowEPPhysics.hh"
-#include "G4EmLivermorePolarizedPhysics.hh"
-#include "G4EmLivermorePhysics.hh"
-#include "G4EmPenelopePhysics.hh"
-#include "G4EmDNAPhysics.hh"
+
+#if (G4VERSION_MAJOR > 9)
+
 #include "G4StepLimiterPhysics.hh"
+
+#endif
 
 //----------------------------------------------------------------------------------------
 GateRunManager::GateRunManager() : G4RunManager() {
@@ -41,7 +36,6 @@ GateRunManager::GateRunManager() : G4RunManager() {
     mIsGateInitializationCalled = false;
     mUserPhysicList = 0;
     mUserPhysicListName = "";
-    mEnableDecay = false;
     EnableGlobalOutput(true);
 }
 //----------------------------------------------------------------------------------------
@@ -84,69 +78,15 @@ void GateRunManager::InitializeAll() {
 
     // Get the build-in physic list if the user ask for it
     // Note the EM-only physic lists has already been build in GatePhysicsList
-
-    // (not very clear why we need to do nothing when name is equal to "")
     if (mUserPhysicListName != "") {
 
+        // Need to be in PreInit state (cheat)
+        G4PhysListFactory *physListFactory = new G4PhysListFactory();
         G4ApplicationState currentState = G4StateManager::GetStateManager()->GetCurrentState();
         G4StateManager::GetStateManager()->SetNewState(G4State_PreInit);
 
-        mUserPhysicList = NULL;
-        if (mUserPhysicListName == "emstandard") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmStandardPhysics());
-        }
-        if (mUserPhysicListName == "emstandard_opt1") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmStandardPhysics_option1());
-        }
-        if (mUserPhysicListName == "emstandard_opt2") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmStandardPhysics_option2());
-        }
-        if (mUserPhysicListName == "emstandard_opt3") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmStandardPhysics_option3());
-        }
-        if (mUserPhysicListName == "emstandard_opt4") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmStandardPhysics_option4());
-        }
-        if (mUserPhysicListName == "emstandard_SS") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmStandardPhysicsSS());
-        }
-        if (mUserPhysicListName == "emLowEP") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmLowEPPhysics());
-        }
-        if (mUserPhysicListName == "emlivermore") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmLivermorePhysics());
-        }
-        if (mUserPhysicListName == "emlivermore_polar") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmLivermorePolarizedPhysics());
-        }
-        if (mUserPhysicListName == "empenelope") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmPenelopePhysics());
-        }
-        if (mUserPhysicListName == "emDNAphysics") {
-            mUserPhysicList = new G4VModularPhysicsList();
-            mUserPhysicList->RegisterPhysics(new G4EmDNAPhysics());
-        }
-
-        if (mUserPhysicList == NULL) {
-            // Need to be in PreInit state (cheat)
-            G4PhysListFactory *physListFactory = new G4PhysListFactory();
-            // Get G4 physics list from the name
-            mUserPhysicList = physListFactory->GetReferencePhysList(mUserPhysicListName);
-        }
-
-        // decay ?
-        if (mEnableDecay)
-            mUserPhysicList->RegisterPhysics(new G4RadioactiveDecayPhysics());
+        // Get G4 physics list from the name
+        mUserPhysicList = physListFactory->GetReferencePhysList(mUserPhysicListName);
 
         // Check if it exists
         if (mUserPhysicList == NULL) {
@@ -190,7 +130,10 @@ void GateRunManager::InitializeAll() {
         GateRunManager::SetUserInitialization(mUserPhysicList);//use inheritance
 
         //To take into account the user cuts (steplimiter and special cuts)
-        mUserPhysicList->RegisterPhysics(new G4StepLimiterPhysics());
+#if (G4VERSION_MAJOR > 9)
+        G4VModularPhysicsList *mUserPhysicListTemp = dynamic_cast<G4VModularPhysicsList *>(mUserPhysicList);
+        mUserPhysicListTemp->RegisterPhysics(new G4StepLimiterPhysics());
+#endif
 
         // Re set the initial state
         G4StateManager::GetStateManager()->SetNewState(currentState);

--- a/source/general/src/GateRunManager.cc
+++ b/source/general/src/GateRunManager.cc
@@ -110,7 +110,7 @@ void GateRunManager::InitializeAll() {
 
         // There are two phys list :
         // - GatePhysicsList::GetInstance() is the one of Gate
-        // - mUserPhysicList : the one created by G4 if user choose a buildin PL.
+        // - mUserListOfPhysicList : the one created by G4 if user choose a buildin PL.
         // the Gate one is used to store/retrieve cuts parameters.
 
         // Consider the e- cut as default (in mm)

--- a/source/general/src/GateRunManager.cc
+++ b/source/general/src/GateRunManager.cc
@@ -23,6 +23,8 @@
 #include "G4LossTableManager.hh"
 #include "G4EmStandardPhysics.hh"
 
+#include "G4RadioactiveDecayPhysics.hh"
+
 #if (G4VERSION_MAJOR > 9)
 
 #include "G4StepLimiterPhysics.hh"
@@ -87,6 +89,9 @@ void GateRunManager::InitializeAll() {
 
         // Get G4 physics list from the name
         mUserPhysicList = physListFactory->GetReferencePhysList(mUserPhysicListName);
+
+        dynamic_cast<G4VModularPhysicsList*>(mUserPhysicList)->RegisterPhysics(new G4RadioactiveDecayPhysics());
+
 
         // Check if it exists
         if (mUserPhysicList == NULL) {

--- a/source/physics/include/GatePhysicsList.hh
+++ b/source/physics/include/GatePhysicsList.hh
@@ -123,7 +123,7 @@ protected:
   G4UserLimits * userlimits;
 
   // Physic list management
-  G4VModularPhysicsList * mUserPhysicList;
+  std::vector<G4VPhysicsConstructor*>  mUserListOfPhysicList;
   //Mixed EM and DNA Physics List
   G4VModularPhysicsList* emPhysicsListMixed;
 

--- a/source/physics/src/GatePhysicsList.cc
+++ b/source/physics/src/GatePhysicsList.cc
@@ -338,9 +338,13 @@ void GatePhysicsList::ConstructPhysicsList(G4String name)
   if (mUserPhysicListName == "emDNAphysics") {
     pl = new G4EmDNAPhysics();
   }
-  if (mUserPhysicListName == "optical") {
+
+#ifdef GATE_USE_OPTICAL
+    if (mUserPhysicListName == "optical") {
     pl = new G4OpticalPhysics();
   }
+#endif
+
 
     if(pl != nullptr)  {
         mUserListOfPhysicList.push_back(pl);

--- a/source/physics/src/GatePhysicsList.cc
+++ b/source/physics/src/GatePhysicsList.cc
@@ -217,13 +217,13 @@ void GatePhysicsList::ConstructProcess()
     }
   else if(mLoadState==1)
     {
-      if (mUserPhysicListName == "") { // if a user physic list is set, transportation is already set
-        AddTransportation();
+      if (mUserListOfPhysicList.empty()) { // if a user physic list is set, transportation is already set
+          AddTransportation();
       }
 
       for(unsigned int i=0; i<GetTheListOfProcesss()->size(); i++)
         (*GetTheListOfProcesss())[i]->ConstructProcess();
-
+//
       //opt->SetVerbose(2);
       if(mDEDXBinning>0)   emPar->SetNumberOfBins(mDEDXBinning);
       if(mLambdaBinning>0) emPar->SetNumberOfBins(mLambdaBinning);
@@ -301,7 +301,7 @@ void GatePhysicsList::ConstructPhysicsList(G4String name)
   mUserPhysicListName = name;
 
   // First, try to create EM only Physic lists
-  G4VPhysicsConstructor * pl = NULL;
+  G4VPhysicsConstructor * pl = nullptr;
   if (mUserPhysicListName == "emstandard") {
     pl = new G4EmStandardPhysics();
   }
@@ -342,11 +342,17 @@ void GatePhysicsList::ConstructPhysicsList(G4String name)
     pl = new G4OpticalPhysics();
   }
 
-  if (pl != NULL) {
-    pl->ConstructParticle();
-    pl->ConstructProcess();
-    //pl->SetVerboseLevel(2);
-    AddTransportation(); // don't forget transportation process.
+    if(pl != nullptr)  {
+        mUserListOfPhysicList.push_back(pl);
+          pl->ConstructParticle();
+          pl->ConstructProcess();
+    }
+
+  if(mUserListOfPhysicList.size() == 1)  {
+      AddTransportation();
+  }
+
+  if (!mUserListOfPhysicList.empty()) {
     GateRunManager::GetRunManager()->SetUserPhysicListName("");
   }
   else {

--- a/source/physics/src/GatePhysicsList.cc
+++ b/source/physics/src/GatePhysicsList.cc
@@ -13,6 +13,7 @@
 #include "GatePhysicsList.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4Hybridino.hh"
+#include "G4ParticleWithCuts.hh"
 #include "G4ProcessManager.hh"
 #include "GatePhysicsListMessenger.hh"
 #include "G4BosonConstructor.hh"
@@ -25,19 +26,40 @@
 #include "G4VPhysicsConstructor.hh"
 #include "G4Region.hh"
 #include "G4RegionStore.hh"
+#include "G4LogicalVolumeStore.hh"
 #include "G4DNAGenericIonsManager.hh"
 #include "G4ParticleTable.hh"
 #include "G4PhysListFactory.hh"
 #include "G4VModularPhysicsList.hh"
+#include "G4ExceptionHandler.hh"
 #include "G4StateManager.hh"
+
+#include "G4EmStandardPhysics.hh"
+#include "G4EmStandardPhysics_option1.hh"
+#include "G4EmStandardPhysics_option2.hh"
+#include "G4EmStandardPhysics_option3.hh"
+#include "G4EmStandardPhysics_option4.hh"
+#include "G4EmStandardPhysicsSS.hh"
+#include "G4EmStandardPhysicsGS.hh"
+#include "G4EmLowEPPhysics.hh"
+#include "G4EmLivermorePolarizedPhysics.hh"
+#include "G4EmLivermorePhysics.hh"
+#include "G4EmPenelopePhysics.hh"
+#include "G4EmDNAPhysics.hh"
 #include "G4LossTableManager.hh"
 #include "G4UAtomicDeexcitation.hh"
 
+#include "GatePhysicsList.hh"
 #include "GateUserLimits.hh"
 #include "GateConfiguration.h"
+#include "GatePhysicsListMessenger.hh"
 #include "GateRunManager.hh"
 #include "GateObjectStore.hh"
 #include "GateMixedDNAPhysics.hh"
+
+#include "G4OpticalPhoton.hh"
+#include "G4OpticalPhysics.hh"
+
 #include "GateParaPositronium.hh"
 #include "GateOrthoPositronium.hh"
 
@@ -276,9 +298,61 @@ void GatePhysicsList::ConstructPhysicsList(G4String name)
     mListOfPhysicsLists += " " ;
   }
 
-  // Physic list will be setup by GateRunManager
   mUserPhysicListName = name;
-  GateRunManager::GetRunManager()->SetUserPhysicListName(mUserPhysicListName);
+
+  // First, try to create EM only Physic lists
+  G4VPhysicsConstructor * pl = NULL;
+  if (mUserPhysicListName == "emstandard") {
+    pl = new G4EmStandardPhysics();
+  }
+  if (mUserPhysicListName == "emstandard_opt1") {
+    pl = new G4EmStandardPhysics_option1();
+  }
+  if (mUserPhysicListName == "emstandard_opt2") {
+    pl = new G4EmStandardPhysics_option2();
+  }
+  if (mUserPhysicListName == "emstandard_opt3") {
+    pl = new G4EmStandardPhysics_option3();
+  }
+  if (mUserPhysicListName == "emstandard_opt4") {
+    pl = new G4EmStandardPhysics_option4();
+  }
+  if (mUserPhysicListName == "emstandard_SS") {
+    pl = new G4EmStandardPhysicsSS();
+  }
+  if (mUserPhysicListName == "emstandard_GS") {
+    pl = new G4EmStandardPhysicsGS();
+  }
+  if (mUserPhysicListName == "emLowEP") {
+    pl = new G4EmLowEPPhysics();
+  }
+  if (mUserPhysicListName == "emlivermore") {
+    pl = new G4EmLivermorePhysics();
+  }
+  if (mUserPhysicListName == "emlivermore_polar") {
+    pl = new G4EmLivermorePolarizedPhysics();
+  }
+  if (mUserPhysicListName == "empenelope") {
+    pl = new G4EmPenelopePhysics();
+  }
+  if (mUserPhysicListName == "emDNAphysics") {
+    pl = new G4EmDNAPhysics();
+  }
+  if (mUserPhysicListName == "optical") {
+    pl = new G4OpticalPhysics();
+  }
+
+  if (pl != NULL) {
+    pl->ConstructParticle();
+    pl->ConstructProcess();
+    //pl->SetVerboseLevel(2);
+    AddTransportation(); // don't forget transportation process.
+    GateRunManager::GetRunManager()->SetUserPhysicListName("");
+  }
+  else {
+    // Set the phys list name. It will be build in GateRunManager.
+    GateRunManager::GetRunManager()->SetUserPhysicListName(mUserPhysicListName);
+  }
 
   // Fluorescence processes
   // - default activation of deexcitation process
@@ -511,21 +585,17 @@ std::vector<GateVProcess*> GatePhysicsList::FindProcess(G4String name)
 void GatePhysicsList::AddProcesses(G4String processname, G4String particle)
 {
   if ( processname == "UHadronElastic")
-      G4Exception( "GatePhysicsList::AddProcesses","AddProcesses", FatalException,
-                   "####### WARNING: 'HadronElastic' process name replace 'UHadronElastic' process name since Geant4 9.5");
-
-  if ((processname == "Decay") or (processname == "RadioactiveDecay")) {
-        GateRunManager::GetRunManager()->EnableDecay(true);
-        return;
-  }
+    G4Exception( "GatePhysicsList::AddProcesses","AddProcesses", FatalException,"####### WARNING: 'HadronElastic' process name replace 'UHadronElastic' process name since Geant4 9.5");
 
   std::vector<GateVProcess *>  process = FindProcess(processname);
   if(process.size()>0)
-      for(unsigned int i=0; i<process.size(); i++) process[i]->CreateEnabledParticle(particle);
-  else {
+    for(unsigned int i=0; i<process.size(); i++) process[i]->CreateEnabledParticle(particle);
+  else
+    {
       GateWarning("Unknown process: "<<processname );
       return;
-  }
+    }
+
 }
 //-----------------------------------------------------------------------------------------
 

--- a/source/physics/src/GatePhysicsList.cc
+++ b/source/physics/src/GatePhysicsList.cc
@@ -15,6 +15,7 @@
 #include "G4Hybridino.hh"
 #include "G4ParticleWithCuts.hh"
 #include "G4ProcessManager.hh"
+
 #include "GatePhysicsListMessenger.hh"
 #include "G4BosonConstructor.hh"
 #include "G4LeptonConstructor.hh"
@@ -48,6 +49,7 @@
 #include "G4EmDNAPhysics.hh"
 #include "G4LossTableManager.hh"
 #include "G4UAtomicDeexcitation.hh"
+#include "G4RadioactiveDecayPhysics.hh"
 
 #include "GatePhysicsList.hh"
 #include "GateUserLimits.hh"
@@ -596,6 +598,15 @@ void GatePhysicsList::AddProcesses(G4String processname, G4String particle)
 {
   if ( processname == "UHadronElastic")
     G4Exception( "GatePhysicsList::AddProcesses","AddProcesses", FatalException,"####### WARNING: 'HadronElastic' process name replace 'UHadronElastic' process name since Geant4 9.5");
+
+    if ((processname == "Decay") or (processname == "RadioactiveDecay")) {
+        G4RadioactiveDecayPhysics p;
+        p.ConstructParticle();
+        p.ConstructProcess();
+        return;
+    }
+
+
 
   std::vector<GateVProcess *>  process = FindProcess(processname);
   if(process.size()>0)


### PR DESCRIPTION
Since commit  0717d057  optical simulation was not compatible with physics list, and EM physics list in particular. 

Aim of this pull request : 
- permits simulation like before 0717d057
- permits to chain physics list like : emlivermore and optical to avoid to add all of the optical processes 

Work to do : 
- [ ] move back all of the physics stuff from GateRunManager to the GatePhysicsList. 
- [ ] avoid multiple calls to ConstructPhysicsList
- [ ] avoid calls to ConstructProcess and ConstructParticle in ConstructPhysicsList

Of course, this pull request has to be tested. 
