### PR TITLE
Provide a way to not use default cut

### DIFF
--- a/source/physics/include/GatePhysicsList.hh
+++ b/source/physics/include/GatePhysicsList.hh
@@ -38,11 +38,16 @@ public:
   struct ParticleCutType {
     G4double gammaCut;
     G4double electronCut;
+    G4bool electronCutDisabledByDefault;
     G4double positronCut;
+    G4bool positronCutDisabledByDefault;
     G4double protonCut;
   };
   typedef std::map<G4String, ParticleCutType> RegionCutMapType;
+  G4bool electronCutDisabledByDefault; // electron cut disabled for all region
+  G4bool positronCutDisabledByDefault; // positron cut disabled for all region
   typedef std::map<G4String, GateUserLimits*> VolumeUserLimitsMapType;
+
 
   // Functions
   static GatePhysicsList *GetInstance() { // static function must be here or icc, not in cc
@@ -81,6 +86,7 @@ public:
   void DefineCuts(G4VUserPhysicsList * phys);
   void DefineCuts() { DefineCuts(this); }
   void SetCutInRegion(G4String particleName, G4String regionName, G4double cutValue);
+  void DisableAllCuts(G4String particleName);
   void SetSpecialCutInRegion(G4String cutType, G4String regionName, G4double cutValue);
   void SetEnergyRangeMinLimit(double val);
   void GetCuts();

--- a/source/physics/include/GatePhysicsList.hh
+++ b/source/physics/include/GatePhysicsList.hh
@@ -37,15 +37,19 @@ public:
   // Types
   struct ParticleCutType {
     G4double gammaCut;
+    G4bool gammaCutDisabledByDefault;
     G4double electronCut;
     G4bool electronCutDisabledByDefault;
     G4double positronCut;
     G4bool positronCutDisabledByDefault;
     G4double protonCut;
+    G4bool protonCutDisabledByDefault;
   };
   typedef std::map<G4String, ParticleCutType> RegionCutMapType;
-  G4bool electronCutDisabledByDefault; // electron cut disabled for all region
-  G4bool positronCutDisabledByDefault; // positron cut disabled for all region
+  G4bool gammaCutDisabledByDefault; // gamma default cut disabled for all region
+  G4bool electronCutDisabledByDefault; // electron default cut disabled for all region
+  G4bool positronCutDisabledByDefault; // positron default cut disabled for all region
+  G4bool protonCutDisabledByDefault; // positron default cut disabled for all region
   typedef std::map<G4String, GateUserLimits*> VolumeUserLimitsMapType;
 
 

--- a/source/physics/include/GatePhysicsListMessenger.hh
+++ b/source/physics/include/GatePhysicsListMessenger.hh
@@ -52,6 +52,9 @@ protected:
   G4UIcmdWithAString * positronCutCmd;
   G4UIcmdWithAString * protonCutCmd;
 
+  G4UIcmdWithoutParameter * electronRemoveCutCmd;
+  G4UIcmdWithoutParameter * positronRemoveCutCmd;
+
   G4UIcmdWithAString * pMaxStepSizeCmd;
   G4UIcmdWithAString * pMaxTrackLengthCmd;
   G4UIcmdWithAString * pMaxToFCmd;

--- a/source/physics/include/GatePhysicsListMessenger.hh
+++ b/source/physics/include/GatePhysicsListMessenger.hh
@@ -52,8 +52,10 @@ protected:
   G4UIcmdWithAString * positronCutCmd;
   G4UIcmdWithAString * protonCutCmd;
 
-  G4UIcmdWithoutParameter * electronRemoveCutCmd;
-  G4UIcmdWithoutParameter * positronRemoveCutCmd;
+  G4UIcmdWithoutParameter * electronRemoveDefaultCutCmd;
+  G4UIcmdWithoutParameter * gammaRemoveDefaultCutCmd;
+  G4UIcmdWithoutParameter * protonRemoveDefaultCutCmd;
+  G4UIcmdWithoutParameter * positronRemoveDefaultCutCmd;
 
   G4UIcmdWithAString * pMaxStepSizeCmd;
   G4UIcmdWithAString * pMaxTrackLengthCmd;

--- a/source/physics/src/GatePhysicsListMessenger.cc
+++ b/source/physics/src/GatePhysicsListMessenger.cc
@@ -134,6 +134,9 @@ void GatePhysicsListMessenger::BuildCommands(G4String base)
   positronCutCmd = new G4UIcmdWithAString(bb,this);
   positronCutCmd->SetGuidance("Set positron production cut for a given region (two parameters 'regionName' and 'cutValue')");
 
+  bb = base + "/Electron/RemoveAllCuts";
+  electronRemoveCutCmd = new G4UIcmdWithoutParameter(bb, this);
+
   bb = base+"/Proton/SetCutInRegion";
   protonCutCmd = new G4UIcmdWithAString(bb,this);
   protonCutCmd->SetGuidance("Set proton production cut for a given region (two parameters 'regionName' and 'cutValue')");
@@ -285,11 +288,16 @@ void GatePhysicsListMessenger::SetNewValue(G4UIcommand* command, G4String param)
     if (command == positronCutCmd) { pPhylist->SetCutInRegion("e+", regionName, cutValue); }
     if (command == protonCutCmd) { pPhylist->SetCutInRegion("proton", regionName, cutValue);}
 
+
+
     if (command == pMaxStepSizeCmd) pPhylist->SetSpecialCutInRegion("MaxStepSize", regionName, cutValue);
     if (command == pMaxToFCmd) pPhylist->SetSpecialCutInRegion("MaxToF", regionName, cutValue);
     if (command == pMinKineticEnergyCmd) pPhylist->SetSpecialCutInRegion("MinKineticEnergy", regionName, cutValue);
     if (command == pMaxTrackLengthCmd) pPhylist->SetSpecialCutInRegion("MaxTrackLength", regionName, cutValue);
     if (command == pMinRemainingRangeCmd) pPhylist->SetSpecialCutInRegion("MinRemainingRange", regionName, cutValue);  }
+
+    if (command == electronRemoveCutCmd) {pPhylist->DisableAllCuts("e-");}
+    if (command == positronCutCmd) {pPhylist->DisableAllCuts("e+");}
 
   if (command == pActivateStepLimiterCmd) pPhylist->mListOfStepLimiter.push_back(param);
   if (command == pActivateSpecialCutsCmd) pPhylist->mListOfG4UserSpecialCut.push_back(param);

--- a/source/physics/src/GatePhysicsListMessenger.cc
+++ b/source/physics/src/GatePhysicsListMessenger.cc
@@ -134,12 +134,22 @@ void GatePhysicsListMessenger::BuildCommands(G4String base)
   positronCutCmd = new G4UIcmdWithAString(bb,this);
   positronCutCmd->SetGuidance("Set positron production cut for a given region (two parameters 'regionName' and 'cutValue')");
 
-  bb = base + "/Electron/RemoveAllCuts";
-  electronRemoveCutCmd = new G4UIcmdWithoutParameter(bb, this);
-
   bb = base+"/Proton/SetCutInRegion";
   protonCutCmd = new G4UIcmdWithAString(bb,this);
   protonCutCmd->SetGuidance("Set proton production cut for a given region (two parameters 'regionName' and 'cutValue')");
+
+  bb = base + "/Gamma/RemoveDefaultCut";
+  gammaRemoveDefaultCutCmd = new G4UIcmdWithoutParameter(bb, this);
+  gammaRemoveDefaultCutCmd->SetGuidance("Remove the default gamma cut for world, and so for any volume");
+  bb = base + "/Electron/RemoveDefaultCut";
+  electronRemoveDefaultCutCmd = new G4UIcmdWithoutParameter(bb, this);
+  electronRemoveDefaultCutCmd->SetGuidance("Remove the default electron cut for world, and so for any volume");
+  bb = base + "/Positron/RemoveDefaultCut";
+  positronRemoveDefaultCutCmd = new G4UIcmdWithoutParameter(bb, this);
+  positronRemoveDefaultCutCmd->SetGuidance("Remove the default positron cut for world, and so for any volume");
+  bb = base + "/Proton/RemoveDefaultCut";
+  protonRemoveDefaultCutCmd = new G4UIcmdWithoutParameter(bb, this);
+  protonRemoveDefaultCutCmd->SetGuidance("Remove the default proton cut for world, and so for any volume");
 
   bb = base+"/SetMaxStepSizeInRegion";
   pMaxStepSizeCmd = new G4UIcmdWithAString(bb,this);
@@ -296,8 +306,10 @@ void GatePhysicsListMessenger::SetNewValue(G4UIcommand* command, G4String param)
     if (command == pMaxTrackLengthCmd) pPhylist->SetSpecialCutInRegion("MaxTrackLength", regionName, cutValue);
     if (command == pMinRemainingRangeCmd) pPhylist->SetSpecialCutInRegion("MinRemainingRange", regionName, cutValue);  }
 
-    if (command == electronRemoveCutCmd) {pPhylist->DisableAllCuts("e-");}
-    if (command == positronCutCmd) {pPhylist->DisableAllCuts("e+");}
+    if (command == electronRemoveDefaultCutCmd) {pPhylist->DisableAllCuts("e-");}
+    if (command == gammaRemoveDefaultCutCmd) {pPhylist->DisableAllCuts("gamma");}
+    if (command == positronRemoveDefaultCutCmd) {pPhylist->DisableAllCuts("e+");}
+    if (command == protonRemoveDefaultCutCmd) {pPhylist->DisableAllCuts("proton");}
 
   if (command == pActivateStepLimiterCmd) pPhylist->mListOfStepLimiter.push_back(param);
   if (command == pActivateSpecialCutsCmd) pPhylist->mListOfG4UserSpecialCut.push_back(param);


### PR DESCRIPTION
Hi, 
in GATE, if no cut are specified by user, default cut (1mm) will propagate from the world to every geometrical region. This cuts concern gamma, electron, positron and proton. 

It can be a source of bug very difficult to fix like the lack of cerenkov photons because of the absence of all possible electrons.

The goal of this pull request is to provide : 

```
/gate/physics/Electron/RemoveDefaultCut
/gate/physics/Gamma/RemoveDefaultCut
/gate/physics/Positron/RemoveDefaultCut
/gate/physics/Proton/RemoveDefaultCut
```

I think we have to keep default cut for retrocompatibility. 