### PR TITLE
Remove additional hash symbol in txt tree output

### DIFF
--- a/source/io/src/GateAsciiFile.cc
+++ b/source/io/src/GateAsciiFile.cc
@@ -124,7 +124,6 @@ void GateOutputAsciiTreeFile::write_header()
     if( (m_mode & ios_base::out) != ios_base::out )
         throw GateModeFileException("OutputAsciiTreeFile::write_header: file not opened in write mode"); // Should not happen
 
-    m_file << "#";
     uint32_t i = 0;
     for (auto&& d : m_vector_of_pointer_to_data) // access by const reference
     {


### PR DESCRIPTION
There is an additional '#' at the beginning of the unified tree output in txt format. This makes it incompatible with other output formats, because the 'PDGEncoding' column in other formats is called '#PDGEncoding' in txt.

If there is a use for the '#', I would be very interested to hear about it.