### PR TITLE
Segmentation Violation in ImageRegionalizedVolume

### DIFF
--- a/source/geometry/src/GateImageRegionalizedVolume.cc
+++ b/source/geometry/src/GateImageRegionalizedVolume.cc
@@ -773,7 +773,7 @@ G4double GateImageRegionalizedVolume::DistanceToOut(const G4ThreeVector& p,
 
   // Test if outside given label (surface)
   GateDebugMessage("Volume",8,"\t\tLabel = " << GetImage()->GetValue(index) << Gateendl);
-  if (GetImage()->GetValue(index) != label) {
+  if (index == -1 || GetImage()->GetValue(index) != label) {
     GateDebugMessage("Volume",8,"\t\tInitialisation **OUTSIDE** the region -> return 0.0\n");
 
     /*

--- a/source/geometry/src/GateImageRegionalizedVolume.cc
+++ b/source/geometry/src/GateImageRegionalizedVolume.cc
@@ -1054,14 +1054,25 @@ G4double GateImageRegionalizedVolume::DistanceToOut(const G4ThreeVector& p, Labe
      GateDebugMessage("Volume",6,"Side = " << side << Gateendl);
   */
 
-  int index = GetImage()->GetIndexFromCoordinates(coord);
+  int index = GetImage()->GetIndexFromPosition(p);
+  // If the index is -1, we detected the position being out of bounds in GetIndexFromPosition.
+  // We need to skip any further processing in order to not have invalid memory access
+  // potentially leading to segmentation faults.
+  // According to comments in Geant4 source code, when outside the volume, return 0.
+  if (index == -1) {
+    GateDebugMessage("Volume", 6, "Index out of bounds; DISTANCETOOUT = " << 0.0 << Gateendl);
+    lPreviousD = 0.0;
+    return 0.0;
+  }
+
   LabelType l = (LabelType)GetImage()->GetValue(index);
   GateDebugMessage("Volume",6,"Index = " << index << " la=" << l << Gateendl);
 
+  index = pDistanceMap->GetIndexFromPosition(p);
   // Not on a side
-  if (l == label) {
-    index = pDistanceMap->GetIndexFromPosition(p);
-    G4double d = pDistanceMap->GetValue(index);
+  if (index != -1 && l == label) {
+    G4double d = 0.0;
+    d = pDistanceMap->GetValue(index);
     if (d!=0) {
       lPreviousD = d;
       return d;


### PR DESCRIPTION
These changes fix 2 places in the code of GateImageRegionalizedVolume, which have been found by running valgrind on a voxelized geometry.

First issue is in line 776:
```
==3191477== Invalid read of size 4
==3191477==    at 0x11DA616: GateImageRegionalizedVolume::DistanceToOut(CLHEP::Hep3Vector const&, CLHEP::Hep3Vector const&, bool, bool*, CLHEP::Hep3Vector*, int) (GateImageRegionalizedVolume.cc:776)
==3191477==    by 0x11D5990: GateImageRegionalizedSubVolume::DistanceToOut(CLHEP::Hep3Vector const&, CLHEP::Hep3Vector const&, bool, bool*, CLHEP::Hep3Vector*) const (GateImageRegionalizedSubVolume.hh:107)
==3191477==    by 0x11D52E6: GateImageRegionalizedSubVolumeSolid::DistanceToOut(CLHEP::Hep3Vector const&, CLHEP::Hep3Vector const&, bool, bool*, CLHEP::Hep3Vector*) const (GateImageRegionalizedSubVolumeSolid.cc:123)
==3191477==    by 0xFA074AD: G4NormalNavigation::ComputeStep(CLHEP::Hep3Vector const&, CLHEP::Hep3Vector const&, double, double&, G4NavigationHistory&, bool&, CLHEP::Hep3Vector&, bool&, bool&, G4VPhysicalVolume**, int&) (G4NormalNavigation.cc:248)
==3191477==    by 0xF9FF162: G4Navigator::ComputeStep(CLHEP::Hep3Vector const&, CLHEP::Hep3Vector const&, double, double&) (G4Navigator.cc:855)
==3191477==    by 0xCDBC7CB: G4Transportation::AlongStepGetPhysicalInteractionLength(G4Track const&, double, double, double&, G4GPILSelection*) (G4Transportation.cc:278)
==3191477==    by 0xB1347A3: G4VProcess::AlongStepGPIL(G4Track const&, double, double, double&, G4GPILSelection*) (G4VProcess.hh:467)
==3191477==    by 0xB132EEB: G4SteppingManager::DefinePhysicalStepLength() (G4SteppingManager2.cc:220)
==3191477==    by 0xB12FE56: G4SteppingManager::Stepping() (G4SteppingManager.cc:192)
==3191477==    by 0xB13B437: G4TrackingManager::ProcessOneTrack(G4Track*) (G4TrackingManager.cc:138)
==3191477==    by 0xAE6E3D0: G4EventManager::DoProcessing(G4Event*) (G4EventManager.cc:173)
==3191477==    by 0xAE6EBF9: G4EventManager::ProcessOneEvent(G4Event*) (G4EventManager.cc:335)
==3191477==  Address 0x59ea403c is 4 bytes before a block of size 557,981,952 alloc'd
==3191477==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==3191477==    by 0xD69969: __gnu_cxx::new_allocator<float>::allocate(unsigned long, void const*) (new_allocator.h:111)
==3191477==    by 0xD695B4: std::allocator_traits<std::allocator<float> >::allocate(std::allocator<float>&, unsigned long) (alloc_traits.h:436)
==3191477==    by 0xD68F15: std::_Vector_base<float, std::allocator<float> >::_M_allocate(unsigned long) (stl_vector.h:296)
==3191477==    by 0xD67ECA: std::vector<float, std::allocator<float> >::_M_default_append(unsigned long) (vector.tcc:604)
==3191477==    by 0xD6509E: std::vector<float, std::allocator<float> >::resize(unsigned long) (stl_vector.h:827)
==3191477==    by 0xD64525: GateImageT<float>::Allocate() (GateImageT.icc:31)
==3191477==    by 0x124D0F0: GateVImageVolume::LoadImage(bool) (GateVImageVolume.cc:273)
==3191477==    by 0x11D7369: GateImageRegionalizedVolume::CreateSubVolumes() (GateImageRegionalizedVolume.cc:135)
==3191477==    by 0x11D710D: GateImageRegionalizedVolume::ImageAndTableFilenamesOK() (GateImageRegionalizedVolume.cc:122)
==3191477==    by 0x124C52D: GateVImageVolume::SetHUToMaterialTableFilename(G4String const&) (GateVImageVolume.cc:194)
==3191477==    by 0x125D484: GateVImageVolumeMessenger::SetNewValue(G4UIcommand*, G4String) (GateVImageVolumeMessenger.cc:147)
```

Second issue is in line 1064:
```
==1140311== Invalid read of size 4
==1140311==    at 0x11DB463: GateImageRegionalizedVolume::DistanceToOut(CLHEP::Hep3Vector const&, int) (GateImageRegionalizedVolume.cc:1064)
==1140311==    by 0x11D59D9: GateImageRegionalizedSubVolume::DistanceToOut(CLHEP::Hep3Vector const&) const (GateImageRegionalizedSubVolume.hh:111)
==1140311==    by 0x11D5326: GateImageRegionalizedSubVolumeSolid::DistanceToOut(CLHEP::Hep3Vector const&) const (GateImageRegionalizedSubVolumeSolid.cc:136)
==1140311==    by 0xFA0783A: G4NormalNavigation::ComputeSafety(CLHEP::Hep3Vector const&, G4NavigationHistory const&, double) (G4NormalNavigation.cc:348)
==1140311==    by 0xFA025CD: G4Navigator::ComputeSafety(CLHEP::Hep3Vector const&, double, bool) (G4Navigator.cc:1900)
==1140311==    by 0xFA1C085: G4SafetyHelper::ComputeSafety(CLHEP::Hep3Vector const&, double) (G4SafetyHelper.cc:112)
==1140311==    by 0xC64855A: G4VMultipleScattering::AlongStepDoIt(G4Track const&, G4Step const&) (G4VMultipleScattering.cc:508)
==1140311==    by 0xB1337B2: G4SteppingManager::InvokeAlongStepDoItProcs() (G4SteppingManager2.cc:439)
==1140311==    by 0xB12FEC6: G4SteppingManager::Stepping() (G4SteppingManager.cc:203)
==1140311==    by 0xB13B437: G4TrackingManager::ProcessOneTrack(G4Track*) (G4TrackingManager.cc:138)
==1140311==    by 0xAE6E3D0: G4EventManager::DoProcessing(G4Event*) (G4EventManager.cc:173)
==1140311==    by 0xAE6EBF9: G4EventManager::ProcessOneEvent(G4Event*) (G4EventManager.cc:335)
==1140311==  Address 0x7b2c703c is 4 bytes before a block of size 557,981,952 alloc'd
==1140311==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==1140311==    by 0xD69969: __gnu_cxx::new_allocator<float>::allocate(unsigned long, void const*) (new_allocator.h:111)
==1140311==    by 0xD695B4: std::allocator_traits<std::allocator<float> >::allocate(std::allocator<float>&, unsigned long) (alloc_traits.h:436)
==1140311==    by 0xD68F15: std::_Vector_base<float, std::allocator<float> >::_M_allocate(unsigned long) (stl_vector.h:296)
==1140311==    by 0xD67ECA: std::vector<float, std::allocator<float> >::_M_default_append(unsigned long) (vector.tcc:604)
==1140311==    by 0xD6509E: std::vector<float, std::allocator<float> >::resize(unsigned long) (stl_vector.h:827)
==1140311==    by 0xD64525: GateImageT<float>::Allocate() (GateImageT.icc:31)
==1140311==    by 0xD71642: GateImageT<float>::ReadMHD(G4String) (GateImageT.icc:193)
==1140311==    by 0xD6B8C0: GateImageT<float>::Read(G4String) (GateImageT.icc:67)
==1140311==    by 0x11D8537: GateImageRegionalizedVolume::LoadDistanceMap() (GateImageRegionalizedVolume.cc:205)
==1140311==    by 0x11D6F5D: GateImageRegionalizedVolume::ConstructOwnSolidAndLogicalVolume(G4Material*, bool) (GateImageRegionalizedVolume.cc:107)
==1140311==    by 0x1261FCC: GateVVolume::ConstructGeometry(G4LogicalVolume*, bool) (GateVVolume.cc:194)
```

Both of these are invalid reads caused by an array access with index -1. In rare cases, this can lead to segmentation violations if this part of the memory is not allocated by the same process.

The fix in both cases is to check that the index is -1 before using it. In that case, the queried point is outside the volume and the behavior is adjusted accordingly, returning 0 in those cases.

After this fix, valgrind does not list it anymore, but I observed other weird behavior, where sometimes a simulation will have about 50% of the hit yield from the rest of the simulations. I am currently in the process of checking, if this fix here is the cause or if we have another issue somewhere. It would be very helpful if someone could confirm that these changes make sense or if they could be causing other wrong behavior.