### PR TITLE
Solved issue 471

### DIFF
--- a/cluster_tools/filemerger/src/GateMergeManager.cc
+++ b/cluster_tools/filemerger/src/GateMergeManager.cc
@@ -342,11 +342,8 @@ void GateMergeManager::StartCleaning(string splitfileName,bool test){
                cout<<"Please remove it manually!"<<endl;
         }
      }
-     const string rmfiles("rm -f "+dir+"/*");
-     system(rmfiles.c_str());
-     const string rmdir="rm -f -r "+dir;
-     const int res2 = system(rmdir.c_str());
-     if(res2) {
+     const string rmdir="rm -rf "+dir;
+     if(system(rmdir.c_str())) {
             cout<<"Could not remove "<<dir<<endl;
             cout<<"Please remove it manually!"<<endl;
      }


### PR DESCRIPTION
From my tests I didn't receive an error mentioned in the [issue 471](https://github.com/OpenGATE/Gate/issues/471)
I checked it with two versions of g++ (9.3.0 and 7.1.0).

However, the reason why this error can raise is caused by calling system(...) without catching returned value.
What it is interesting is fact that there are unnecessary lines of code - an author of code executes two commands:

`rm -f dir/*`

`rm -f -r dir`

which can be done with one command:

`rm -rf dir`

Because a returned values is only required to check its output (0 - command successed, 1 - command failed) there is no point to assign this output to the variable - instead, it is better to redirect this to if(...).