### PR TITLE
2 small mods : non binary reflexion (XrayBoundaryProcess) and reset data (FluenceActor)

### DIFF
--- a/source/digits_hits/src/GateFluenceActor.cc
+++ b/source/digits_hits/src/GateFluenceActor.cc
@@ -219,6 +219,7 @@ void GateFluenceActor::ResetData()
 void GateFluenceActor::BeginOfRunAction(const G4Run *)
 {
   GateDebugMessage("Actor", 3, "GateFluenceActor -- Begin of Run\n");
+  ResetData();
 }
 
 void GateFluenceActor::BeginOfEventAction(const G4Event * e)

--- a/source/physics/src/G4XrayBoundaryProcess.cc
+++ b/source/physics/src/G4XrayBoundaryProcess.cc
@@ -158,11 +158,20 @@ G4VParticleChange *G4XrayBoundaryProcess::PostStepDoIt(const G4Track &aTrack, co
         }
 
         if (sint1 > 0.0) {      // incident ray oblique
+	  // Compute the reflectance and sample a uniform random to test if reflected or transmitted
+	  G4double diti = (Rindex1*cost1 - Rindex2*cost2) / (Rindex1*cost1 + Rindex2*cost2);
+	  G4double ditj = (Rindex1*cost2 - Rindex2*cost1) / (Rindex1*cost2 + Rindex2*cost1);
+	  G4double reflectance = 0.5 * ( diti*diti + ditj*ditj ) ;
+	  G4double isReflected = CLHEP::RandFlat::shoot() ;
+	  if (isReflected < reflectance) { // if reflectance test passed
+	    DoReflection(); // *** Total reflection ***
+	  } else {
             G4double alpha = cost1 - cost2 * (Rindex2 / Rindex1);
             NewMomentum = OldMomentum + alpha * theGlobalNormal;
+	  }
         } else {                // incident ray perpendicular ==> transmission
-            NewMomentum = OldMomentum;
-            NewPolarization = OldPolarization;
+	  NewMomentum = OldMomentum;
+	  NewPolarization = OldPolarization;
         }
     }
 


### PR DESCRIPTION
1.
Reflectance in XrayBoundaryProcess was binary, The reflexion coef (which is in [0,1] is computed and a random number shoot to randomly accept reflexion.

2.
In the time (setTimeStart|Stop|Slice) is activated in the FluenceActor, the images (scatter, direct...) were not reinitialized betweeen runs. This corrects it. NB: the scatter images indexed by the interaction nr are still not reset between runs with this.  