### PR TITLE
volumeID included by default in Singles root tree (old way)

### DIFF
--- a/source/general/include/GateRootDefs.hh
+++ b/source/general/include/GateRootDefs.hh
@@ -254,6 +254,7 @@ class GateRootSingleBuffer
     Float_t  globalPosY;
     Float_t  globalPosZ;
     Int_t    outputID[ROOT_OUTPUTIDSIZE];
+    Int_t    volumeID[ROOT_VOLUMEIDSIZE];
     Int_t    comptonPhantom; 
     Int_t    comptonCrystal;    
     Int_t    RayleighPhantom; 

--- a/source/general/src/GateRootDefs.cc
+++ b/source/general/src/GateRootDefs.cc
@@ -361,6 +361,8 @@ void GateRootSingleBuffer::Clear()
   strcpy (RayleighVolumeName," ");
   // HDS : septal
   septalNb = 0;
+  for ( d = 0 ; d < ROOT_VOLUMEIDSIZE ; ++d )
+      volumeID[d] = -1;
 }
 
 
@@ -393,6 +395,7 @@ void GateRootSingleBuffer::Fill(GateSingleDigi* aDigi)
 
   // HDS : septal penetration
   septalNb = aDigi->GetNSeptal();
+  aDigi->GetPulse().GetVolumeID().StoreDaughterIDs(volumeID,ROOT_VOLUMEIDSIZE);
 }
 
 
@@ -443,6 +446,8 @@ void GateSingleTree::Init(GateRootSingleBuffer& buffer)
   if ( GateSingleDigi::GetSingleASCIIMask(20) )
     // HDS : record septal penetration
     if (GateRootDefs::GetRecordSeptalFlag())	Branch("septalNb",   &buffer.septalNb,"septalNb/I");
+   //Initialized by default.TO DO: Mask option should be included or a flag
+  Branch("volumeID",       (void *)buffer.volumeID,"volumeID[10]/I");
 }
 
 


### PR DESCRIPTION
VolumeID info included by default in Singles tree (old way, GateRootDefs)
Root tree obtained using the following commands:
/gate/output/root/enable
/gate/output/root/setFileName             YourFileName
/gate/output/root/setRootHitFlag          1
/gate/output/root/setRootSinglesFlag      1

