### PR TITLE
Acollinearity in back-to-back source

### DIFF
--- a/source/physics/src/GateBackToBack.cc
+++ b/source/physics/src/GateBackToBack.cc
@@ -54,12 +54,17 @@ void GateBackToBack::GenerateVertex( G4Event* aEvent, G4bool accolinearityFlag)
       G4ThreeVector DirectionPhoton( sin( dev ) * cos( Phi1 ),
                                      sin( dev ) * sin( Phi1 ), cos( dev ) );
       
+      // Scale vector to unit length before rotation, re-scale to original length after rotation:
+      G4double gammaMom_mag = gammaMom.mag();
+      gammaMom = gammaMom.unit();
       DirectionPhoton.rotateUz(gammaMom);
       
-      particle1->SetMomentum( DirectionPhoton.x(),
-                              DirectionPhoton.y(), DirectionPhoton.z() );
-      particle->SetMomentum( -gammaMom.x(),
-                             -gammaMom.y(), -gammaMom.z() );
+      particle1->SetMomentum( gammaMom_mag*DirectionPhoton.x(),
+                              gammaMom_mag*DirectionPhoton.y(),
+                              gammaMom_mag*DirectionPhoton.z() );
+      particle->SetMomentum( -gammaMom_mag*gammaMom.x(),
+                             -gammaMom_mag*gammaMom.y(),
+                             -gammaMom_mag*gammaMom.z() );
       
       /*G4cout<<"gammaMom.x() = "<<gammaMom.x() << Gateendl;
       G4cout<<"gammaMom.y() = "<<gammaMom.y() << Gateendl;

--- a/source/physics/src/GateBackToBack.cc
+++ b/source/physics/src/GateBackToBack.cc
@@ -47,8 +47,12 @@ void GateBackToBack::GenerateVertex( G4Event* aEvent, G4bool accolinearityFlag)
     {
         
       G4ThreeVector gammaMom = particle->GetMomentum();
-      
-      G4double dev = CLHEP::RandGauss::shoot( 0.,m_source->GetAccoValue() / GateConstants::fwhm_to_sigma );
+      G4double accoValue = m_source->GetAccoValue();
+      if (accoValue == 0.0){
+        accoValue = 0.5*pi / 180;
+      }
+    
+      G4double dev = CLHEP::RandGauss::shoot( 0.,accoValue / GateConstants::fwhm_to_sigma );
       G4double Phi1 = ( twopi * G4UniformRand() )/2. ;
       
       G4ThreeVector DirectionPhoton( sin( dev ) * cos( Phi1 ),


### PR DESCRIPTION
I am suggesting a fix for issue #381. The problem seems to be a missing normalisation of a G4ThreeVector before rotation, and a missing default value for acollinearity.