### PR TITLE
Generate docker image for Gate v9.2

### DIFF
--- a/source/docker/DockerFileGeant
+++ b/source/docker/DockerFileGeant
@@ -6,7 +6,7 @@
 #push: docker push opengatecollaboration/geant4:10.6.1
 #interactive: docker run -it --rm -v $PWD:/APP opengatecollaboration/geant4:10.6.1 /bin/bash
 
-FROM centos:8
+FROM rockylinux:8
 ARG ROOT_Version=v6-19-02
 ARG CLHEP_Version=2.4.4.1
 ARG Geant4_Version=v10.6.1
@@ -43,7 +43,7 @@ RUN mkdir software/clhep \
  && wget -q $CLHEP_URL \
  && tar -zxf $CLHEP_File -C ./src --strip-components=1 \
  && cd bin \
- && cmake -DCMAKE_INSTALL_PREFIX=/software/clhep/install ../src/CLHEP \
+ && cmake -DCMAKE_CXX_FLAGS=-std=c++17 -DCMAKE_INSTALL_PREFIX=/software/clhep/install ../src/CLHEP \
  && cmake --build . -- -j \
  && cmake --build . --target install \
  && cd .. \
@@ -63,6 +63,7 @@ RUN mkdir software/geant4 \
                   -DGEANT4_USE_OPENGL_X11=ON \
                   -DGEANT4_USE_SYSTEM_CLHEP=ON \
                   -DCLHEP_ROOT_DIR=/software/clhep/install \
+                  -DGEANT4_BUILD_MULTITHREADED=OFF \
  && make -j install \
  && cd .. \
  && rm -rf bin src
@@ -74,7 +75,7 @@ RUN mkdir software/ITK \
  && mkdir src bin \
  && git clone https://github.com/InsightSoftwareConsortium/ITK.git src \
  && cd bin \
- && cmake ../src/ -DCMAKE_CXX_FLAGS:STRING=-std=c++11 \
+ && cmake ../src/ -DCMAKE_CXX_FLAGS:STRING=-std=c++17 \
                   -DBUILD_DOCUMENTATION=OFF \
                   -DBUILD_EXAMPLES=OFF \
                   -DBUILD_TESTING=OFF \
@@ -90,7 +91,13 @@ RUN mkdir software/root-cern \
  && mkdir src bin install \
  && git clone --branch $ROOT_Version https://github.com/root-project/root.git src \
  && cd bin \
- && cmake ../src/ -Dpython=OFF \
+ && cmake ../src/ -DCMAKE_CXX_STANDARD=17 \
+                  -DCXX_STANDARD_STRING=17 \
+                  -Dpython=OFF \
+                  -Dxrootd=OFF \
+                  -Dbuiltin_xrootd=OFF \
+                  -Dbuiltin_openssl=OFF \
+                  -Dssl=OFF \
                   -DCMAKE_INSTALL_PREFIX=/software/root-cern/install \
  && make -j install \
  && cd .. \

--- a/source/docker/Generate-9.2.sh
+++ b/source/docker/Generate-9.2.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+#Variables to modify
+Repository=opengatecollaboration
+ROOT_Version=v6-24-06
+CLHEP_Version=2.4.5.1
+Geant4_Version=11.0.0
+Gate_Version=9.2
+
+#Variables to preserve
+Geant4_Tag=$Repository/geant4:$Geant4_Version
+Gate_Tag=$Repository/gate:$Gate_Version-docker
+
+docker build -t $Geant4_Tag -f DockerFileGeant \
+    --build-arg ROOT_Version=$ROOT_Version \
+    --build-arg CLHEP_Version=$CLHEP_Version \
+    --build-arg Geant4_Version=v$Geant4_Version .
+docker push $Geant4_Tag
+
+docker build -t $Gate_Tag -f DockerFileGate \
+    --build-arg Geant4_Version=$Geant4_Tag \
+    --build-arg Gate_Version=v$Gate_Version .
+docker push $Gate_Tag

--- a/source/docker/README.md
+++ b/source/docker/README.md
@@ -10,7 +10,7 @@ login: `docker login`
 
 [build and use]
 * build: 
-    * `docker build -t opengatecollaboration/geant4:10.6.1 -f DockerFileGeant --build-arg ROOT_Version=v6-19-02 --build-arg Geant4_Version=v10.6.1 .`
+    * `docker build -t opengatecollaboration/geant4:11.0.0 -f DockerFileGeant --build-arg ROOT_Version=v6-24-06 --build-arg Geant4_Version=v11.0.0 .`
 * push: 
     * `docker push opengatecollaboration/geant4:$version`
 * interactive: 
@@ -18,7 +18,7 @@ login: `docker login`
 
 Where: 
 
-* `$version` is `10.6.1` for gate `9.0`
+* `$version` is `11.0.0` for gate `9.2`
 
 # Second image Gate
 ## Docker for gate
@@ -29,7 +29,7 @@ login: `docker login`
 
 [build and use]
 * build: 
-    * `docker build -t opengatecollaboration/gate:9.0 -f DockerFileGate --build-arg Geant4_Version=opengatecollaboration/geant4:10.6.1 --build-arg Gate_Version=v9.0 .`
+    * `docker build -t opengatecollaboration/gate:9.2 -f DockerFileGate --build-arg Geant4_Version=opengatecollaboration/geant4:11.0.0 --build-arg Gate_Version=v9.2 .`
 * push:  
     * `docker push opengatecollaboration/gate:$version`
 * run command:  
@@ -41,4 +41,4 @@ You can just install docker and then create an alias in your configuration
 * ```echo "alias Gate='docker run -i --rm -v $PWD:/APP opengatecollaboration/gate:$version'" >> ~/.bashrc```
 
 Where: 
-* `$version=9.0`
+* `$version=9.2`


### PR DESCRIPTION
Updated scripts to generate the docker image for Gate 9.2

I needed to change from centos to rockylinux because centos is not supported anymore:
https://www.how2shout.com/linux/centos-8-linux-alternatives/