### PR TITLE
Fix uninitialized GatePhysicsList::gammaCutDisabledByDefault etc.

### DIFF
--- a/source/physics/include/GatePhysicsList.hh
+++ b/source/physics/include/GatePhysicsList.hh
@@ -46,10 +46,10 @@ public:
     G4bool protonCutDisabledByDefault;
   };
   typedef std::map<G4String, ParticleCutType> RegionCutMapType;
-  G4bool gammaCutDisabledByDefault; // gamma default cut disabled for all region
-  G4bool electronCutDisabledByDefault; // electron default cut disabled for all region
-  G4bool positronCutDisabledByDefault; // positron default cut disabled for all region
-  G4bool protonCutDisabledByDefault; // positron default cut disabled for all region
+  G4bool gammaCutDisabledByDefault = false; // gamma default cut disabled for all region
+  G4bool electronCutDisabledByDefault = false; // electron default cut disabled for all region
+  G4bool positronCutDisabledByDefault = false; // positron default cut disabled for all region
+  G4bool protonCutDisabledByDefault = false; // positron default cut disabled for all region
   typedef std::map<G4String, GateUserLimits*> VolumeUserLimitsMapType;
 
 


### PR DESCRIPTION
Applying Valgrind to the current develop branch of GATE and the `t4_necr` benchmark (modified `/gate/application/setTimeSlice` and `/gate/application/setTimeStop` to make it run faster), some messages like
```
==556418== Conditional jump or move depends on uninitialised value(s)
==556418==    at 0x12062AF: GatePhysicsList::DefineCuts(G4VUserPhysicsList*) (GatePhysicsList.cc:848)
==556418==    by 0x120E596: GatePhysicsList::DefineCuts() (GatePhysicsList.hh:91)
==556418==    by 0x120186F: GatePhysicsList::ConstructProcess() (GatePhysicsList.cc:242)
==556418==    by 0xACFC2E2: G4VUserPhysicsList::Construct() (G4VUserPhysicsList.hh:334)
==556418==    by 0xACF9713: G4RunManagerKernel::InitializePhysics() (G4RunManagerKernel.cc:703)
==556418==    by 0xACE8B85: G4RunManager::InitializePhysics() (G4RunManager.cc:741)
==556418==    by 0x1072C95: GateRunManager::InitializeAll() (GateRunManager.cc:150)
==556418==    by 0x10756B8: GateRunManagerMessenger::SetNewValue(G4UIcommand*, G4String) (GateRunManagerMessenger.cc:45)
==556418==    by 0x108494BF: G4UIcommand::DoIt(G4String) (G4UIcommand.cc:277)
==556418==    by 0x108608ED: G4UImanager::ApplyCommand(char const*) (G4UImanager.cc:585)
==556418==    by 0x10860067: G4UImanager::ApplyCommand(G4String const&) (G4UImanager.cc:481)
==556418==    by 0x10843C8D: G4UIbatch::ExecCommand(G4String const&) (G4UIbatch.cc:182)
==556418==  Uninitialised value was created by a heap allocation
==556418==    at 0x4C36833: operator new(unsigned long) (vg_replace_malloc.c:417)
==556418==    by 0xBDD3B5: GatePhysicsList::GetInstance() (GatePhysicsList.hh:61)
==556418==    by 0xBDB619: main (Gate.cc:288)
```
show up. They indicate that `GatePhysicsList::gammaCutDisabledByDefault`, `electronCutDisabledByDefault`, `positronCutDisabledByDefault`, `protonCutDisabledByDefault` are uninitialized when they are used in `GatePhysicsList::DefineCuts`. With a debugger I verified that they actually never written to. Grepping the source code, I think the variables can only be written to by having `GatePhysicsList::DisableAllCuts` set them true. I propose to initialize them with `false`

There are some additional messages about illegal reads in destructors, which are not covered in this PR.

Related to #480.