### PR TITLE
Fixes of uninitialized variables, part 4/?

### DIFF
--- a/source/digits_hits/include/GateToRoot.hh
+++ b/source/digits_hits/include/GateToRoot.hh
@@ -296,7 +296,6 @@ private:
     G4double nbPrimaries;
     G4double mTimeStop;
     G4double mTimeStart;
-    G4int m_nb_of_hits;
 
     G4double m_positronKinEnergy;
     G4int m_recordFlag;
@@ -331,10 +330,7 @@ private:
     G4double MomentumDirectionx, MomentumDirectiony, MomentumDirectionz;
 // v. cuplov - optical photons
 
-    G4int m_updateROOTmodulo;
     G4bool m_rootHitFlag;
-    G4bool m_rootSingleDigiFlag;
-    G4bool m_rootCoincDigiFlag;
     G4bool m_rootNtupleFlag;
     G4bool m_saveRndmFlag;
     G4bool m_rootOpticalFlag = false;

--- a/source/digits_hits/include/GateToTree.hh
+++ b/source/digits_hits/include/GateToTree.hh
@@ -124,7 +124,7 @@ private:
   G4bool m_hits_enabled;
   G4String m_uselessFileName; //only for GiveNameOfFile which return a reference..
 
-  G4bool m_opticalData_enabled;
+  G4bool m_opticalData_enabled = false;
 
  private:
 

--- a/source/digits_hits/src/GateToRoot.cc
+++ b/source/digits_hits/src/GateToRoot.cc
@@ -93,7 +93,7 @@ ComptonRayleighData &ComptonRayleighData::operator=(const ComptonRayleighData &a
 
 //--------------------------------------------------------------------------
 GateToRoot::GateToRoot(const G4String &name, GateOutputMgr *outputMgr, DigiMode digiMode)
-        : GateVOutputModule(name, outputMgr, digiMode), m_hfile(0), m_treeHit(0), m_updateROOTmodulo(10),
+        : GateVOutputModule(name, outputMgr, digiMode), m_hfile(0), m_treeHit(0),
           m_rootHitFlag(digiMode == kruntimeMode), m_rootNtupleFlag(true), m_saveRndmFlag(true),
           m_fileName(" ") // All default output file from all output modules are set to " ".
         // They are then checked in GateApplicationMgr::StartDAQ, using

--- a/source/general/src/GateClockDependentMessenger.cc
+++ b/source/general/src/GateClockDependentMessenger.cc
@@ -49,8 +49,12 @@ GateClockDependentMessenger::GateClockDependentMessenger(GateClockDependent* its
     pDisableCmd->SetGuidance(guidance.c_str());
     pDisableCmd->SetParameterName("flag",true);
     pDisableCmd->SetDefaultValue(true);
+  } else {
+    pEnableCmd = nullptr;
+    pDisableCmd = nullptr;
   }
-  ARFcmd = 0;
+  ARFcmd = nullptr;
+  AttachARFSDcmd = nullptr;
 }
 //----------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes two issues with variables that were used although they were uninitialized: 
<details><summary><tt>GateToTree::m_opticalData_enabled</tt>, popped up when running valgrind with the benchmark <tt>t6_dpk</tt>.</summary>

```
==3756498== Conditional jump or move depends on uninitialised value(s)
==3756498==    at 0x103DFCB: GateToTree::RecordBeginOfAcquisition() (GateToTree.cc:337)
==3756498==    by 0xF52A12: GateOutputMgr::RecordBeginOfAcquisition() (GateOutputMgr.cc:246)
==3756498==    by 0x10D5640: GateApplicationMgr::StartDAQ() (GateApplicationMgr.cc:364)
==3756498==    by 0x10DB6C6: GateApplicationMgrMessenger::SetNewValue(G4UIcommand*, G4String) (GateApplicationMgrMessenger.cc:190)
==3756498==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756498==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756498==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756498==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756498==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756498==    by 0x104DCAFD: G4UImanager::ExecuteMacroFile(char const*) (G4UImanager.cc:308)
==3756498==    by 0x104D8A2A: G4UIcontrolMessenger::SetNewValue(G4UIcommand*, G4String) (G4UIcontrolMessenger.cc:418)
==3756498==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756498==  Uninitialised value was created by a heap allocation
==3756498==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==3756498==    by 0xF5126A: GateOutputMgr::GateOutputMgr(G4String) (GateOutputMgr.cc:118)
==3756498==    by 0xCE1A76: GateOutputMgr::GetInstance() (GateOutputMgr.hh:87)
==3756498==    by 0xCE0157: main (Gate.cc:309)
```
</details>
<details><summary>Some UI commands in <tt>GateClockDependentMessenger</tt>, found when running valgrind with the benchmark <tt>t5_pet</tt>.</summary>

```
==3756367== Conditional jump or move depends on uninitialised value(s)
==3756367==    at 0x10E20F0: GateClockDependentMessenger::SetNewValue(G4UIcommand*, G4String) (GateClockDependentMessenger.cc:89)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756367==    by 0x104DCAFD: G4UImanager::ExecuteMacroFile(char const*) (G4UImanager.cc:308)
==3756367==    by 0x104D8A2A: G4UIcontrolMessenger::SetNewValue(G4UIcommand*, G4String) (G4UIcontrolMessenger.cc:418)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==  Uninitialised value was created by a heap allocation
==3756367==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==3756367==    by 0x1187032: GateCylindricalPETSystem::GateCylindricalPETSystem(G4String const&) (GateCylindricalPETSystem.cc:36)
==3756367==    by 0x1224EDE: GateSystemListManager::InsertNewSystem(G4String const&) (GateSystemListManager.cc:196)
==3756367==    by 0x1224CDF: GateSystemListManager::CheckScannerAutoCreation(GateVVolume*) (GateSystemListManager.cc:152)
==3756367==    by 0x114E774: GateObjectChildListMessenger::InsertIntoCreator(G4String const&) (GateObjectChildListMessenger.cc:117)
==3756367==    by 0x114E42B: GateObjectChildListMessenger::DoInsertion(G4String const&) (GateObjectChildListMessenger.cc:85)
==3756367==    by 0x1138541: GateListMessenger::SetNewValue(G4UIcommand*, G4String) (GateListMessenger.cc:101)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756367==
==3756367== Conditional jump or move depends on uninitialised value(s)
==3756367==    at 0x10E214A: GateClockDependentMessenger::SetNewValue(G4UIcommand*, G4String) (GateClockDependentMessenger.cc:91)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756367==    by 0x104DCAFD: G4UImanager::ExecuteMacroFile(char const*) (G4UImanager.cc:308)
==3756367==    by 0x104D8A2A: G4UIcontrolMessenger::SetNewValue(G4UIcommand*, G4String) (G4UIcontrolMessenger.cc:418)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==  Uninitialised value was created by a heap allocation
==3756367==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==3756367==    by 0x1187032: GateCylindricalPETSystem::GateCylindricalPETSystem(G4String const&) (GateCylindricalPETSystem.cc:36)
==3756367==    by 0x1224EDE: GateSystemListManager::InsertNewSystem(G4String const&) (GateSystemListManager.cc:196)
==3756367==    by 0x1224CDF: GateSystemListManager::CheckScannerAutoCreation(GateVVolume*) (GateSystemListManager.cc:152)
==3756367==    by 0x114E774: GateObjectChildListMessenger::InsertIntoCreator(G4String const&) (GateObjectChildListMessenger.cc:117)
==3756367==    by 0x114E42B: GateObjectChildListMessenger::DoInsertion(G4String const&) (GateObjectChildListMessenger.cc:85)
==3756367==    by 0x1138541: GateListMessenger::SetNewValue(G4UIcommand*, G4String) (GateListMessenger.cc:101)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756367==
==3756367== Conditional jump or move depends on uninitialised value(s)
==3756367==    at 0x10E2232: GateClockDependentMessenger::SetNewValue(G4UIcommand*, G4String) (GateClockDependentMessenger.cc:98)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756367==    by 0x104DCAFD: G4UImanager::ExecuteMacroFile(char const*) (G4UImanager.cc:308)
==3756367==    by 0x104D8A2A: G4UIcontrolMessenger::SetNewValue(G4UIcommand*, G4String) (G4UIcontrolMessenger.cc:418)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==  Uninitialised value was created by a heap allocation
==3756367==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==3756367==    by 0x1187032: GateCylindricalPETSystem::GateCylindricalPETSystem(G4String const&) (GateCylindricalPETSystem.cc:36)
==3756367==    by 0x1224EDE: GateSystemListManager::InsertNewSystem(G4String const&) (GateSystemListManager.cc:196)
==3756367==    by 0x1224CDF: GateSystemListManager::CheckScannerAutoCreation(GateVVolume*) (GateSystemListManager.cc:152)
==3756367==    by 0x114E774: GateObjectChildListMessenger::InsertIntoCreator(G4String const&) (GateObjectChildListMessenger.cc:117)
==3756367==    by 0x114E42B: GateObjectChildListMessenger::DoInsertion(G4String const&) (GateObjectChildListMessenger.cc:85)
==3756367==    by 0x1138541: GateListMessenger::SetNewValue(G4UIcommand*, G4String) (GateListMessenger.cc:101)
==3756367==    by 0x104C9659: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:262)
==3756367==    by 0x104DE6E4: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:584)
==3756367==    by 0x104DDE71: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==3756367==    by 0x104C4561: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==3756367==    by 0x104C4790: G4UIbatch::SessionStart() (G4UIbatch.cc:230)
==3756367==

```
</details>

Furthermore some unused members of `GateToRoot` were removed.

Related work: #480.