### PR TITLE
Fix uninitialized value, fourth finding in #480

### DIFF
--- a/source/physics/include/GateSourcePencilBeam.hh
+++ b/source/physics/include/GateSourcePencilBeam.hh
@@ -119,7 +119,7 @@ protected:
   RandGauss * mGaussianEnergy;
   //Others
   bool mTestFlag;
-  double mparticle_time;
+  double mparticle_time = 0.0;
   int mCurrentParticleNumber;
 };
 


### PR DESCRIPTION
Initialize [`GateSourcePencilBeam::mparticle_time`](https://github.com/OpenGATE/Gate/blob/86083caae3a4f41903b3d1e3c3d5571e807e041e/source/physics/include/GateSourcePencilBeam.hh#L122) with 0.0.

Currently the member is not initialized. I have no idea which value should be chosen to initialize it, as I don't know the purpose of this member, 0.0 is just a default guess. **Which value should go here?** Without the proposed change, the program just takes whatever value has been previously stored in that memory location. Surprisingly this has always been the same value in my checks: `22958.0`, which I think is related to the entry `29.958` of some energy table of a cross-section table like [this one](https://github.com/Geant4/geant4/blob/460fe6dfb2fc3b2e509ee3d8ec5aef963a464b05/source/processes/hadronic/models/im_r_matrix/src/G4XNDeltastarTable.cc#L68).

Initializing the variable fixes a *Conditional jump of move depends on uninitialized value(s)* message by valgrind, the
fourth finding mentioned in #480. 
To verify that, I ran valgrind for Gate v9.1 (with a configuration that I could probably share if requested)
[without](https://github.com/OpenGATE/Gate/files/7949765/valg-withsupp-orig.txt) and [with](https://github.com/OpenGATE/Gate/files/7949766/valg-withsupp-change4.txt) the proposed change, using the [suppression file](https://github.com/root-project/root/blob/e1e22198f55729f46f81f5274022e287e405ce57/etc/valgrind-root.supp) of the ROOT project.
I already removed the PIDs in the attached logs, and compared them with `diff`. The forth message in #480 is gone. However there are some other significant differences, e.g. in the now 4th, previously 7th finding *Use of uninitialised value of size 8* in `deflate_fast` (`deflate.c:1849`): 
- The last entry of the backtrace is `TTree::Write(char const*, int, int) const (TTree.cxx:9408)` now, instead of 
- the previous ` TTree::Fill() (TTree.cxx:4533)` of the original Gate v9.1. 

I suspect that the changed initial value really has an effect on the control flow.

See #483 for a fix of the first valgrind finding reported in #480.