### PR TITLE
Spatial blurring module (error corrected)

### DIFF
--- a/docs/digitizer_and_detector_modeling.rst
+++ b/docs/digitizer_and_detector_modeling.rst
@@ -491,6 +491,8 @@ For SPECT simulations, the spatial resolution is assumed to follow a Gaussian di
    /gate/digitizer/Singles/spblurring/setSpresolution 2.0 mm 
    /gate/digitizer/Singles/spblurring/verbose 1
 
+BEWARE: The final position of the pulse is located within the original detector volume  (smallest volume). If the position obtained after applying a Gaussian blurring exceeds the limits of the original volume, it is set to the surface of that volume.  In other words, the volumeID of the pulse does not change by the application of this module. 
+
 In PET analysis, coincidence events provide the lines of response (LOR) needed for the image reconstruction. Only the two crystal numbers are transferred by the simulation. The determination of these crystal numbers is based on the crystal in which the highest energy has been deposited. Without additional spatial blurring of the crystal, simulation results will always have a better spatial resolution than experimental measurements. This module is only available for the *ecat* system. The spatial blurring is based on a 2D Gaussian function::
 
    # E C A T 7 

--- a/source/digits_hits/src/GateSpblurring.cc
+++ b/source/digits_hits/src/GateSpblurring.cc
@@ -56,7 +56,7 @@ void GateSpblurring::ProcessOnePulse(const GatePulse* inputPulse,GatePulseList& 
     inputPulse->GetVolumeID().GetBottomCreator()->GetLogicalVolume()->GetSolid()->CalculateExtent(kYAxis, limits, at, Ymin, Ymax);
     inputPulse->GetVolumeID().GetBottomCreator()->GetLogicalVolume()->GetSolid()->CalculateExtent(kZAxis, limits, at, Zmin, Zmax);
     if(PxNew<Xmin) PxNew=Xmin;
-    if(PxNew<Ymin) PyNew=Ymin;
+    if(PyNew<Ymin) PyNew=Ymin;
     if(PzNew<Zmin) PzNew=Zmin;
     if(PxNew>Xmax) PxNew=Xmax;
     if(PyNew>Ymax) PyNew=Ymax;


### PR DESCRIPTION

 
Before version 9.0, spatial resolution module  applied a Gaussian blurring to the interaction positions without restricting the new generated positions to the detector limits. Therefore, spatial blurring module could lead to a position of the pulse outside sensitive detector. In version 9.0, the boundaries of the detector were taken into account. This is included in the documentation.
However, there was an error setting detector boundaries that affects only to detectors of different size in X and Y directions. This is corrected in this PR.
