### PR TITLE
Fix uninitialized value, first finding in #480

### DIFF
--- a/source/digits_hits/include/GateCrystalSD.hh
+++ b/source/digits_hits/include/GateCrystalSD.hh
@@ -83,7 +83,7 @@ class GateCrystalSD : public G4VSensitiveDetector
 
   protected:
      GateVSystem* m_system;                           //! System to which the SD is attached //mhadi_obso obsollete, because we use the multi-system approach
-     GateSystemList* m_systemList;                    //! System list instead of one system
+     GateSystemList* m_systemList = nullptr;          //! System list instead of one system
   private:
       GateCrystalHitsCollection * crystalCollection;  //! Hit collection
 


### PR DESCRIPTION
Initialize [`GateCrystalSD::m_systemList`](https://github.com/OpenGATE/Gate/blob/86083caae3a4f41903b3d1e3c3d5571e807e041e/source/digits_hits/include/GateCrystalSD.hh#L86) with `nullptr`.

Currently the member is not initialized. I believe `nullptr` is the right initial value because of [this check](https://github.com/OpenGATE/Gate/blob/86083caae3a4f41903b3d1e3c3d5571e807e041e/source/digits_hits/src/GateCrystalSD.cc#L245).

This fixes a *Conditional jump or move depends on uninitialized value(s)* message by valgrind, the first finding mentioned in #480. To verify that, I ran valgrind for Gate v9.1 (with a configuration that I could probably share if requested)
[without](https://github.com/OpenGATE/Gate/files/7949618/valg-withsupp-orig.txt) and [with](https://github.com/OpenGATE/Gate/files/7949620/valg-withsupp-change1.txt) the proposed change, using the [suppression file](https://github.com/root-project/root/blob/e1e22198f55729f46f81f5274022e287e405ce57/etc/valgrind-root.supp) of the ROOT project. I already removed the PIDs in the attached logs, and compared them with `diff`. The first message in #480 is gone, and apart from that some pointers changed, which I think is irrelevant.
