### PR TITLE
With Geant4 v11, it's not possible to read rayl/* data anymore

### DIFF
--- a/source/digits_hits/include/GateDiffCrossSectionActor.hh
+++ b/source/digits_hits/include/GateDiffCrossSectionActor.hh
@@ -64,6 +64,9 @@ class GateDiffCrossSectionActor : public GateVActor
   void SetMaterial(G4String name);
   void ReadMaterialList(G4String filename);
 
+  G4double findValue(const unsigned int & Z, const double & energy);
+  void ReadData(size_t Z, const char* path);
+
   std::ofstream PointerToFileDataOutSF;
   std::ofstream PointerToFileDataOutFF;
   std::ofstream PointerToFileDataOutDCScompton;
@@ -87,7 +90,7 @@ protected:
   std::vector<G4double > mUserAngleList;
   std::vector<G4String > mUserMaterialList;
   G4VEMDataSet* scatterFunctionData;
-  G4VEMDataSet* formFactorData;
+  std::vector<G4PhysicsFreeVector*> m_dataFF;
 
 };
 


### PR DESCRIPTION
The data are now in livermore/rayl/* and the function to read it is different.

https://github.com/OpenGATE/Gate/issues/492

Do not merge for the moment, because the output rayleigh.mha is different with Geant4 v10.7 and Geant4 v11 for GateContrib/CT/FFD example