### PR TITLE
Readout modifications

### DIFF
--- a/source/digits_hits/include/GateReadout.hh
+++ b/source/digits_hits/include/GateReadout.hh
@@ -18,9 +18,10 @@ See LICENSE.md for further details
 #include "GateVPulseProcessor.hh"
 #include "GateVSystem.hh"
 #include "GateArrayComponent.hh"
+#include "GateObjectStore.hh"
 
-#define READOUT_POLICY_WINNER 0
-#define READOUT_POLICY_CENTROID 1
+//#define READOUT_POLICY_WINNER 0
+//#define READOUT_POLICY_CENTROID 1
 
 class GateReadoutMessenger;
 class GateOutputVolumeID;
@@ -58,7 +59,23 @@ class GateReadout : public GateVPulseProcessor
     inline void  SetDepth(G4int aDepth)         { m_depth = aDepth; }
 
     //! Set the policy of the readout
-    void SetPolicy(const G4String& aPolicy);
+    inline void SetPolicy(const G4String& aPolicy)  { m_policy = aPolicy; };
+    inline G4String GetPolicy() const  	      	{ return m_policy; }
+
+    //! Set the volume for the readout
+    inline void SetVolumeName(const G4String& aName) { m_volumeName = aName; };
+    inline G4String GetVolumeName() const  	      	{ return m_volumeName; }
+
+    //! Set how the resulting positions should be defined
+    inline void SetResultingXY(const G4String& aString) { m_resultingXY= aString;};
+    inline G4String GetResultingXY() const  	      	{ return m_resultingXY; };
+
+    inline void SetResultingZ(const G4String& aString){m_resultingZ= aString;};
+    inline G4String GetResultingZ() const  	      	{ return m_resultingZ; };
+
+
+    void SetReadoutParameters();
+
 
   protected:
     //! Implementation of the pure virtual method declared by the base class GateVPulseProcessor
@@ -69,6 +86,8 @@ class GateReadout : public GateVPulseProcessor
     //! Overload the virtual (not pure) method of GateVPulseProcessor
     GatePulseList* ProcessPulseList(const GatePulseList* inputPulseList);
 
+
+
   private:
     //! The default is the one parameter that defines how a readout works:
     //! pulses will be summed up if their volume IDs are identical up to this depth.
@@ -77,7 +96,8 @@ class GateReadout : public GateVPulseProcessor
     G4int m_depth;
 
     //! S. Stute: add an option to choose the policy of the readout (using two define integers; see the beginning of this file)
-    G4int m_policy;
+    //G4int m_policy;
+    G4String m_policy;
     GateVSystem* m_system;
     G4int m_nbCrystalsX;
     G4int m_nbCrystalsY;
@@ -87,6 +107,15 @@ class GateReadout : public GateVPulseProcessor
     G4int m_crystalDepth;
     GateArrayComponent* m_crystalComponent;
 
+    G4String m_volumeName;
+
+    G4String m_resultingXY;
+    G4String m_resultingZ;
+    G4bool   m_IsFirstEntrance;//Entrance
+
+    std::vector<int> numberOfComponentForLevel; //!< Table of number of element for each geometric level
+    G4int numberOfHigherLevels ;  //!< number of geometric level higher than the one chosen by the user
+    G4int numberOfLowerLevels ;  //!< number of geometric level higher than the one chosen by the user
     GateReadoutMessenger *m_messenger;	  //!< Messenger for this readout
 };
 

--- a/source/digits_hits/include/GateReadoutMessenger.hh
+++ b/source/digits_hits/include/GateReadoutMessenger.hh
@@ -45,6 +45,11 @@ class GateReadoutMessenger: public GatePulseProcessorMessenger
   private:
     G4UIcmdWithAnInteger*      SetDepthCmd;
     G4UIcmdWithAString*        SetPolicyCmd;
+    G4UIcmdWithAString*        SetVolNameCmd;
+    G4UIcmdWithAString*		   SetResultingXYCmd;
+    G4UIcmdWithAString*        SetResultingZCmd;
+
+
 };
 
 #endif

--- a/source/digits_hits/src/GateReadout.cc
+++ b/source/digits_hits/src/GateReadout.cc
@@ -18,6 +18,7 @@ See LICENSE.md for further details
 #include "GateArrayComponent.hh"
 #include "GateVSystem.hh"
 
+//class GateVSystem;
 /*
   S. Stute - June 2014: complete redesign of the readout module and add a new policy to emulate PMT.
     - Fix bug in choosing the maximum energy pulse.We now have some temporary lists of variables to deal
@@ -34,15 +35,21 @@ See LICENSE.md for further details
       with global position, we can fall between two crystals in the presence of gaps).
       The depth is ignored with this strategy; it is forced to be at one level above the 'crystal' level.
       If there a 'layer' level below the 'crystal' level, an energy winner strategy is adopted.
+
+  O. Kochebina - April 2022: new messenger options are added and some minor bugs corrected
 */
 
 GateReadout::GateReadout(GatePulseProcessorChain* itsChain,
       	      	      	 const G4String& itsName)
   : GateVPulseProcessor(itsChain,itsName),
-    m_depth(1),
-    m_policy(READOUT_POLICY_WINNER)
+    m_depth(0),
+	m_policy("TakeEnergyWinner"),
+	m_IsFirstEntrance(1)
 {
-  m_messenger = new GateReadoutMessenger(this);
+
+	//G4cout<<"GateReadout::GateReadout"<<Gateendl;
+
+	m_messenger = new GateReadoutMessenger(this);
   // S. Stute: These variables are used for the energy centroid strategy
   m_nbCrystalsX  = -1;
   m_nbCrystalsY  = -1;
@@ -52,6 +59,9 @@ GateReadout::GateReadout(GatePulseProcessorChain* itsChain,
   m_systemDepth  = -1;
   m_system = NULL;
   m_crystalComponent = NULL;
+
+  //G4cout<<"GateReadout::GateReadout "<< m_policy<<Gateendl;
+
 }
 
 GateReadout::~GateReadout()
@@ -59,49 +69,103 @@ GateReadout::~GateReadout()
   delete m_messenger;
 }
 
-void GateReadout::SetPolicy(const G4String& aPolicy)
+void GateReadout::SetReadoutParameters()
 {
-  if (aPolicy=="TakeEnergyWinner") m_policy = READOUT_POLICY_WINNER;
-  else if (aPolicy=="TakeEnergyCentroid")
-  {
-    // Find useful stuff for centroid based computation
-    m_policy = READOUT_POLICY_CENTROID;
-    // Get the system
-    GateVSystem* m_system = this->GetChain()->GetSystem();
-    if (m_system==NULL) G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
-                                   "Failed to get the system corresponding to that processor chain. Abort.\n");
-    // Get the array component corresponding to the crystal level using the name 'crystal'
-    GateArrayComponent* m_crystalComponent = m_system->FindArrayComponent("crystal");
-    if (m_crystalComponent==NULL) G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
+	//checking the if depth or readoutVolumeName are defined and that only one is set.
+	if(!m_volumeName.empty() && m_depth!=0)
+		GateError("***ERROR*** You can choose readout parameter either with /setDepth OR /setReadoutVolume but not both!");
+
+	 //////////////DEPTH SETTING/////////
+	 //set the previously default value for compatibility of users macros
+	 if(m_volumeName.empty() && m_depth==0)
+		 m_depth=1;
+
+	 //set m_depth according user defined volume name
+	 if(!m_volumeName.empty())
+	 	 {
+
+		 	 GateVSystem* m_system = this->GetChain()->GetSystem();
+		 	 if (m_system==NULL) G4Exception( "GateReadout::SetReadoutParameters", "SetReadoutParameters", FatalException,
+	  	  	                                   "Failed to get the system corresponding to that processor chain. Abort.\n");
+
+		 	 m_systemDepth = m_system->GetTreeDepth();
+
+		 	 GateObjectStore* anInserterStore = GateObjectStore::GetInstance();
+		 	 for (G4int i=1;i<m_systemDepth;i++)
+		 	 {
+		 		 GateSystemComponent* comp0= (m_system->MakeComponentListAtLevel(i))[0][0];
+		 		 GateVVolume *creator = comp0->GetCreator();
+		 		 GateVVolume* anInserter = anInserterStore->FindCreator(m_volumeName);
+
+		 		 if(creator==anInserter)
+		 			 m_depth=i;
+
+	  	   }
+	  	}
+
+
+	 //////////////Resulting positioning SETTING/////////
+	 //previously default conditions for compatibility of users macros
+	 if(m_resultingXY.empty() && m_resultingZ.empty() && m_policy =="TakeEnergyCentroid")
+	 {
+		 m_resultingXY="crystalCenter";
+		 m_resultingZ="crystalCenter";
+	 }
+	 if (m_resultingXY.empty() && m_resultingZ.empty() && m_policy =="TakeEnergyWinner")
+	 {
+		 m_resultingXY="exactPostion";
+		 m_resultingZ="exactPostion";
+	 }
+
+
+	if (m_policy=="TakeEnergyCentroid")
+	{
+		// Find useful stuff for centroid based computation
+		//m_policy = "TakeEnergyCentroid";
+		// Get the system
+		GateVSystem* m_system = this->GetChain()->GetSystem();
+		if (m_system==NULL) G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
+				"Failed to get the system corresponding to that processor chain. Abort.\n");
+		// Get the array component corresponding to the crystal level using the name 'crystal'
+		GateArrayComponent* m_crystalComponent = m_system->FindArrayComponent("crystal");
+		if (m_crystalComponent==NULL) G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
                                               "Failed to get the array component corresponding to the crystal. Abort.\n");
-    // Get the number of crystals in each direction
-    m_nbCrystalsZ  = m_crystalComponent->GetRepeatNumber(2);
-    m_nbCrystalsY  = m_crystalComponent->GetRepeatNumber(1);
-    m_nbCrystalsX  = m_crystalComponent->GetRepeatNumber(0);
-    m_nbCrystalsXY = m_nbCrystalsX * m_nbCrystalsY;
-    if (m_nbCrystalsX<1 || m_nbCrystalsY<1 || m_nbCrystalsZ<1)
-      G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
-                   "Crystal repeater numbers are wrong !\n");
-    //G4cout << "[" << GetObjectName() << "] -> Found crystal array with associated repeater: ["
-    //       << m_nbCrystalsX << ";" << m_nbCrystalsY << ";" << m_nbCrystalsZ << "]\n";
-    // Get tree depth of the system
-    m_systemDepth = m_system->GetTreeDepth();
-    //G4cout << "  Depth of the system: " << m_systemDepth << Gateendl;
-    // Find the crystal depth in the system
-    GateSystemComponent* this_component = m_system->GetBaseComponent();
-    m_crystalDepth = 0;
-    while (this_component!=m_crystalComponent && m_crystalDepth+1<m_systemDepth)
-    {
-      this_component = this_component->GetChildComponent(0);
-      m_crystalDepth++;
-    }
-    if (this_component!=m_crystalComponent) G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
-                                                        "Failed to get the system depth corresponding to the crystal. Abort.\n");
-    //G4cout << "  Crystal depth: " << m_crystalDepth << Gateendl;
-    // Now force m_depth to be right above the crystal depth
-    m_depth = m_crystalDepth - 1;
-  }
-  else G4Exception( "GateReadout::SetPolicy", "SetPolicy", FatalException, "Unknown provided policy, please see the guidance. Abort.\n");
+		// Get the number of crystals in each direction
+		m_nbCrystalsZ  = m_crystalComponent->GetRepeatNumber(2);
+		m_nbCrystalsY  = m_crystalComponent->GetRepeatNumber(1);
+		m_nbCrystalsX  = m_crystalComponent->GetRepeatNumber(0);
+		m_nbCrystalsXY = m_nbCrystalsX * m_nbCrystalsY;
+		if (m_nbCrystalsX<1 || m_nbCrystalsY<1 || m_nbCrystalsZ<1)
+			G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
+					"Crystal repeater numbers are wrong !\n");
+		//G4cout << "[" << GetObjectName() << "] -> Found crystal array with associated repeater: ["
+		//       << m_nbCrystalsX << ";" << m_nbCrystalsY << ";" << m_nbCrystalsZ << "]\n";
+		// Get tree depth of the system
+		m_systemDepth = m_system->GetTreeDepth();
+		//G4cout << "  Depth of the system: " << m_systemDepth << Gateendl;
+		// Find the crystal depth in the system
+		GateSystemComponent* this_component = m_system->GetBaseComponent();
+		m_crystalDepth = 0;
+		while (this_component!=m_crystalComponent && m_crystalDepth+1<m_systemDepth)
+		{
+			this_component = this_component->GetChildComponent(0);
+			m_crystalDepth++;
+		}
+		if (this_component!=m_crystalComponent) G4Exception( "GateReadout::ProcessPulseList", "ProcessPulseList", FatalException,
+																"Failed to get the system depth corresponding to the crystal. Abort.\n");
+		//G4cout << "  Crystal depth: " << m_crystalDepth << Gateendl;
+		// Now force m_depth to be right above the crystal depth
+		m_depth = m_crystalDepth - 1;
+	}
+
+	if (m_policy!="TakeEnergyCentroid" && m_policy!="TakeEnergyWinner")
+		G4Exception( "GateReadout::SetPolicy", "SetPolicy", FatalException, "Unknown provided policy, please see the guidance. Abort.\n");
+
+	/*G4cout<<"Policy = "<< m_policy<< Gateendl;
+	G4cout<<"Depth =  "<< m_depth<<Gateendl;
+	G4cout<<"resultingXY = "<< m_resultingXY<<Gateendl;
+	G4cout<<"reulstingZ = "<< m_resultingZ<<Gateendl;
+*/
 }
 
 // S. Stute: This function is virtual (but not pure) in the mother GateVPulseProcessor.
@@ -111,16 +175,24 @@ void GateReadout::SetPolicy(const G4String& aPolicy)
 //           Note: this new strategy also allowed us to correct the bug for the energyWinner policy.
 GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList)
 {
+	if(m_IsFirstEntrance) //set parameters at the first iteration
+	{
+		SetReadoutParameters();
+		m_IsFirstEntrance=0;
+	}
+
   if (!inputPulseList)
     return 0;
 
   size_t n_pulses = inputPulseList->size();
+
   if (nVerboseLevel>1)
     G4cout << "[" << GetObjectName() << "::ProcessPulseList]: processing input list with " << n_pulses << " entries\n";
   if (!n_pulses)
     return 0;
 
   GatePulseList* outputPulseList = new GatePulseList(GetObjectName());
+  //G4cout<<"Policy "<< m_policy<< " "<< m_depth<<" "<< m_resultingXY<<" "<< m_resultingZ<<Gateendl;
 
   // S. Stute: these variables are used for the energy centroid policy
   G4double* final_time = NULL;
@@ -130,7 +202,7 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
   G4double* final_energy = NULL;
   G4int* final_nb_pulses = NULL;
   GatePulse** final_pulses = NULL;
-  if (m_policy==READOUT_POLICY_CENTROID)
+  if (m_policy=="TakeEnergyCentroid")
   {
     final_time         = (G4double*)calloc(n_pulses,sizeof(G4double));
     final_crystal_posX = (G4double*)calloc(n_pulses,sizeof(G4double));
@@ -150,11 +222,12 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
   for (iterIn = inputPulseList->begin() ; iterIn != inputPulseList->end() ; ++iterIn)
   {
     GatePulse* inputPulse = *iterIn;
+
     const GateOutputVolumeID& blockID = inputPulse->GetOutputVolumeID().Top(m_depth);
 
     if (blockID.IsInvalid())
     {
-      if (nVerboseLevel>1)
+     if (nVerboseLevel>1)
         G4cout << "[GateReadout::ProcessOnePulse]: out-of-block hit for \n"
                <<  *inputPulse << Gateendl
                << " -> pulse ignored\n\n";
@@ -172,7 +245,7 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
       // --------------------------------------------------------------------------------
       // WinnerTakeAllPolicy (APD like)
       // --------------------------------------------------------------------------------
-      if (m_policy==READOUT_POLICY_WINNER)
+      if (m_policy=="TakeEnergyWinner")
       {
         // If energy is higher then replace the pulse by the new one
         if ( inputPulse->GetEnergy() > final_pulses[this_output_pulse]->GetEnergy() ) final_pulses[this_output_pulse] = inputPulse;
@@ -181,7 +254,7 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
       // --------------------------------------------------------------------------------
       // EnergyCentroidPolicy1 (like block PMT)
       // --------------------------------------------------------------------------------
-      else if (m_policy==READOUT_POLICY_CENTROID) // Crystal element is considered to be the deepest element
+      else if (m_policy=="TakeEnergyCentroid") // Crystal element is considered to be the deepest element
       {
         // First, if the energy of this pulse is higher than the previous one, take it as the reference
         // in order to have an EnergyWinner policy at levels below the crystal, if any.
@@ -211,7 +284,7 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
     else
     {
       G4double energy = inputPulse->GetEnergy();
-      if (m_policy==READOUT_POLICY_CENTROID)
+      if (m_policy=="TakeEnergyCentroid")
       {
         // Time will be averaged then
         final_time[final_nb_out_pulses] = inputPulse->GetTime();
@@ -242,7 +315,7 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
     // Affect energy
     outputPulse->SetEnergy( final_energy[p] );
     // Special affectations for centroid policy
-    if (m_policy==READOUT_POLICY_CENTROID)
+    if (m_policy=="TakeEnergyCentroid")
     {
       // Affect time being the mean
       outputPulse->SetTime( final_time[p] / ((G4double)final_nb_pulses[p]) );
@@ -252,6 +325,13 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
       G4int crys_posZ = ((G4int)(final_crystal_posZ[p]/final_energy[p]));
       // Compute final crystal id
       G4int crystal_id = crys_posZ * m_nbCrystalsXY + crys_posY * m_nbCrystalsX + crys_posX;
+      if((outputPulse->GetVolumeID()).GetDaughterID(m_crystalDepth) == (-1)) //check to avoid Seg. fault
+      {
+	  GateError("Error: not all required geometry levels and sublevels for this system are defined. "
+			  "(Ex.: for cylindricalPET, the required levels are: rsector, module, submodule, crystal). Please, add them to your geometry macro");
+      }
+
+      
       // We change the level of the volumeID and the outputVolumeID corresponding to the crystal with the new crystal ID
       outputPulse->ChangeVolumeIDAndOutputVolumeIDValue(m_crystalDepth,crystal_id);
       // Change coordinates (we choose here to place the coordinates at the center of the chosen crystal)
@@ -267,7 +347,7 @@ GatePulseList* GateReadout::ProcessPulseList(const GatePulseList* inputPulseList
   }
 
   // Free temporary variables used by the centroid policy
-  if (m_policy==READOUT_POLICY_CENTROID)
+  if (m_policy=="TakeEnergyCentroid")
   {
     free(final_time);
     free(final_crystal_posX);
@@ -296,12 +376,15 @@ void GateReadout::ProcessOnePulse(const GatePulse* ,GatePulseList& )
 {
 }
 
+
+
+
 void GateReadout::DescribeMyself(size_t indent)
 {
   G4cout << GateTools::Indent(indent) << "Readout at depth:      " << m_depth << Gateendl;
   G4cout << GateTools::Indent(indent) << "  --> policy: ";
-  if (m_policy==READOUT_POLICY_WINNER) G4cout << "TakeEnergyWinner\n";
-  else if (m_policy==READOUT_POLICY_CENTROID) G4cout << "TakeEnergyCentroid\n";
+  if (m_policy=="TakeEnergyWinner") G4cout << "TakeEnergyWinner\n";
+  else if (m_policy=="TakeEnergyCentroid") G4cout << "TakeEnergyCentroid\n";
   else G4cout << "Unknown policy !\n";
 }
 

--- a/source/digits_hits/src/GateReadoutMessenger.cc
+++ b/source/digits_hits/src/GateReadoutMessenger.cc
@@ -26,6 +26,7 @@ GateReadoutMessenger::GateReadoutMessenger(GateReadout* itsReadout)
     SetDepthCmd->SetGuidance("For instance, the default depth is 1: ");
     SetDepthCmd->SetGuidance("this means that pulses will be considered as taking place in a same block ");
     SetDepthCmd->SetGuidance("if their volume IDs are identical up to a depth of 1, i.e. the first two figures (depth 0 + depth 1)");
+    
     // Command for choosing the policy to create the final pulse (S. Stute)
     // Note: in gate releases until v7.0 included, there was only one policy which was something like "TakeTheWinnerInEnergyForFinalPosition"
     //       we now introduce an option to choose a PMT like readout by using a policy like "TakeTheCentroidInEnergyForFinalPosition".
@@ -37,6 +38,20 @@ GateReadoutMessenger::GateReadoutMessenger(GateReadout* itsReadout)
     SetPolicyCmd->SetGuidance("  --> 'TakeEnergyWinner': the final position will be the one for which the maximum energy was deposited");
     SetPolicyCmd->SetGuidance("  --> 'TakeEnergyCentroid': the energy centroid is computed based on crystal indices, meaning that the 'crystal' component of the system must be used. The depth is thus ignored.");
     SetPolicyCmd->SetGuidance("Note: when using the energyCentroid policy, the mother volume of the crystal level MUST NOT have any other daughter volumes declared BEFORE the crystal. Declaring it after is not a problem though.");
+
+    //OK: Choosing the name of the volume where readout is applied
+    cmdName = GetDirectoryName() + "setReadoutVolume";
+    SetVolNameCmd = new G4UIcmdWithAString(cmdName,this);
+    SetVolNameCmd->SetGuidance("Choose a volume (depth) for readout (e.g. crystal/module)");
+     //to add these options later
+  /*  cmdName = GetDirectoryName() + "setResultingXY";
+    SetResultingXYCmd = new G4UIcmdWithAString(cmdName,this);
+    SetResultingXYCmd->SetGuidance("Choose the resulting policy for the local position: crystalCenter/exactPostion");
+
+    cmdName = GetDirectoryName() + "setResultingZ";
+    SetResultingZCmd = new G4UIcmdWithAString(cmdName,this);
+    SetResultingZCmd->SetGuidance("Choose the resulting policy for the local position: crystalCenter/exactPostion/meanFreePath");
+*/
 }
 
 
@@ -44,14 +59,27 @@ GateReadoutMessenger::~GateReadoutMessenger()
 {
   delete SetDepthCmd;
   delete SetPolicyCmd;
+  delete SetVolNameCmd;
+
+  delete SetResultingXYCmd;
+  delete SetResultingZCmd;
+
 }
 
 void GateReadoutMessenger::SetNewValue(G4UIcommand* aCommand, G4String aString)
 {
   if( aCommand==SetDepthCmd )
     { GetReadout()->SetDepth(SetDepthCmd->GetNewIntValue(aString)); }
+  else if ( aCommand==SetVolNameCmd )
+    { GetReadout()->SetVolumeName(aString); }
   else if ( aCommand==SetPolicyCmd )
     { GetReadout()->SetPolicy(aString); }
+  /*else if ( aCommand==SetResultingXYCmd )
+     { GetReadout()->SetResultingXY(aString); }
+  else if ( aCommand==SetResultingZCmd )
+     { GetReadout()->SetResultingZ(aString); }
+     */
   else
     GatePulseProcessorMessenger::SetNewValue(aCommand,aString);
+
 }

--- a/source/geometry/include/GateVSystem.hh
+++ b/source/geometry/include/GateVSystem.hh
@@ -208,9 +208,10 @@ class GateVSystem : public GateClockDependent
     //G4ThreeVector ComputeObjectCenter(const std::vector<G4int>& numList) const;
     G4ThreeVector ComputeObjectCenter(const GateVolumeID* volID) const;
     GateVolumeID* MakeVolumeID(const std::vector<G4int>& numList) const;
-  protected:
+  public:
     typedef std::vector< GateSystemComponent* > compList_t;
     compList_t* MakeComponentListAtLevel(G4int level) const;
+  protected:
     GateSystemComponent * m_BaseComponent;      	//!< The base component of the system
     size_t m_mainComponentDepth;		//!< depth of the main component (0 or 1)
     G4String m_itsOwnName;                      //! a name of a system, may be any name (multi-system approach)


### PR DESCRIPTION
Following modifications:
1) Patch for Seg. fault if the system is not defined completely (i. e. not all expected levels of system geometry are defined)
2) For Centroid policy from documentation: "If the energy centroid policy is used, the depth is forced to be at the level just above the crystal level, whatever the system used." It was not respected --> corrected
3)  For different order of "setPolicy" and "setDepth" commands, result was different --> corrected 
4) New option "setReadoutVolume". The same as "setDepth" but with a name. 