### PR TITLE
Revert "GateActions:GateEventAction::EndOfEventAction go to next event if no …"

### DIFF
--- a/source/digits_hits/src/GateActions.cc
+++ b/source/digits_hits/src/GateActions.cc
@@ -143,10 +143,8 @@ inline void GateEventAction::EndOfEventAction(const G4Event* anEvent)
 {
   GateMessage("Core", 2, "End Of Event " << anEvent->GetEventID() << "\n");
 
-  G4int CHCollID = G4SDManager::GetSDMpointer()->GetCollectionID(GateCrystalSD::GetCrystalCollectionName() ); //"crystalCollection");
-  GateCrystalHitsCollection * CHC = (GateCrystalHitsCollection *) ( anEvent->GetHCofThisEvent()->GetHC( CHCollID ) );
-  if (CHC->entries()==0) return; //go to next event if no hits
-  
+
+
 #ifdef G4ANALYSIS_USE_GENERAL
   // Here we fill the histograms of the OutputMgr manager
   // Pre-digitalisation outputMgr (hits)
@@ -164,8 +162,8 @@ inline void GateEventAction::EndOfEventAction(const G4Event* anEvent)
   if ( theMode == TrackingMode::kTracker )
     {
 
-      // G4int CHCollID = G4SDManager::GetSDMpointer()->GetCollectionID(GateCrystalSD::GetCrystalCollectionName() ); //"crystalCollection");
-      //GateCrystalHitsCollection * CHC = (GateCrystalHitsCollection *) ( anEvent->GetHCofThisEvent()->GetHC( CHCollID ) );
+      G4int CHCollID = G4SDManager::GetSDMpointer()->GetCollectionID(GateCrystalSD::GetCrystalCollectionName() ); //"crystalCollection");
+      GateCrystalHitsCollection * CHC = (GateCrystalHitsCollection *) ( anEvent->GetHCofThisEvent()->GetHC( CHCollID ) );
 
       if (CHC != 0)
 	{ if ( CHC->GetSize() > 0 )


### PR DESCRIPTION
@dsarrut @kochebina 

Reverts OpenGATE/Gate#526

I revert the commit because with test7, it fails. It seems that the 2 lines:
```
G4int CHCollID = G4SDManager::GetSDMpointer()->GetCollectionID(GateCrystalSD::GetCrystalCollectionName() ); //"crystalCollection");
GateCrystalHitsCollection * CHC = (GateCrystalHitsCollection *) ( anEvent->GetHCofThisEvent()->GetHC( CHCollID ) );
```
are not defined correctly with ARF