### PR TITLE
Reorganize beginning of documentation

### DIFF
--- a/docs/compilation_instructions.rst
+++ b/docs/compilation_instructions.rst
@@ -1,21 +1,46 @@
 .. _compilation_instructions-label:
 
-Compiling GATE (V9.2)
-=============================
+Compiling GATE V9.2
+=====================
+
 
 .. contents:: Table of Contents
    :depth: 15
    :local:
+   
+  
+This section describes the installation procedure of GATE. This includes three steps:
 
-**IMPORTANT** Before continuing, make sure all required packages are properly installed on your system. See :ref:`package_requirements-label`
+* Install Geant4
+* Install ROOT
+* Install GATE
 
-Required dependencies
-----------------
+This section starts with a brief overview of the recommended configurations, followed by a short introduction to the installation of Geant4, and then explains the installation of GATE itself on Linux.
 
-For compiling GATE V9.2, the required dependencies are ::
+It should be highlighted that features depending on external components (libraries or packages) may only be activated if the corresponding component is installed. It is the user's responsibility to check that these components are installed before activating a feature. Except for Geant4, which is closely related to GATE, the user should refer to the Installation Guide of the external components.
 
-   Geant4 11  # including the embedded CLHEP
-   ROOT (ROOT 6.xx) # still required, but it may become optional in the future
+In addition, you should also install any Geant4 helper you wish to use, especially *OpenGL* if required, before installing Geant4 itself. You can either download the source codes and compile the libraries or download precompiled packages which are available for a number of platform-compiler. If you choose to or have to compile the packages, you will need:
+
+* a C++ compiler (new enough to compile code with the C++11 standard)
+* the GNU version of *make*
+* `CMAKE <https://www.cmake.org>`_ tool (3.3 or newer)
+
+The ROOT data analysis package may also be needed for post-processing or for using the GATE online plotter (enabling the visualization of various simulation parameters and results in real time). ROOT is available for many platforms and a variety of precompiled packages can be found on the `ROOT homepage <http://root.cern.ch/>`_. If your gcc compiler is version 6 or newer, then you should use a recent ROOT 6 release.
+
+The `LMF <http://opengatecollaboration.org/sites/default/files/lmf_v3_0.tar.gz>`_ and `ecat7 <http://www.opengatecollaboration.org/ECAT>`_ packages are also provided on the `GATE <http://www.opengatecollaboration.org>`_ website. They offer the possibility to have different output formats for your simulations. Note that this code is very old and not supported by the Gate collaboration, only provided "as is". With newer compilers you may have to do some minor hacking (for ECAT you may need to add compiler flags to select the C90 standard, for instance).
+      
+      
+
+Direct dependencies of GATE
+---------------------------
+
+
+For compiling GATE V9.2, the required dependencies are
+  
+* Geant4 11 (available in http://geant4.web.cern.ch/geant4/support/download.shtml), but remains backward compatible with 10.7 also. 
+* ROOT (ROOT 6.xx) # still required, but it may become optional in the future
+   
+Geant4 needs to be compiled. ROOT is avalaible as binary on some platform (or has to be compiled)
    
 
 Optional packages ::
@@ -26,7 +51,16 @@ Optional packages ::
    LMF
    libTorch # see section below
    
+   
+Packages required in order to compile dependencies and GATE
+-----------------------------------------------------------
 
+Compiling software usually requires certain system libraries and compilation tools. Furthermore, GATE and Geant4 have various package requirements which have to be met BEFORE installing or compiling. 
+
+Please find instructions here : :ref:`package_requirements-label`. Adapt instructions to your platform.
+   
+
+   
 CLHEP
 -----
 

--- a/docs/gatert.rst
+++ b/docs/gatert.rst
@@ -1,11 +1,9 @@
 .. _gatert-label:
 
 GateRT
-======
+------
 
-.. contents:: Table of Contents
-   :depth: 15
-   :local:
+
 
 Some examples could be found here : https://davidsarrut.pages.in2p3.fr/gate-exercices-site/
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -5,10 +5,7 @@ Getting started
    :maxdepth: 1
    :numbered:
 
-   introduction
    installation
-   package_requirements
    compilation_instructions
    validating_installation
-   gatert
    enabling_lut_davis_model

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Welcome to GATE's documentation!
 .. toctree::
    :maxdepth: 2
 
+   introduction
    general
    general_concept
    imaging_applications

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,88 +7,23 @@ Installation Guide V9.2
    :depth: 15
    :local:
 
-General Information about GATE
-------------------------------
+How to retrieve GATE
+--------------------
 
-The GATE mailing list
-~~~~~~~~~~~~~~~~~~~~~
+There are several ways to get a working GATE installation on your computer depending on your system and your needs. 
 
-You are encouraged to participate in the dialog and post your suggestion or even implementation on the
-Gate-users mailing list, the GATE mailing list for users.
-You can subscribe to the Gate-users mailing list, by `signing up to the gate-users mailing list <http://lists.opengatecollaboration.org/mailman/listinfo/gate-users>`_.
+For macOS users, you can install pre-compiled version of GATE (via MacPorts) or you can compile it (:ref:`compilation_instructions-label`). 
 
-If you have a question, it is possible that it has been asked and answered before, and stored in the `archives <http://lists.opengatecollaboration.org/pipermail/gate-users/>`_.
-These archives are public and are indexed by the usual search engines. By starting your Google search string with *site:lists.opengatecollaboration.org* you'll get list of all matches of your search on the gate-users mailing list, e.g. `site:lists.opengatecollaboration.org pencilbeam <https://www.google.com/search?q=site%3Alists.opengatecollaboration.org+pencilbeam>`_.
+For linux users, you can use docker version (no compilation), singularity (from docker, no compilation) or you can compile it. 
 
-The GATE project on GitHub
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+For windows, we provide vGATE, an complete virtual machine which runs ubuntu with GATE already installed. 
 
-GATE project is now publicly available on `GitHub <https://github.com/OpenGATE/Gate>`_. You can use this to:
 
-* Check out the bleeding edge development version
-* Report bugs by creating a new `issue <https://github.com/OpenGATE/Gate/issues>`_. (If you are not entirely sure that what you are reporting is indeed a bug in Gate, then please first check the `gate-users mailing list <http://lists.opengatecollaboration.org/mailman/listinfo/gate-users>`_.)
-* Contribute to Gate by changing the source code to fix bugs or implement new features:
+Without compilation
+-------------------
 
-  * Get a (free) account on GitHub, if you do not have one already.
-  * `Install Git <https://git-scm.com/download/linux>`_ on the computer where you do your development, if it has not yet been installed already. And make sure to configure git `with your name <https://help.github.com/articles/setting-your-username-in-git/>`_ and `with your email address <https://help.github.com/articles/setting-your-commit-email-address-in-git/>`_.
-  * Start by `making a fork <https://help.github.com/articles/fork-a-repo/>`_ of the GATE public repository (click the "Fork" button in the upper right corner on the `Gate main page <https://github.com/OpenGATE/Gate/>`_ on GitHub.
-  * Note that we use the *develop* branch to collect all the bleeding edge developments and the *master* to track the releases. In the future we may merge these two, and use only *master*, like it's done in most other projects on GitHub. Releases are defined using "tags".
-  * Then clone your own fork: *git clone https://github.com/YOUR_USERNAME/Gate.git* to get the code on the computer that you will use to develop and compile Gate.
-  * Make a new branch, dedicated to the bugfix or new feature that want to implement in Gate. You can either create the branch first on GitHub and then *git pull* it to your clone, or create it directly in your clone and *git push* it later. Make sure that your branch is based on the *develop* branch. Note that after creating your branch you also need to check it out.
-  * With *git branch -l* you can check which branches are available in your clone and which one is currently checked out. With *git checkout <branchname>* you can change between branches. Be careful not to do this when you still have uncommitted changes (unless you deliberately want to undo those changes).
-  * Now: implement your bugfix or your new feature and *commit* your changes to your new branch. It's usually better to make many small commits than a single big one (though it is of course also desirable that every commit leaves the code in a compilable state). Please provide `concise but informative commit messages <https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53>`_ ! Use *git push* to upload your commits to (your fork on) GitHub. This facilitates developing on multiple machines and also avoids loss of time and effort in the unfortunate event of a hardware failure.
-  * If you are working for a longer time on your fix or new feature, like a few days, weeks or even months, then it is important to make sure to `keep your fork in sync with the upstream repository <https://help.github.com/articles/syncing-a-fork/>`_.
-  * Once you are convinced that your code is OK, make sure it's all pushed to your fork on GitHub. Then:
-
-    1) Create a `pull-request <https://help.github.com/articles/using-pull-requests/>`_ from the branch on your Gate repository to the official Gate repository
-    2) Provide an example that tests your new feature
-    3) If you implemented a new feature, have the associated documentation ready
-    4) Inform these three people from the collaboration (Sebastien Jan, David Sarrut and David Boersma) who will then get in touch with you to integrate your changes in the official repository.
-
-  * For your next bugfix or new feature you do not need to make a new fork, you can use the existing one. But before doing any new work you should make sure to `synchronize <https://help.github.com/articles/syncing-a-fork/>`_ the *develop* branch in your fork with the "upstream" (main) *develop* branch:
-
-    1) Check your "remote repositories" with *git remote -v*
-    2) The "origin" repository should be your own fork on GitHub, *https://github.com/YOUR_USERNAME/Gate*.
-    3) The "upstream" repository should be the main Gate one, that is *https://github.com/OpenGATE/Gate*.
-    4) If your clone does not yet have an "upstream", then add it with *git remote add upstream https://github.com/OpenGATE/Gate*.
-    5) Run *git status* to make sure that you checked out the *develop* branch, and *git pull* to make sure that it is in sync with your fork on GitHub and that there no uncommitted edits.
-    6) Then run *git fetch upstream*, followed by *git merge upstream/develop*.
-    7) Now you are ready to create new branches for new bugfixes and features.
-
-* For more detailed references, recipes, and tutorials on git: please check the web. When copypasting commands, remember that in Gate the "develop" branch currently plays the role of the "master" branch. Our "master" branch is used to track the releases. You will not find the latest bleeding edge code on it. We may change this policy in the near future, to be more conforming to the predominant conventions.
-
-Installing GATE on Linux
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-This section describes the installation procedure of GATE. This includes three steps:
-
-* Install Geant4
-* Install ROOT
-* Install GATE
-
-This section starts with a brief overview of the recommended configurations, followed by a short introduction to the installation of Geant4, and then explains the installation of GATE itself on Linux.
-
-It should be highlighted that features depending on external components (libraries or packages) may only be activated if the corresponding component is installed. It is the user's responsibility to check that these components are installed before activating a feature. Except for Geant4, which is closely related to GATE, the user should refer to the Installation Guide of the external components.
-
-In addition, you should also install any Geant4 helper you wish to use, especially *OpenGL* if required, before installing Geant4 itself. You can either download the source codes and compile the libraries or download precompiled packages which are available for a number of platform-compiler. If you choose to or have to compile the packages, you will need:
-
-* a C++ compiler (new enough to compile code with the C++11 standard)
-* the GNU version of *make*
-* `CMAKE <https://www.cmake.org>`_ tool (3.3 or newer)
-
-The ROOT data analysis package may also be needed for post-processing or for using the GATE online plotter (enabling the visualization of various simulation parameters and results in real time). ROOT is available for many platforms and a variety of precompiled packages can be found on the `ROOT homepage <http://root.cern.ch/>`_. If your gcc compiler is version 6 or newer, then you should use a recent ROOT 6 release.
-
-The `LMF <http://opengatecollaboration.org/sites/default/files/lmf_v3_0.tar.gz>`_ and `ecat7 <http://www.opengatecollaboration.org/ECAT>`_ packages are also provided on the `GATE <http://www.opengatecollaboration.org>`_ website. They offer the possibility to have different output formats for your simulations. Note that this code is very old and not supported by the Gate collaboration, only provided "as is". With newer compilers you may have to do some minor hacking (for ECAT you may need to add compiler flags to select the C90 standard, for instance).
-
-Package Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-Compiling software usually requires certain system libraries and compilation tools.
-Furthermore, GATE and Geant4 have various package requirements which have to be met BEFORE installing or compiling.
-Currently lists have been created for Ubuntu 14.04 (and newer) and SuSE Leap 42.3. Visit the :ref:`package_requirements-label` page for detailed package lists.
-
-Installing with MacPorts on OS X
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing with MacPorts (macOS users only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 GATE can be installed on Mac OS X by following the previous installation instruction on Linux. An alternative way is to install Gate via MacPorts (http://www.macports.org/) with::
 
@@ -100,22 +35,28 @@ Apart from the `Gate` command this also installs a standalone app::
 
 (Thanks Mojca Miklavec for this contribution).
 
-GATE compilation and installation
----------------------------------
 
-Recommended configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~
+With Docker
+~~~~~~~~~~~
 
-For the 9.2 release, the recommended configuration is the following:
+See :ref:`docker_gate-label`
 
-* Geant4 11 (available in http://geant4.web.cern.ch/geant4/support/download.shtml), but remains backward compatible with 10.7 also. 
-* The `GateRTion 1.0 <http://opengatecollaboration.org/GateRTion>`_ release, which is very similar to Gate 8.1, can *only* be built with Geant4 10.03.p03.
-* CMake minimal version: 3.3 (with SSL support)
 
-Compilation instructions
-~~~~~~~~~~~~~~~~~~~~~~~~
+With Singularity
+~~~~~~~~~~~~~~~~
 
-:ref:`compilation_instructions-label`
+To be written
+
+Via virtual machine
+~~~~~~~~~~~~~~~~~~~
+
+See :ref:`vgate-label`
+
+Compiling GATE (macOS, unix and linux users)
+----------------------------------------------
+
+
+See dedicated page : :ref:`compilation_instructions-label`
 
 Validating Installation
 -----------------------

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -116,3 +116,60 @@ Chapter 10 draws the architecture of a simulation. Data output are described in
 Chapter 11. Finally, Chapter 12 gives the principal material definitions
 available in GATE. Chapter 13 illustrates the interactive, bathc, or cluster
 modes of running GATE.
+
+The GATE mailing list
+---------------------
+
+
+You are encouraged to participate in the dialog and post your suggestion or even implementation on the
+Gate-users mailing list, the GATE mailing list for users.
+You can subscribe to the Gate-users mailing list, by `signing up to the gate-users mailing list <http://lists.opengatecollaboration.org/mailman/listinfo/gate-users>`_.
+
+If you have a question, it is possible that it has been asked and answered before, and stored in the `archives <http://lists.opengatecollaboration.org/pipermail/gate-users/>`_.
+These archives are public and are indexed by the usual search engines. By starting your Google search string with *site:lists.opengatecollaboration.org* you'll get list of all matches of your search on the gate-users mailing list, e.g. `site:lists.opengatecollaboration.org pencilbeam <https://www.google.com/search?q=site%3Alists.opengatecollaboration.org+pencilbeam>`_.
+
+
+
+The GATE project on GitHub
+--------------------------
+
+
+GATE project is now publicly available on `GitHub <https://github.com/OpenGATE/Gate>`_. You can use this to:
+
+* Check out the bleeding edge development version
+* Report bugs by creating a new `issue <https://github.com/OpenGATE/Gate/issues>`_. (If you are not entirely sure that what you are reporting is indeed a bug in Gate, then please first check the `gate-users mailing list <http://lists.opengatecollaboration.org/mailman/listinfo/gate-users>`_.)
+* Contribute to Gate by changing the source code to fix bugs or implement new features:
+
+  * Get a (free) account on GitHub, if you do not have one already.
+  * `Install Git <https://git-scm.com/download/linux>`_ on the computer where you do your development, if it has not yet been installed already. And make sure to configure git `with your name <https://help.github.com/articles/setting-your-username-in-git/>`_ and `with your email address <https://help.github.com/articles/setting-your-commit-email-address-in-git/>`_.
+  * Start by `making a fork <https://help.github.com/articles/fork-a-repo/>`_ of the GATE public repository (click the "Fork" button in the upper right corner on the `Gate main page <https://github.com/OpenGATE/Gate/>`_ on GitHub.
+  * Note that we use the *develop* branch to collect all the bleeding edge developments and the *master* to track the releases. In the future we may merge these two, and use only *master*, like it's done in most other projects on GitHub. Releases are defined using "tags".
+  * Then clone your own fork: *git clone https://github.com/YOUR_USERNAME/Gate.git* to get the code on the computer that you will use to develop and compile Gate.
+  * Make a new branch, dedicated to the bugfix or new feature that want to implement in Gate. You can either create the branch first on GitHub and then *git pull* it to your clone, or create it directly in your clone and *git push* it later. Make sure that your branch is based on the *develop* branch. Note that after creating your branch you also need to check it out.
+  * With *git branch -l* you can check which branches are available in your clone and which one is currently checked out. With *git checkout <branchname>* you can change between branches. Be careful not to do this when you still have uncommitted changes (unless you deliberately want to undo those changes).
+  * Now: implement your bugfix or your new feature and *commit* your changes to your new branch. It's usually better to make many small commits than a single big one (though it is of course also desirable that every commit leaves the code in a compilable state). Please provide `concise but informative commit messages <https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53>`_ ! Use *git push* to upload your commits to (your fork on) GitHub. This facilitates developing on multiple machines and also avoids loss of time and effort in the unfortunate event of a hardware failure.
+  * If you are working for a longer time on your fix or new feature, like a few days, weeks or even months, then it is important to make sure to `keep your fork in sync with the upstream repository <https://help.github.com/articles/syncing-a-fork/>`_.
+  * Once you are convinced that your code is OK, make sure it's all pushed to your fork on GitHub. Then:
+
+    1) Create a `pull-request <https://help.github.com/articles/using-pull-requests/>`_ from the branch on your Gate repository to the official Gate repository
+    2) Provide an example that tests your new feature
+    3) If you implemented a new feature, have the associated documentation ready
+    4) Inform these three people from the collaboration (Sebastien Jan, David Sarrut and David Boersma) who will then get in touch with you to integrate your changes in the official repository.
+
+  * For your next bugfix or new feature you do not need to make a new fork, you can use the existing one. But before doing any new work you should make sure to `synchronize <https://help.github.com/articles/syncing-a-fork/>`_ the *develop* branch in your fork with the "upstream" (main) *develop* branch:
+
+    1) Check your "remote repositories" with *git remote -v*
+    2) The "origin" repository should be your own fork on GitHub, *https://github.com/YOUR_USERNAME/Gate*.
+    3) The "upstream" repository should be the main Gate one, that is *https://github.com/OpenGATE/Gate*.
+    4) If your clone does not yet have an "upstream", then add it with *git remote add upstream https://github.com/OpenGATE/Gate*.
+    5) Run *git status* to make sure that you checked out the *develop* branch, and *git pull* to make sure that it is in sync with your fork on GitHub and that there no uncommitted edits.
+    6) Then run *git fetch upstream*, followed by *git merge upstream/develop*.
+    7) Now you are ready to create new branches for new bugfixes and features.
+
+* For more detailed references, recipes, and tutorials on git: please check the web. When copypasting commands, remember that in Gate the "develop" branch currently plays the role of the "master" branch. Our "master" branch is used to track the releases. You will not find the latest bleeding edge code on it. We may change this policy in the near future, to be more conforming to the predominant conventions.
+
+
+.. include:: gatert.rst
+
+
+

--- a/docs/package_requirements.rst
+++ b/docs/package_requirements.rst
@@ -1,15 +1,14 @@
+:orphan:
+
 .. _package_requirements-label:
 
-Package Requirements
-====================
+Installation of required dependendencies on some specific platforms
+===================================================================
 
-.. contents:: Table of Contents
-   :depth: 15
-   :local:
 
 *Note: some of this information may be out of date for the 8.1 release.*
 
-Compiling software usually requires certain system libraries and compilation tools. Furthermore, GATE and Geant4 have various package requirements which have to be met BEFORE installing or compiling. Visit the Package Requirements page for detailed package lists. This list may change frequently, last update: Dec. 31 2015
+ This list may change frequently, last update: Dec. 31 2015
 
 Ubuntu 18.04.2 LTS (for GATE v8.2 w/ Geant4 10.5 p01)
 -----------------------------------------------------
@@ -79,49 +78,7 @@ Note: In the event a package does not exist in the Ubuntu repository, you can se
 
 **GATE benchmark results here** http://www.opengatecollaboration.org/PETBenchmark **appears to be outdated.**
 
-Ubuntu 11.x
------------
 
-Use::
-
-   sudo apt-get update
-   sudo apt-get install <packages here>
-
-to install the packages. Replace <packages here> with the correct packages.
-
-The following packages are required::
-
-  build-essential autoconf automake tcl tk g++ libglu1-mesa-dev libxt-dev libxmu-dev gfortran libxaw7-dev
-  libX11-dev libxft-dev libxpm-dev libxt-dev freeglut3 freeglut3-dev x11proto-print-dev libmudflap0 po-debconf
-  libusb-dev libboost-dev libtool libc6-dev graphviz graphviz-dev libxext-dev libpcre3-dev libglew1.5-dev libfftw3-dev
-  libftgl-dev graphviz-dev libgsl0-dev libkrb5-dev libssl-dev libxml2-dev libldap2-dev libavahi-compat-libdnssd-dev
-  libncurses5-dev libglu1-mesa-dev libcfitsio3-dev libmotif4 libmotif-dev libxml2 libxml2-dev libqt4-opengl
-  libqt4-opengl-dev libgl1-mesa-dev libglw1-mesa-dev libxpm4 libxerces-c3-dev libqt4-core qt4-qmake libqt4-dev
-  libgtkgl2.0-dev libgtkglarea-cil-dev liblablgl-ocaml-dev liblablgl-ocaml libxerces-c-dev libxerces-c3.1
-  libxmltooling-dev happycoders-libsocket-dev happycoders-libsocket libvtk5.6 libvtk5-dev libglui-dev libfftw3-3 libxt-dev
-  libfftw3-dev libfftw3-doc
-
-Ubuntu 10.04
-------------
-
-Use::
-
-   sudo apt-get update
-   sudo apt-get install <packages here>
-
-to install the packages. Replace <packages here> with the correct packages.
-
-The following packages are required::
-
-  build-essential autoconf automake tcl tk g++ libglu1-mesa-dev libxt-dev libxmu-dev gfortran libxaw7-dev
-  libX11-dev libxft-dev libxpm-dev libxt-dev freeglut3 freeglut3-dev libglut3 libglut3-dev  x11proto-print-dev
-  libmudflap0 po-debconf libusb-dev libboost-dev libtool libc6-dev graphviz graphviz-dev libxext-dev libpcre3-dev
-  libglew1.5-dev libfftw3-dev libftgl-dev graphviz-dev libgsl0-dev libkrb5-dev libssl-dev libxml2-dev libldap2-dev
-  libavahi-compat-libdnssd-dev libncurses5-dev libglu1-mesa-dev libcfitsio3-dev libmotif-dev libxml2 libxml2-dev
-  libqt4-opengl libqt4-opengl-dev libgl1-mesa-dev libglw1-mesa-dev libxpm4 libxerces-c3-dev libqt4-core qt4-qmake
-  libqt4-dev libgtkgl2.0-dev libgtkglarea-cil-dev liblablgl-ocaml-dev liblablgl-ocaml libxerces-c-dev libxerces-c3.1
-  libxmltooling-dev libvtk5.2 libvtk5-dev libmotif3 happycoders-libsocket-dev happycoders-libsocket libfftw3-3  libxt-dev
-  libfftw3-dev libfftw3-doc
 
 Fedora
 ------


### PR DESCRIPTION
I propose some changes in the documentation: 

- move Introduction from "getting started" to top
- move "The GATE mailing list" and "The GATE project on GitHub" from "Installation Guide" to Introduction
- emphasis possibility to retrieve binary version of gate : mention docker and vgate in installation section. 
- remove instruction for very old ubuntu
- move GateRT to introduction (even if I dont fully understand the purpose of this section)