### PR TITLE
Delete actors at the end of the simulation

### DIFF
--- a/source/digits_hits/include/GateActorManager.hh
+++ b/source/digits_hits/include/GateActorManager.hh
@@ -106,6 +106,7 @@ public:
 protected:
   //std::vector<GateMultiSensitiveDetector*> theListOfMultiSensitiveDetector;
   std::vector<GateVActor*> theListOfActors;
+  std::vector<GateVActor*> theListOfOwnedActors;
   std::vector<GateVActor*> theListOfActorsEnabledForBeginOfRun;
   std::vector<GateVActor*> theListOfActorsEnabledForEndOfRun;
   std::vector<GateVActor*> theListOfActorsEnabledForBeginOfEvent;


### PR DESCRIPTION
Revert 12dd4c4f4267d10cda6ee6bed70ac869c903b28e This commit was already a revert (due to issue #155). In this commit, the destructor only delete actors which are not given to MultiFonctionalDetctor.