### PR TITLE
Check for parallel geometry only if source is a plane.

### DIFF
--- a/source/digits_hits/src/GateFixedForcedDetectionActor.cc
+++ b/source/digits_hits/src/GateFixedForcedDetectionActor.cc
@@ -1579,7 +1579,7 @@ void GateFixedForcedDetectionActor::ComputeGeometryInfoInImageCoordinateSystem(G
     s = src->GetPosDist()->GetCentreCoords();
     s = m_SourceToCT.TransformPoint(s);
     } /*  point */
-  else // parallel geometry
+  else if (mSourceType == "plane") // parallel geometry
     {
     s = dp;
     G4ThreeVector dw = du.cross(dv);


### PR DESCRIPTION
Parallel geometry is not a problem if the source is isotropic.
Fixes #351