### PR TITLE
Added support for ions in phaseSpaceSource and charge in phaseSpaceActor

### DIFF
--- a/source/digits_hits/include/GatePhaseSpaceActor.hh
+++ b/source/digits_hits/include/GatePhaseSpaceActor.hh
@@ -6,8 +6,6 @@
   See LICENSE.md for further details
   ----------------------*/
 
-
-
 #ifndef GATEPHASESPACEACTOR_HH
 #define GATEPHASESPACEACTOR_HH
 
@@ -23,258 +21,260 @@ class G4EmCalculator;
 class GatePhaseSpaceActorMessenger;
 
 //====================================================================
-class GatePhaseSpaceActor : public GateVActor {
+class GatePhaseSpaceActor : public GateVActor
+{
 public:
+  virtual ~GatePhaseSpaceActor();
 
-    virtual ~GatePhaseSpaceActor();
+  //====================================================================
+  // This macro initialize the CreatePrototype and CreateInstance
+  FCT_FOR_AUTO_CREATOR_ACTOR(GatePhaseSpaceActor)
 
-    //====================================================================
-    // This macro initialize the CreatePrototype and CreateInstance
-    FCT_FOR_AUTO_CREATOR_ACTOR(GatePhaseSpaceActor)
+  //====================================================================
+  // Constructs the sensor
+  virtual void Construct();
 
-    //====================================================================
-    // Constructs the sensor
-    virtual void Construct();
+  //====================================================================
+  // Callbacks
+  virtual void UserSteppingAction(const GateVVolume *, const G4Step *);
 
-    //====================================================================
-    // Callbacks
-    virtual void UserSteppingAction(const GateVVolume *, const G4Step *);
+  virtual void PreUserTrackingAction(const GateVVolume *, const G4Track *);
 
-    virtual void PreUserTrackingAction(const GateVVolume *, const G4Track *);
+  virtual void PostUserTrackingAction(const GateVVolume *, const G4Track *);
 
-    virtual void PostUserTrackingAction(const GateVVolume *, const G4Track *);
+  virtual void BeginOfEventAction(const G4Event *e);
 
-    virtual void BeginOfEventAction(const G4Event *e);
+  virtual void BeginOfRunAction(const G4Run *r);
 
-    virtual void BeginOfRunAction(const G4Run *r);
+  virtual void RecordEndOfAcquisition();
 
-    virtual void RecordEndOfAcquisition();
+  //=======================================================
+  /// Saves the data collected to the file
+  virtual void SaveData();
 
-    //=======================================================
-    /// Saves the data collected to the file
-    virtual void SaveData();
+  virtual void ResetData();
 
-    virtual void ResetData();
+  void InitTree();
 
-    void InitTree();
+  void SetIsXPositionEnabled(bool b) { EnableXPosition = b; }
 
-    void SetIsXPositionEnabled(bool b) { EnableXPosition = b; }
+  void SetIsYPositionEnabled(bool b) { EnableYPosition = b; }
 
-    void SetIsYPositionEnabled(bool b) { EnableYPosition = b; }
+  void SetIsZPositionEnabled(bool b) { EnableZPosition = b; }
 
-    void SetIsZPositionEnabled(bool b) { EnableZPosition = b; }
+  void SetIsEkineEnabled(bool b) { EnableEkine = b; }
 
-    void SetIsEkineEnabled(bool b) { EnableEkine = b; }
+  void SetIsXDirectionEnabled(bool b) { EnableXDirection = b; }
 
-    void SetIsXDirectionEnabled(bool b) { EnableXDirection = b; }
+  void SetIsYDirectionEnabled(bool b) { EnableYDirection = b; }
 
-    void SetIsYDirectionEnabled(bool b) { EnableYDirection = b; }
+  void SetIsZDirectionEnabled(bool b) { EnableZDirection = b; }
 
-    void SetIsZDirectionEnabled(bool b) { EnableZDirection = b; }
+  void SetIsParticleNameEnabled(bool b) { EnablePartName = b; }
 
-    void SetIsParticleNameEnabled(bool b) { EnablePartName = b; }
+  void SetIsProdVolumeEnabled(bool b) { EnableProdVol = b; }
 
-    void SetIsProdVolumeEnabled(bool b) { EnableProdVol = b; }
+  void SetIsProdProcessEnabled(bool b) { EnableProdProcess = b; }
 
-    void SetIsProdProcessEnabled(bool b) { EnableProdProcess = b; }
+  void SetIsWeightEnabled(bool b) { EnableWeight = b; }
 
-    void SetIsWeightEnabled(bool b) { EnableWeight = b; }
+  void SetIsTimeEnabled(bool b) { EnableTime = b; }
 
-    void SetIsTimeEnabled(bool b) { EnableTime = b; }
+  void SetIsLocalTimeEnabled(bool b) { EnableLocalTime = b; }
 
-    void SetIsLocalTimeEnabled(bool b) { EnableLocalTime = b; }
+  void SetIsTimeFromBeginOfEventEnabled(bool b) { EnableTimeFromBeginOfEvent = b; }
 
-    void SetIsTimeFromBeginOfEventEnabled(bool b) { EnableTimeFromBeginOfEvent = b; }
+  void SetTrackLengthEnabled(bool b) { EnableTrackLengthFlag = b; }
 
-    void SetTrackLengthEnabled(bool b) { EnableTrackLengthFlag = b; }
+  void SetIsMassEnabled(bool b) { EnableMass = b; }
 
-    void SetIsMassEnabled(bool b) { EnableMass = b; }
+  void SetIsSecStored(bool b) { EnableSec = b; }
 
-    void SetIsSecStored(bool b) { EnableSec = b; }
+  void SetIsAllStep(bool b) { EnableAllStep = b; }
 
-    void SetIsAllStep(bool b) { EnableAllStep = b; }
+  void SetIsTOutEnabled(bool b) { EnableTOut = b; }
 
-    void SetIsTOutEnabled(bool b) { EnableTOut = b; }
+  void SetIsTProdEnabled(bool b) { EnableTProd = b; }
 
-    void SetIsTProdEnabled(bool b) { EnableTProd = b; }
+  void SetIsChargeEnabled(bool b) { EnableCharge = b; }
 
-    void SetIsChargeEnabled(bool b) { EnableCharge = b; }
+  void SetIsAtomicNumberEnabled(bool b) { EnableAtomicNumber = b; }
 
-    void SetIsElectronicDEDXEnabled(bool b) { EnableElectronicDEDX = b; }
+  void SetIsElectronicDEDXEnabled(bool b) { EnableElectronicDEDX = b; }
 
-    void SetIsTotalDEDXEnabled(bool b) { EnableTotalDEDX = b; }
+  void SetIsTotalDEDXEnabled(bool b) { EnableTotalDEDX = b; }
 
-    void SetUseVolumeFrame(bool b) { mUseVolFrame = b; }
+  void SetUseVolumeFrame(bool b) { mUseVolFrame = b; }
 
-    bool GetUseVolumeFrame() { return mUseVolFrame; }
+  bool GetUseVolumeFrame() { return mUseVolFrame; }
 
-    void SetStoreOutgoingParticles(bool b) { mStoreOutPart = b; }
+  void SetStoreOutgoingParticles(bool b) { mStoreOutPart = b; }
 
-    bool GetStoreOutgoingParticles() { return mStoreOutPart; }
+  bool GetStoreOutgoingParticles() { return mStoreOutPart; }
 
-    void SetMaxFileSize(double size) { mFileSize = size; }
+  void SetMaxFileSize(double size) { mFileSize = size; }
 
-    double GetMaxFileSize() { return mFileSize; }
+  double GetMaxFileSize() { return mFileSize; }
 
-    void SetIsPrimaryEnergyEnabled(bool b) { bEnablePrimaryEnergy = b; }
+  void SetIsPrimaryEnergyEnabled(bool b) { bEnablePrimaryEnergy = b; }
 
-    void SetIsEmissionPointEnabled(bool b) { bEnableEmissionPoint = b; }
+  void SetIsEmissionPointEnabled(bool b) { bEnableEmissionPoint = b; }
 
-    void SetEnableCoordFrame() { bEnableCoordFrame = true; }
+  void SetEnableCoordFrame() { bEnableCoordFrame = true; }
 
-    bool GetEnableCoordFrame() { return bEnableCoordFrame; }
+  bool GetEnableCoordFrame() { return bEnableCoordFrame; }
 
-    void SetCoordFrame(G4String nameOfFrame) { bCoordFrame = nameOfFrame; }
+  void SetCoordFrame(G4String nameOfFrame) { bCoordFrame = nameOfFrame; }
 
-    G4String GetCoordFrame() { return bCoordFrame; }
+  G4String GetCoordFrame() { return bCoordFrame; }
 
-    void SetIsSpotIDEnabled() { bEnableSpotID = true; }
+  void SetIsSpotIDEnabled() { bEnableSpotID = true; }
 
-    bool GetIsSpotIDEnabled() { return bEnableSpotID; }
+  bool GetIsSpotIDEnabled() { return bEnableSpotID; }
 
-    void SetSpotIDFromSource(G4String nameOfSource) { bSpotIDFromSource = nameOfSource; }
+  void SetSpotIDFromSource(G4String nameOfSource) { bSpotIDFromSource = nameOfSource; }
 
-    G4String GetSpotIDFromSource() { return bSpotIDFromSource; }
+  G4String GetSpotIDFromSource() { return bSpotIDFromSource; }
 
-    void SetEnabledCompact(bool b) { bEnableCompact = b; }
+  void SetEnabledCompact(bool b) { bEnableCompact = b; }
 
-    void SetEnablePDGCode(bool b) { bEnablePDGCode = b; }
+  void SetEnablePDGCode(bool b) { bEnablePDGCode = b; }
 
-    void SetIsNuclearFlagEnabled(bool b) { EnableNuclearFlag = b; }
+  void SetIsNuclearFlagEnabled(bool b) { EnableNuclearFlag = b; }
 
-    void SetEnabledSphereProjection(bool b) { mSphereProjectionFlag = b; }
+  void SetEnabledSphereProjection(bool b) { mSphereProjectionFlag = b; }
 
-    void SetSphereProjectionCenter(G4ThreeVector c) { mSphereProjectionCenter = c; }
+  void SetSphereProjectionCenter(G4ThreeVector c) { mSphereProjectionCenter = c; }
 
-    void SetSphereProjectionRadius(double r) { mSphereProjectionRadius = r; }
+  void SetSphereProjectionRadius(double r) { mSphereProjectionRadius = r; }
 
-    void SetEnabledTranslationAlongDirection(bool b) { mTranslateAlongDirectionFlag = b; }
+  void SetEnabledTranslationAlongDirection(bool b) { mTranslateAlongDirectionFlag = b; }
 
-    void SetTranslationAlongDirectionLength(double r) { mTranslationLength = r; }
+  void SetTranslationAlongDirectionLength(double r) { mTranslationLength = r; }
 
-    void SetMaskFilename(G4String filename);
+  void SetMaskFilename(G4String filename);
 
-    void SetKillParticleFlag(bool b);
+  void SetKillParticleFlag(bool b);
 
 protected:
-    GatePhaseSpaceActor(G4String name, G4int depth = 0);
+  GatePhaseSpaceActor(G4String name, G4int depth = 0);
 
-    G4String mFileType;
-    G4int mNevent;
+  G4String mFileType;
+  G4int mNevent;
 
-    GateOutputTreeFileManager *mFile;
+  GateOutputTreeFileManager *mFile;
 
-    bool EnableCharge;
-    bool EnableElectronicDEDX;
-    bool EnableTotalDEDX;
-    bool EnableXPosition;
-    bool EnableYPosition;
-    bool EnableZPosition;
-    bool EnableEkine;
-    bool EnableXDirection;
-    bool EnableYDirection;
-    bool EnableZDirection;
-    bool EnablePartName;
-    bool EnableProdVol;
-    bool EnableProdProcess;
-    bool EnableWeight;
-    bool EnableTime;
-    bool EnableLocalTime;
-    bool EnableMass;
-    bool EnableSec;
-    bool EnableAllStep;
-    bool mUseVolFrame;
-    bool mStoreOutPart;
-    bool EnableNuclearFlag;
-    bool EnableTimeFromBeginOfEvent;
-    bool EnableTrackLengthFlag;
+  bool EnableCharge;
+  bool EnableAtomicNumber;
+  bool EnableElectronicDEDX;
+  bool EnableTotalDEDX;
+  bool EnableXPosition;
+  bool EnableYPosition;
+  bool EnableZPosition;
+  bool EnableEkine;
+  bool EnableXDirection;
+  bool EnableYDirection;
+  bool EnableZDirection;
+  bool EnablePartName;
+  bool EnableProdVol;
+  bool EnableProdProcess;
+  bool EnableWeight;
+  bool EnableTime;
+  bool EnableLocalTime;
+  bool EnableMass;
+  bool EnableSec;
+  bool EnableAllStep;
+  bool mUseVolFrame;
+  bool mStoreOutPart;
+  bool EnableNuclearFlag;
+  bool EnableTimeFromBeginOfEvent;
+  bool EnableTrackLengthFlag;
 
-    bool EnableTOut;
-    bool EnableTProd;
+  bool EnableTOut;
+  bool EnableTProd;
 
-    bool mSphereProjectionFlag;
-    G4ThreeVector mSphereProjectionCenter;
-    double mSphereProjectionRadius;
+  bool mSphereProjectionFlag;
+  G4ThreeVector mSphereProjectionCenter;
+  double mSphereProjectionRadius;
 
-    bool mTranslateAlongDirectionFlag;
-    double mTranslationLength;
+  bool mTranslateAlongDirectionFlag;
+  double mTranslationLength;
 
-    bool bEnableCoordFrame;
-    G4String bCoordFrame;
-    bool bEnablePrimaryEnergy;
-    float bPrimaryEnergy;
-    bool bEnableEmissionPoint;
-    float bEmissionPointX, bEmissionPointY, bEmissionPointZ;
-    bool bEnableSpotID;
-    G4String bSpotIDFromSource;
-    int bSpotID;
-    bool bEnableCompact;
-    bool bEnablePDGCode;
-    int bPDGCode;
-    double trackLength;
+  bool bEnableCoordFrame;
+  G4String bCoordFrame;
+  bool bEnablePrimaryEnergy;
+  float bPrimaryEnergy;
+  bool bEnableEmissionPoint;
+  float bEmissionPointX, bEmissionPointY, bEmissionPointZ;
+  bool bEnableSpotID;
+  G4String bSpotIDFromSource;
+  int bSpotID;
+  bool bEnableCompact;
+  bool bEnablePDGCode;
+  int bPDGCode;
+  double trackLength;
 
-    bool mMaskIsEnabled;
-    G4String mMaskFilename;
-    GateImage mMask;
-    bool mKillParticleFlag;
+  bool mMaskIsEnabled;
+  G4String mMaskFilename;
+  GateImage mMask;
+  bool mKillParticleFlag;
 
-    bool bEnableTOut;
-    bool bEnableTProd;
+  bool bEnableTOut;
+  bool bEnableTProd;
 
-    double mFileSize;
+  double mFileSize;
 
-    long int mNumberOfTrack;
+  long int mNumberOfTrack;
 
-    bool mIsFirstStep;
+  bool mIsFirstStep;
 
-    char pname[256];
+  char pname[256];
 
-    G4int Za;
-    float elecDEDX;
-    float totalDEDX;
-    float stepLength;
-    float edep;
+  G4int Za;
+  G4double charge;
+  float elecDEDX;
+  float totalDEDX;
+  float stepLength;
+  float edep;
 
-    float x;
-    float y;
-    float z;
-    float dx;
-    float dy;
-    float dz;
-    float e;
-    float ekPost;
-    float ekPre;
-    float w;
-    float tOut;
-    float tProd;
-    double t;//t is either time or local time.
-    double fTimeFromBeginOfEvent;
-    double fBeginOfEventTime;
+  float x;
+  float y;
+  float z;
+  float dx;
+  float dy;
+  float dz;
+  float e;
+  float ekPost;
+  float ekPre;
+  float w;
+  float tOut;
+  float tProd;
+  double t; // t is either time or local time.
+  double fTimeFromBeginOfEvent;
+  double fBeginOfEventTime;
 
-    G4int m;
-    char vol[256];
+  G4int m;
+  char vol[256];
 
-    char creator_process[256];
-    char pro_step[256];
+  char creator_process[256];
+  char pro_step[256];
 
-    int trackid;
-    int parentid;
-    int eventid;
-    int runid;
+  int trackid;
+  int parentid;
+  int eventid;
+  int runid;
 
-    int creator;
-    int nucprocess;
-    int order;
+  int creator;
+  int nucprocess;
+  int order;
 
-    G4EmCalculator *emcalc;
-    GatePhaseSpaceActorMessenger *pMessenger;
+  G4EmCalculator *emcalc;
+  GatePhaseSpaceActorMessenger *pMessenger;
 
-    iaea_record_type *pIAEARecordType;
-    iaea_header_type *pIAEAheader;
+  iaea_record_type *pIAEARecordType;
+  iaea_header_type *pIAEAheader;
 };
 
 MAKE_AUTO_CREATOR_ACTOR(PhaseSpaceActor, GatePhaseSpaceActor)
 
-
 #endif /* end #define GATESOURCEACTOR_HH */
-

--- a/source/digits_hits/include/GatePhaseSpaceActorMessenger.hh
+++ b/source/digits_hits/include/GatePhaseSpaceActorMessenger.hh
@@ -6,7 +6,6 @@
   See LICENSE.md for further details
   ----------------------*/
 
-
 /*
   \class  GatePhaseSpaceActorMessenger
   \author thibault.frisson@creatis.insa-lyon.fr
@@ -34,62 +33,62 @@ class G4UIcmdWith3VectorAndUnit;
 
 class GatePhaseSpaceActor;
 
-class GatePhaseSpaceActorMessenger : public GateActorMessenger {
+class GatePhaseSpaceActorMessenger : public GateActorMessenger
+{
 public:
-    GatePhaseSpaceActorMessenger(GatePhaseSpaceActor *sensor);
+  GatePhaseSpaceActorMessenger(GatePhaseSpaceActor *sensor);
 
-    virtual ~GatePhaseSpaceActorMessenger();
+  virtual ~GatePhaseSpaceActorMessenger();
 
-    void BuildCommands(G4String base);
+  void BuildCommands(G4String base);
 
-    virtual void SetNewValue(G4UIcommand *, G4String);
+  virtual void SetNewValue(G4UIcommand *, G4String);
 
 protected:
-    GatePhaseSpaceActor *pActor;
+  GatePhaseSpaceActor *pActor;
 
-    G4UIcmdWithABool *pEnableChargeCmd;
-    G4UIcmdWithABool *pEnableElectronicDEDXCmd;
-    G4UIcmdWithABool *pEnableTotalDEDXCmd;
-    G4UIcmdWithABool *pEnableEkineCmd;
-    G4UIcmdWithABool *pEnablePositionXCmd;
-    G4UIcmdWithABool *pEnablePositionYCmd;
-    G4UIcmdWithABool *pEnablePositionZCmd;
-    G4UIcmdWithABool *pEnableDirectionXCmd;
-    G4UIcmdWithABool *pEnableDirectionYCmd;
-    G4UIcmdWithABool *pEnableDirectionZCmd;
-    G4UIcmdWithABool *pEnableProdVolumeCmd;
-    G4UIcmdWithABool *pEnableProdProcessCmd;
-    G4UIcmdWithABool *pEnableParticleNameCmd;
-    G4UIcmdWithABool *pEnableWeightCmd;
-    G4UIcmdWithABool *pEnableTimeCmd;
-    G4UIcmdWithABool *pEnableTimeFromBeginOfEventCmd;
-    G4UIcmdWithABool *pEnableTrackLengthCmd;
-    G4UIcmdWithABool *pEnableMassCmd;
-    G4UIcmdWithABool *pEnableSecCmd;
-    G4UIcmdWithABool *pEnableStoreAllStepCmd;
-    G4UIcmdWithABool *pCoordinateInVolumeFrameCmd;
-    G4UIcmdWithADoubleAndUnit *pMaxSizeCmd;
-    G4UIcmdWithABool *pInOrOutGoingParticlesCmd;
-    G4UIcmdWithABool *bEnablePrimaryEnergyCmd;
-    G4UIcmdWithABool *bEnableEmissionPointCmd;
-    G4UIcmdWithAString *bCoordinateFrameCmd;
-    G4UIcmdWithABool *bEnableLocalTimeCmd;
-    G4UIcmdWithAString *bSpotIDFromSourceCmd;
-    G4UIcmdWithABool *bEnablePDGCodeCmd;
-    G4UIcmdWithABool *bEnableCompactCmd;
-    G4UIcmdWithABool *pEnableNuclearFlagCmd;
-    G4UIcmdWithABool *bEnableSphereProjection;
-    G4UIcmdWith3VectorAndUnit *bSetSphereProjectionCenter;
-    G4UIcmdWithADoubleAndUnit *bSetSphereProjectionRadius;
-    G4UIcmdWithABool *bEnableTranslationAlongDirection;
-    G4UIcmdWithADoubleAndUnit *bSetTranslationAlongDirectionLength;
+  G4UIcmdWithABool *pEnableChargeCmd;
+  G4UIcmdWithABool *pEnableAtomicNumberCmd;
+  G4UIcmdWithABool *pEnableElectronicDEDXCmd;
+  G4UIcmdWithABool *pEnableTotalDEDXCmd;
+  G4UIcmdWithABool *pEnableEkineCmd;
+  G4UIcmdWithABool *pEnablePositionXCmd;
+  G4UIcmdWithABool *pEnablePositionYCmd;
+  G4UIcmdWithABool *pEnablePositionZCmd;
+  G4UIcmdWithABool *pEnableDirectionXCmd;
+  G4UIcmdWithABool *pEnableDirectionYCmd;
+  G4UIcmdWithABool *pEnableDirectionZCmd;
+  G4UIcmdWithABool *pEnableProdVolumeCmd;
+  G4UIcmdWithABool *pEnableProdProcessCmd;
+  G4UIcmdWithABool *pEnableParticleNameCmd;
+  G4UIcmdWithABool *pEnableWeightCmd;
+  G4UIcmdWithABool *pEnableTimeCmd;
+  G4UIcmdWithABool *pEnableTimeFromBeginOfEventCmd;
+  G4UIcmdWithABool *pEnableTrackLengthCmd;
+  G4UIcmdWithABool *pEnableMassCmd;
+  G4UIcmdWithABool *pEnableSecCmd;
+  G4UIcmdWithABool *pEnableStoreAllStepCmd;
+  G4UIcmdWithABool *pCoordinateInVolumeFrameCmd;
+  G4UIcmdWithADoubleAndUnit *pMaxSizeCmd;
+  G4UIcmdWithABool *pInOrOutGoingParticlesCmd;
+  G4UIcmdWithABool *bEnablePrimaryEnergyCmd;
+  G4UIcmdWithABool *bEnableEmissionPointCmd;
+  G4UIcmdWithAString *bCoordinateFrameCmd;
+  G4UIcmdWithABool *bEnableLocalTimeCmd;
+  G4UIcmdWithAString *bSpotIDFromSourceCmd;
+  G4UIcmdWithABool *bEnablePDGCodeCmd;
+  G4UIcmdWithABool *bEnableCompactCmd;
+  G4UIcmdWithABool *pEnableNuclearFlagCmd;
+  G4UIcmdWithABool *bEnableSphereProjection;
+  G4UIcmdWith3VectorAndUnit *bSetSphereProjectionCenter;
+  G4UIcmdWithADoubleAndUnit *bSetSphereProjectionRadius;
+  G4UIcmdWithABool *bEnableTranslationAlongDirection;
+  G4UIcmdWithADoubleAndUnit *bSetTranslationAlongDirectionLength;
 
-    G4UIcmdWithABool *pEnableTOutCmd;
-    G4UIcmdWithABool *pEnableTProdCmd;
-    G4UIcmdWithAString *pUseMaskCmd;
-    G4UIcmdWithABool *pEnableKillCmd;
-
+  G4UIcmdWithABool *pEnableTOutCmd;
+  G4UIcmdWithABool *pEnableTProdCmd;
+  G4UIcmdWithAString *pUseMaskCmd;
+  G4UIcmdWithABool *pEnableKillCmd;
 };
 
 #endif /* end #define GATESOURCEACTORMESSENGER_HH*/
-

--- a/source/digits_hits/src/GatePhaseSpaceActor.cc
+++ b/source/digits_hits/src/GatePhaseSpaceActor.cc
@@ -6,7 +6,6 @@
   See LICENSE.md for further details
   ----------------------*/
 
-
 //
 /*
   \brief Class GatePhaseSpaceActor
@@ -15,7 +14,6 @@
   david.sarrut@creatis.insa-lyon.fr
   brent.huisman@insa-lyon.fr
 */
-
 
 #include "GatePhaseSpaceActor.hh"
 #include <G4EmCalculator.hh>
@@ -31,14 +29,14 @@
 #include "GatePhaseSpaceActorMessenger.hh"
 #include "GateIAEAHeader.h"
 
-
 // --------------------------------------------------------------------
-GatePhaseSpaceActor::GatePhaseSpaceActor(G4String name, G4int depth) :
-    GateVActor(name, depth) {
+GatePhaseSpaceActor::GatePhaseSpaceActor(G4String name, G4int depth) : GateVActor(name, depth)
+{
     GateDebugMessageInc("Actor", 4, "GatePhaseSpaceActor() -- begin\n");
 
     pMessenger = new GatePhaseSpaceActorMessenger(this);
     EnableCharge = true;
+    EnableAtomicNumber = true;
     EnableElectronicDEDX = false;
     EnableTotalDEDX = false;
     EnableXPosition = true;
@@ -101,10 +99,10 @@ GatePhaseSpaceActor::GatePhaseSpaceActor(G4String name, G4int depth) :
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
 /// Destructor
-GatePhaseSpaceActor::~GatePhaseSpaceActor() {
+GatePhaseSpaceActor::~GatePhaseSpaceActor()
+{
     GateDebugMessageInc("Actor", 4, "~GatePhaseSpaceActor() -- begin\n");
 
     free(pIAEAheader);
@@ -119,7 +117,8 @@ GatePhaseSpaceActor::~GatePhaseSpaceActor() {
 
 // --------------------------------------------------------------------
 /// Construct
-void GatePhaseSpaceActor::Construct() {
+void GatePhaseSpaceActor::Construct()
+{
     GateVActor::Construct();
     // Enable callbacks
     EnableBeginOfRunAction(true);
@@ -132,56 +131,78 @@ void GatePhaseSpaceActor::Construct() {
     G4String extension = getExtension(mSaveFilename);
 
     // If mask, load the image
-    if (mMaskIsEnabled) {
+    if (mMaskIsEnabled)
+    {
         GateMessage("Actor", 1, "GatePhaseSpaceActor read mask file " << mMaskFilename);
         mMask.Read(mMaskFilename);
     }
 
-    if (extension == "IAEAphsp" || extension == "IAEAheader") {
+    if (extension == "IAEAphsp" || extension == "IAEAheader")
+    {
         mFileType = "iaeaFile";
-        pIAEAheader = (iaea_header_type *) calloc(1, sizeof(iaea_header_type));
+        pIAEAheader = (iaea_header_type *)calloc(1, sizeof(iaea_header_type));
         pIAEAheader->initialize_counters();
-        pIAEARecordType = (iaea_record_type *) calloc(1, sizeof(iaea_record_type));
+        pIAEARecordType = (iaea_record_type *)calloc(1, sizeof(iaea_record_type));
 
         G4String IAEAFileExt = ".IAEAphsp";
         G4String IAEAFileName = " ";
         IAEAFileName = G4String(removeExtension(mSaveFilename));
 
         pIAEARecordType->p_file = open_file(const_cast<char *>(IAEAFileName.c_str()),
-                                            const_cast<char *>(IAEAFileExt.c_str()), (char *) "wb");
+                                            const_cast<char *>(IAEAFileExt.c_str()), (char *)"wb");
 
-        if (pIAEARecordType->p_file == NULL) GateError("File " << IAEAFileName << IAEAFileExt << " not opened.");
+        if (pIAEARecordType->p_file == NULL)
+            GateError("File " << IAEAFileName << IAEAFileExt << " not opened.");
         if (pIAEARecordType->initialize() != OK)
             GateError("File " << IAEAFileName << IAEAFileExt << " not initialized.");
 
-        if (EnableXPosition) pIAEARecordType->ix = 1;
-        if (EnableYPosition) pIAEARecordType->iy = 1;
-        if (EnableZPosition) pIAEARecordType->iz = 1;
-        if (EnableXDirection) pIAEARecordType->iu = 1;
-        if (EnableYDirection) pIAEARecordType->iv = 1;
-        if (EnableZDirection) pIAEARecordType->iw = 1;
-        if (EnableWeight) pIAEARecordType->iweight = 1;
-        if (EnableTime || EnableLocalTime) {
+        if (EnableXPosition)
+            pIAEARecordType->ix = 1;
+        if (EnableYPosition)
+            pIAEARecordType->iy = 1;
+        if (EnableZPosition)
+            pIAEARecordType->iz = 1;
+        if (EnableXDirection)
+            pIAEARecordType->iu = 1;
+        if (EnableYDirection)
+            pIAEARecordType->iv = 1;
+        if (EnableZDirection)
+            pIAEARecordType->iw = 1;
+        if (EnableWeight)
+            pIAEARecordType->iweight = 1;
+        if (EnableTime || EnableLocalTime)
+        {
             GateWarning("'Time' is not available in IAEA phase space.");
         }
-        if (EnableMass) {
+        if (EnableMass)
+        {
             GateWarning("'Mass' is not available in IAEA phase space.");
         }
-        if (pIAEAheader->set_record_contents(pIAEARecordType) == FAIL) GateError("Record contents not setted.");
-    } else {
-        if (extension == "root") {
+        if (pIAEAheader->set_record_contents(pIAEARecordType) == FAIL)
+            GateError("Record contents not setted.");
+    }
+    else
+    {
+        if (extension == "root")
+        {
             mFileType = "rootFile";
-        } else if (extension == "npy") {
+        }
+        else if (extension == "npy")
+        {
             mFileType = "npyFile";
-        } else if (extension == "txt") {
+        }
+        else if (extension == "txt")
+        {
             mFileType = "txtFile";
-        } else
+        }
+        else
             GateError("Unknown extension for phasespace");
     }
 }
 // --------------------------------------------------------------------
 
-void GatePhaseSpaceActor::InitTree() {
+void GatePhaseSpaceActor::InitTree()
+{
     mFile = new GateOutputTreeFileManager();
 
     if (mFileType == "npyFile")
@@ -193,54 +214,88 @@ void GatePhaseSpaceActor::InitTree() {
 
     mFile->set_tree_name("PhaseSpace");
 
-    if (EnableCharge) mFile->write_variable("AtomicNumber", &Za);
+    if (EnableAtomicNumber)
+        mFile->write_variable("AtomicNumber", &Za);
 
-    if (EnableElectronicDEDX) mFile->write_variable("ElectronicDEDX", &elecDEDX);
-    if (EnableElectronicDEDX) mFile->write_variable("StepLength", &stepLength);
-    if (EnableElectronicDEDX) mFile->write_variable("Edep", &edep);
-    if (EnableTotalDEDX) mFile->write_variable("TotalDEDX", &totalDEDX);
+    if (EnableCharge)
+        mFile->write_variable("Charge", &charge);
 
-    if (EnableEkine) mFile->write_variable("Ekine", &e);
-    if (EnableElectronicDEDX) mFile->write_variable("Ekpost", &ekPost);
-    if (EnableElectronicDEDX) mFile->write_variable("Ekpre", &ekPre);
-    if (EnableWeight) mFile->write_variable("Weight", &w);
-    if (EnableTime || EnableLocalTime) mFile->write_variable("Time", &t);
-    if (EnableMass) mFile->write_variable("Mass", &m); // in MeV/c2
-    if (EnableXPosition) mFile->write_variable("X", &x);
-    if (EnableYPosition) mFile->write_variable("Y", &y);
-    if (EnableZPosition) mFile->write_variable("Z", &z);
-    if (EnableXDirection) mFile->write_variable("dX", &dx);
-    if (EnableYDirection) mFile->write_variable("dY", &dy);
-    if (EnableZDirection) mFile->write_variable("dZ", &dz);
+    if (EnableElectronicDEDX)
+        mFile->write_variable("ElectronicDEDX", &elecDEDX);
+    if (EnableElectronicDEDX)
+        mFile->write_variable("StepLength", &stepLength);
+    if (EnableElectronicDEDX)
+        mFile->write_variable("Edep", &edep);
+    if (EnableTotalDEDX)
+        mFile->write_variable("TotalDEDX", &totalDEDX);
 
-    if (EnableTrackLengthFlag) mFile->write_variable("trackLength", &trackLength);
+    if (EnableEkine)
+        mFile->write_variable("Ekine", &e);
+    if (EnableElectronicDEDX)
+        mFile->write_variable("Ekpost", &ekPost);
+    if (EnableElectronicDEDX)
+        mFile->write_variable("Ekpre", &ekPre);
+    if (EnableWeight)
+        mFile->write_variable("Weight", &w);
+    if (EnableTime || EnableLocalTime)
+        mFile->write_variable("Time", &t);
+    if (EnableMass)
+        mFile->write_variable("Mass", &m); // in MeV/c2
+    if (EnableXPosition)
+        mFile->write_variable("X", &x);
+    if (EnableYPosition)
+        mFile->write_variable("Y", &y);
+    if (EnableZPosition)
+        mFile->write_variable("Z", &z);
+    if (EnableXDirection)
+        mFile->write_variable("dX", &dx);
+    if (EnableYDirection)
+        mFile->write_variable("dY", &dy);
+    if (EnableZDirection)
+        mFile->write_variable("dZ", &dz);
 
-    if (EnablePartName /*&& bEnableCompact==false*/) mFile->write_variable("ParticleName", pname, sizeof(pname));
-    if (EnableProdVol && bEnableCompact == false) mFile->write_variable("ProductionVolume", vol, sizeof(vol));
+    if (EnableTrackLengthFlag)
+        mFile->write_variable("trackLength", &trackLength);
+
+    if (EnablePartName /*&& bEnableCompact==false*/)
+        mFile->write_variable("ParticleName", pname, sizeof(pname));
+    if (EnableProdVol && bEnableCompact == false)
+        mFile->write_variable("ProductionVolume", vol, sizeof(vol));
     if (EnableProdProcess && bEnableCompact == false)
         mFile->write_variable("CreatorProcess", creator_process, sizeof(creator_process));
     if (EnableProdProcess && bEnableCompact == false)
         mFile->write_variable("ProcessDefinedStep", pro_step, sizeof(pro_step));
-    if (bEnableCompact == false) mFile->write_variable("TrackID", &trackid);
-    if (bEnableCompact == false) mFile->write_variable("ParentID", &parentid);
-    if (bEnableCompact == false) mFile->write_variable("EventID", &eventid);
-    if (bEnableCompact == false) mFile->write_variable("RunID", &runid);
-    if (bEnablePrimaryEnergy) mFile->write_variable("PrimaryEnergy", &bPrimaryEnergy);
-    if (bEnablePDGCode) mFile->write_variable("PDGCode", &bPDGCode);
-    if (bEnableEmissionPoint) {
+    if (bEnableCompact == false)
+        mFile->write_variable("TrackID", &trackid);
+    if (bEnableCompact == false)
+        mFile->write_variable("ParentID", &parentid);
+    if (bEnableCompact == false)
+        mFile->write_variable("EventID", &eventid);
+    if (bEnableCompact == false)
+        mFile->write_variable("RunID", &runid);
+    if (bEnablePrimaryEnergy)
+        mFile->write_variable("PrimaryEnergy", &bPrimaryEnergy);
+    if (bEnablePDGCode)
+        mFile->write_variable("PDGCode", &bPDGCode);
+    if (bEnableEmissionPoint)
+    {
         mFile->write_variable("EmissionPointX", &bEmissionPointX);
         mFile->write_variable("EmissionPointY", &bEmissionPointY);
         mFile->write_variable("EmissionPointZ", &bEmissionPointZ);
     }
-    if (bEnableSpotID) mFile->write_variable("SpotID", &bSpotID);
+    if (bEnableSpotID)
+        mFile->write_variable("SpotID", &bSpotID);
 
-    if (EnableTOut) mFile->write_variable("TOut", &tOut);
-    if (EnableTProd) mFile->write_variable("TProd", &tProd);
+    if (EnableTOut)
+        mFile->write_variable("TOut", &tOut);
+    if (EnableTProd)
+        mFile->write_variable("TProd", &tProd);
 
     if (EnableTimeFromBeginOfEvent)
         mFile->write_variable("TimeFromBeginOfEvent", &fTimeFromBeginOfEvent);
 
-    if (EnableNuclearFlag) {
+    if (EnableNuclearFlag)
+    {
         mFile->write_variable("CreatorProcess", &creator);
         mFile->write_variable("NuclearProcess", &nucprocess);
         mFile->write_variable("Order", &order);
@@ -249,50 +304,57 @@ void GatePhaseSpaceActor::InitTree() {
 }
 
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::BeginOfRunAction(const G4Run *r) {
-    if (!this->mOverWriteFilesFlag) {
+void GatePhaseSpaceActor::BeginOfRunAction(const G4Run *r)
+{
+    if (!this->mOverWriteFilesFlag)
+    {
         mSaveFilename = GetSaveCurrentFilename(mSaveInitialFilename);
         InitTree();
-    } else {
+    }
+    else
+    {
         // Only init the tree at the first run
-        if (r->GetRunID() == 0) {
+        if (r->GetRunID() == 0)
+        {
             InitTree();
         }
     }
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::RecordEndOfAcquisition() {
+void GatePhaseSpaceActor::RecordEndOfAcquisition()
+{
     // For npy output, write and close must be done at the end.
-    if (this->mOverWriteFilesFlag) {
+    if (this->mOverWriteFilesFlag)
+    {
         mFile->write();
         mFile->close();
     }
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::SetMaskFilename(G4String filename) {
+void GatePhaseSpaceActor::SetMaskFilename(G4String filename)
+{
     mMaskFilename = filename;
     mMaskIsEnabled = true;
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::SetKillParticleFlag(bool b) {
+void GatePhaseSpaceActor::SetKillParticleFlag(bool b)
+{
     mKillParticleFlag = b;
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::PreUserTrackingAction(const GateVVolume * /*v*/, const G4Track *t) {
+void GatePhaseSpaceActor::PreUserTrackingAction(const GateVVolume * /*v*/, const G4Track *t)
+{
     mIsFirstStep = true;
-    if (bEnableEmissionPoint) {
+    if (bEnableEmissionPoint)
+    {
         bEmissionPointX = t->GetVertexPosition().x();
         bEmissionPointY = t->GetVertexPosition().y();
         bEmissionPointZ = t->GetVertexPosition().z();
@@ -301,27 +363,30 @@ void GatePhaseSpaceActor::PreUserTrackingAction(const GateVVolume * /*v*/, const
 // --------------------------------------------------------------------
 
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::PostUserTrackingAction(const GateVVolume * /*v*/, const G4Track *t) {
-    if (EnableTrackLengthFlag) {
+void GatePhaseSpaceActor::PostUserTrackingAction(const GateVVolume * /*v*/, const G4Track *t)
+{
+    if (EnableTrackLengthFlag)
+    {
         trackLength = t->GetTrackLength();
     }
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::BeginOfEventAction(const G4Event *e) {
+void GatePhaseSpaceActor::BeginOfEventAction(const G4Event *e)
+{
     // Set Primary Energy
-    bPrimaryEnergy = e->GetPrimaryVertex()->GetPrimary()->GetKineticEnergy(); //GetInitialEnergy oid.
+    bPrimaryEnergy = e->GetPrimaryVertex()->GetPrimary()->GetKineticEnergy(); // GetInitialEnergy oid.
 
     // Store the application time of the event
     auto app = GateApplicationMgr::GetInstance();
     fBeginOfEventTime = app->GetCurrentTime();
-    //std::cout << "GatePhaseSpaceActor::BeginOfEventAction fBeginOfEventTime = "
-    //          << G4BestUnit(fBeginOfEventTime, "Time") << std::endl;
+    // std::cout << "GatePhaseSpaceActor::BeginOfEventAction fBeginOfEventTime = "
+    //           << G4BestUnit(fBeginOfEventTime, "Time") << std::endl;
 
     // Set SourceID
-    if (GetIsSpotIDEnabled()) {
+    if (GetIsSpotIDEnabled())
+    {
         GateSourceTPSPencilBeam *tpspencilsource =
             dynamic_cast<GateSourceTPSPencilBeam *>(GateSourceMgr::GetInstance()->GetSourceByName(
                 bSpotIDFromSource));
@@ -330,9 +395,9 @@ void GatePhaseSpaceActor::BeginOfEventAction(const G4Event *e) {
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *step) {
+void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *step)
+{
 
     /*
       Options:
@@ -347,29 +412,36 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     // It is initialized to true in PreUserTrackingAction and to false here.
 
     // If track already stored and the option EnableAllStep is not true, do nothing.
-    if (!mIsFirstStep && !EnableAllStep) return;
+    if (!mIsFirstStep && !EnableAllStep)
+        return;
 
     // If this is the first time we see the track and this is an event,
     // increment mNevent (used by iaea output)
-    if (mIsFirstStep && step->GetTrack()->GetTrackID() == 1) mNevent++;
+    if (mIsFirstStep && step->GetTrack()->GetTrackID() == 1)
+        mNevent++;
 
     // By default, we consider the preStep (starting point), except if
     // user set mStoreOutPart or if the option EnableAllStep is enabled
     G4StepPoint *stepPoint;
-    if (mStoreOutPart || EnableAllStep) stepPoint = step->GetPostStepPoint();
-    else stepPoint = step->GetPreStepPoint();
+    if (mStoreOutPart || EnableAllStep)
+        stepPoint = step->GetPostStepPoint();
+    else
+        stepPoint = step->GetPreStepPoint();
 
     // If needed, check if in the mask, if not, do nothing (do not store, do not mark particle)
-    if (mMaskIsEnabled) {
-        //auto vox = dynamic_cast<const GateVImageVolume*>(mVolume);
-        if (mVolume != NULL) {
+    if (mMaskIsEnabled)
+    {
+        // auto vox = dynamic_cast<const GateVImageVolume*>(mVolume);
+        if (mVolume != NULL)
+        {
             const bool mPositionIsSet = false;
             const G4ThreeVector mPosition;
             const GateVImageActor::StepHitType mStepHitType = GateVImageActor::PreStepHitType;
             auto index = GateVImageActor::GetIndexFromStepPosition2(mVolume, step, mMask, mPositionIsSet, mPosition,
                                                                     mStepHitType);
             auto value = mMask.GetValue(index);
-            if (value == 1) return; // do nothing
+            if (value == 1)
+                return; // do nothing
         }
     }
 
@@ -380,19 +452,22 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     strcpy(vol, st.c_str());
 
     //----------- ??? -------------
-    //FIXME: Document what this is/does.
-    //if(vol!=mVolume->GetLogicalVolumeName() && mStoreOutPart) return;
-    if (vol == mVolume->GetLogicalVolumeName() && !EnableSec && !mStoreOutPart) return;
-    //if(!( mStoreOutPart && step->IsLastStepInVolume())) return;
+    // FIXME: Document what this is/does.
+    // if(vol!=mVolume->GetLogicalVolumeName() && mStoreOutPart) return;
+    if (vol == mVolume->GetLogicalVolumeName() && !EnableSec && !mStoreOutPart)
+        return;
+    // if(!( mStoreOutPart && step->IsLastStepInVolume())) return;
 
     //----------- ??? -------------
-    //FIXME: Document what this is/does.
-    //something wrong here:
-    if (mStoreOutPart && step->GetTrack()->GetVolume() == step->GetTrack()->GetNextVolume()) return;
+    // FIXME: Document what this is/does.
+    // something wrong here:
+    if (mStoreOutPart && step->GetTrack()->GetVolume() == step->GetTrack()->GetNextVolume())
+        return;
 
     //----------- Workaround for outgoing particles flag -------------
-    //FIXME: Document why necesary?
-    if (mStoreOutPart) {
+    // FIXME: Document why necesary?
+    if (mStoreOutPart)
+    {
         /* 2014-06-11: Brent & David
          * There is a rare bug when using the PhaseSpaceActor to store outgoing particles and very long cuts on particles (nongammas).
          * When a particle crosses from a segmented_log_X volume to a segmented_log_X, Gate segfaults.
@@ -400,19 +475,24 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
          * Unsure if this hack is dirty and needs to be checked.
          */
         G4VPhysicalVolume *pv = step->GetTrack()->GetNextVolume();
-        if (pv == 0) return;
+        if (pv == 0)
+            return;
         GateVVolume *nextVol = GateObjectStore::GetInstance()->FindVolumeCreator(pv);
-        if (nextVol == 0) return;
-        if (nextVol == mVolume)return;
+        if (nextVol == 0)
+            return;
+        if (nextVol == mVolume)
+            return;
         GateVVolume *parent = nextVol->GetParentVolume();
-        while (parent) {
-            if (parent == mVolume) return;
+        while (parent)
+        {
+            if (parent == mVolume)
+                return;
             parent = parent->GetParentVolume();
         }
     }
 
     //----------- ??? -------------
-    //FIXME: remove?
+    // FIXME: remove?
     /*if(mStoreOutPart && step->GetTrack()->GetVolume()!=mVolume->GetPhysicalVolume() ){
       GateVVolume *parent = mVolume->GetParentVolume();
       while(parent){
@@ -429,23 +509,28 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     strcpy(pname, st.c_str());
     bPDGCode = step->GetTrack()->GetDefinition()->GetPDGEncoding();
 
-    //cout << step->GetTrack()->GetDefinition()->GetPDGEncoding() << endl;
-    // TODO doesnt work, undefined reference. Problem with makefile?
-    //Solution, use PDGcode instead of ParticleName. However, GatePhaseSpaceSource uses Particlename char[64] while GatePhaseSpaceActor stores Char_t[256].
+    // cout << step->GetTrack()->GetDefinition()->GetPDGEncoding() << endl;
+    //  TODO doesnt work, undefined reference. Problem with makefile?
+    // Solution, use PDGcode instead of ParticleName. However, GatePhaseSpaceSource uses Particlename char[64] while GatePhaseSpaceActor stores Char_t[256].
 
     //------------Write position of the steps presents at the simulation-------------
     G4ThreeVector localPosition = stepPoint->GetPosition();
 
-    if (GetUseVolumeFrame()) {
+    if (GetUseVolumeFrame())
+    {
         const G4AffineTransform transformation = step->GetPreStepPoint()->GetTouchable()->GetHistory()->GetTopTransform();
         localPosition = transformation.TransformPoint(localPosition);
-    } else if (GetEnableCoordFrame()) {
+    }
+    else if (GetEnableCoordFrame())
+    {
         // Give GetUseVolumeFrame preference
 
         // Find the transform from GetCoordFrame volume to the world.
         GateVVolume *v = GateObjectStore::GetInstance()->FindCreator(GetCoordFrame());
-        if (v == NULL) {
-            if (mFileType == "rootFile") {
+        if (v == NULL)
+        {
+            if (mFileType == "rootFile")
+            {
                 mFile->close();
             }
             GateError("Error, cannot find the volume '" << GetCoordFrame() << "' -> (see the setCoordinateFrame)");
@@ -453,7 +538,8 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
 
         G4VPhysicalVolume *phys = v->GetPhysicalVolume();
         G4AffineTransform volumeToWorld = G4AffineTransform(phys->GetRotation(), phys->GetTranslation());
-        while (v->GetLogicalVolumeName() != "world_log") {
+        while (v->GetLogicalVolumeName() != "world_log")
+        {
             v = v->GetParentVolume();
             phys = v->GetPhysicalVolume();
             G4AffineTransform x(phys->GetRotation(), phys->GetTranslation());
@@ -463,10 +549,9 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
         volumeToWorld = volumeToWorld.NetRotation();
         G4AffineTransform worldToVolume = volumeToWorld.Inverse();
 
-        //old crap:stepLength
-        //const G4AffineTransform transformation = GateObjectStore::GetInstance()->FindCreator(GetCoordFrame())->GetPhysicalVolume()->GetTouchable()->GetHistory()->GetTopTransform();
+        // old crap:stepLength
+        // const G4AffineTransform transformation = GateObjectStore::GetInstance()->FindCreator(GetCoordFrame())->GetPhysicalVolume()->GetTouchable()->GetHistory()->GetTopTransform();
         localPosition = worldToVolume.TransformPoint(localPosition);
-
     }
 
     trackid = step->GetTrack()->GetTrackID();
@@ -485,11 +570,13 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     // protonInelastic = 2
     //===============================================================================================================
 
-    if (EnableNuclearFlag) {
+    if (EnableNuclearFlag)
+    {
         GateProtonNuclearInformation *info = dynamic_cast<GateProtonNuclearInformation *>(step->GetTrack()->GetUserInformation());
         if (info == NULL)
             GateWarning("Could not retrieve GateProtonNuclearInformation, EnableNuclearFlag needs it");
-        else {
+        else
+        {
             creator = 0;
             nucprocess = 0;
             order = info->GetScatterOrder();
@@ -523,17 +610,21 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     //--------------Write momentum of the steps presents at the simulation----------
     G4ThreeVector localMomentum = stepPoint->GetMomentumDirection();
 
-    if (GetUseVolumeFrame()) {
+    if (GetUseVolumeFrame())
+    {
         const G4AffineTransform transformation = step->GetPreStepPoint()->GetTouchable()->GetHistory()->GetTopTransform();
         localMomentum = transformation.TransformAxis(localMomentum);
-    } else if (GetEnableCoordFrame()) {
+    }
+    else if (GetEnableCoordFrame())
+    {
         // Give GetUseVolumeFrame preference
 
         // Find the transform from GetCoordFrame volume to the world.
         GateVVolume *v = GateObjectStore::GetInstance()->FindCreator(GetCoordFrame());
         G4VPhysicalVolume *phys = v->GetPhysicalVolume();
         G4AffineTransform volumeToWorld = G4AffineTransform(phys->GetRotation(), phys->GetTranslation());
-        while (v->GetLogicalVolumeName() != "world_log") {
+        while (v->GetLogicalVolumeName() != "world_log")
+        {
             v = v->GetParentVolume();
             phys = v->GetPhysicalVolume();
             G4AffineTransform x(phys->GetRotation(), phys->GetTranslation());
@@ -572,7 +663,8 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
        position than the one where it has been detected. The option
        ''SphereProjection' change the particle position: it compute the projection
        on a sphere. */
-    if (mSphereProjectionFlag) {
+    if (mSphereProjectionFlag)
+    {
         // Project point position on the use sphere
         // https://en.wikipedia.org/wiki/Line–sphere_intersection
 
@@ -591,13 +683,15 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
 
         // How many intersection ? 0,1 or 2 ?
         // If no intersection, we ignore this hit
-        if (B < 0) return;
+        if (B < 0)
+            return;
 
         // else we consider the closest one
         double d1 = (A + sqrt(B)) / C;
         double d2 = (A - sqrt(B)) / C;
         double d = d1;
-        if (fabs(d2) < fabs(d1)) d = d2;
+        if (fabs(d2) < fabs(d1))
+            d = d2;
         x = x + dx * d;
         y = y + dy * d;
         z = z + dz * d;
@@ -606,7 +700,8 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     /*
       Translate the particle point along the direction by a given value
     */
-    if (mTranslateAlongDirectionFlag) {
+    if (mTranslateAlongDirectionFlag)
+    {
 
         // move point along its direction by a length d (may be negative)
         G4ThreeVector o(x, y, z);
@@ -620,19 +715,16 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     //-------------Write weight of the steps presents at the simulation-------------
     w = stepPoint->GetWeight();
 
-    if (EnableLocalTime) {
+    if (EnableLocalTime)
+    {
         t = stepPoint->GetLocalTime();
-    } else t = stepPoint->GetGlobalTime();
+    }
+    else
+        t = stepPoint->GetGlobalTime();
 
-    //t = step->GetTrack()->GetProperTime() ; //tibo : which time?????
-    GateDebugMessage("Actor", 4, st
-        << " stepPoint time proper=" << G4BestUnit(stepPoint->GetProperTime(), "Time")
-        << " global=" << G4BestUnit(stepPoint->GetGlobalTime(), "Time")
-        << " local=" << G4BestUnit(stepPoint->GetLocalTime(), "Time") << Gateendl);
-    GateDebugMessage("Actor", 4, "trackid="
-        << step->GetTrack()->GetParentID()
-        << " event=" << GateRunManager::GetRunManager()->GetCurrentEvent()->GetEventID()
-        << " run=" << GateRunManager::GetRunManager()->GetCurrentRun()->GetRunID() << Gateendl);
+    // t = step->GetTrack()->GetProperTime() ; //tibo : which time?????
+    GateDebugMessage("Actor", 4, st << " stepPoint time proper=" << G4BestUnit(stepPoint->GetProperTime(), "Time") << " global=" << G4BestUnit(stepPoint->GetGlobalTime(), "Time") << " local=" << G4BestUnit(stepPoint->GetLocalTime(), "Time") << Gateendl);
+    GateDebugMessage("Actor", 4, "trackid=" << step->GetTrack()->GetParentID() << " event=" << GateRunManager::GetRunManager()->GetCurrentEvent()->GetEventID() << " run=" << GateRunManager::GetRunManager()->GetCurrentRun()->GetRunID() << Gateendl);
     GateDebugMessage("Actor", 4, "pos = " << x << " " << y << " " << z << Gateendl);
     GateDebugMessage("Actor", 4, "E = " << G4BestUnit(stepPoint->GetKineticEnergy(), "Energy") << Gateendl);
 
@@ -641,15 +733,18 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
     ekPost = step->GetPostStepPoint()->GetKineticEnergy();
     ekPre = step->GetPreStepPoint()->GetKineticEnergy();
 
-    Za = step->GetTrack()->GetDefinition()->GetAtomicNumber();//std::floor(stepPoint->GetCharge()+0.1);  //floor & +0.1 to avoid round off error
+    Za = step->GetTrack()->GetDefinition()->GetAtomicNumber(); // std::floor(stepPoint->GetCharge()+0.1);  //floor & +0.1 to avoid round off error
+    charge = step->GetTrack()->GetDefinition()->GetPDGCharge();
+
     m = step->GetTrack()->GetDefinition()->GetAtomicMass();
 
-    if (EnableElectronicDEDX || EnableTotalDEDX) {
-        G4Material *material = step->GetPreStepPoint()->GetMaterial();//->GetName();
+    if (EnableElectronicDEDX || EnableTotalDEDX)
+    {
+        G4Material *material = step->GetPreStepPoint()->GetMaterial(); //->GetName();
         G4double energy1 = step->GetPreStepPoint()->GetKineticEnergy();
         G4double energy2 = step->GetPostStepPoint()->GetKineticEnergy();
         G4double energy = (energy1 + energy2) / 2;
-        G4ParticleDefinition *partname = step->GetTrack()->GetDefinition();//->GetParticleName();
+        G4ParticleDefinition *partname = step->GetTrack()->GetDefinition(); //->GetParticleName();
 
         elecDEDX = emcalc->ComputeElectronicDEDX(energy, partname, material);
         stepLength = step->GetStepLength();
@@ -658,10 +753,10 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
         totalDEDX = emcalc->ComputeTotalDEDX(energy, partname, material);
     }
 
-    //elecDEDX= 1.;
-    //totalDEDX=2.;
+    // elecDEDX= 1.;
+    // totalDEDX=2.;
 
-    //G4cout << st << " " << step->GetTrack()->GetDefinition()->GetAtomicMass() << " " << step->GetTrack()->GetDefinition()->GetPDGMass() << Gateendl;
+    // G4cout << st << " " << step->GetTrack()->GetDefinition()->GetAtomicMass() << " " << step->GetTrack()->GetDefinition()->GetPDGMass() << Gateendl;
 
     //----------Process name at origin Track--------------------
     st = "";
@@ -675,58 +770,71 @@ void GatePhaseSpaceActor::UserSteppingAction(const GateVVolume *, const G4Step *
         st = stepPoint->GetProcessDefinedStep()->GetProcessName();
     strcpy(pro_step, st.c_str());
 
-    if (mFileType == "iaeaFile") {
+    if (mFileType == "iaeaFile")
+    {
 
         const G4Track *aTrack = step->GetTrack();
         int pdg = aTrack->GetDefinition()->GetPDGEncoding();
 
-        if (pdg == 22) pIAEARecordType->particle = 1; // gamma
-        else if (pdg == 11) pIAEARecordType->particle = 2; // electron
-        else if (pdg == -11) pIAEARecordType->particle = 3; // positron
-        else if (pdg == 2112) pIAEARecordType->particle = 4; // neutron
-        else if (pdg == 2212) pIAEARecordType->particle = 5; // proton
+        if (pdg == 22)
+            pIAEARecordType->particle = 1; // gamma
+        else if (pdg == 11)
+            pIAEARecordType->particle = 2; // electron
+        else if (pdg == -11)
+            pIAEARecordType->particle = 3; // positron
+        else if (pdg == 2112)
+            pIAEARecordType->particle = 4; // neutron
+        else if (pdg == 2212)
+            pIAEARecordType->particle = 5; // proton
         else
             GateError("Actor phase space: particle not available in IAEA format.");
 
         pIAEARecordType->energy = e;
 
-        if (pIAEARecordType->ix > 0) pIAEARecordType->x = localPosition.x() / cm;
-        if (pIAEARecordType->iy > 0) pIAEARecordType->y = localPosition.y() / cm;
-        if (pIAEARecordType->iz > 0) pIAEARecordType->z = localPosition.z() / cm;
+        if (pIAEARecordType->ix > 0)
+            pIAEARecordType->x = localPosition.x() / cm;
+        if (pIAEARecordType->iy > 0)
+            pIAEARecordType->y = localPosition.y() / cm;
+        if (pIAEARecordType->iz > 0)
+            pIAEARecordType->z = localPosition.z() / cm;
 
-        if (pIAEARecordType->iu > 0) pIAEARecordType->u = localMomentum.x();
-        if (pIAEARecordType->iv > 0) pIAEARecordType->v = localMomentum.y();
-        if (pIAEARecordType->iw > 0) pIAEARecordType->w = fabs(localMomentum.z()) / localMomentum.z();
+        if (pIAEARecordType->iu > 0)
+            pIAEARecordType->u = localMomentum.x();
+        if (pIAEARecordType->iv > 0)
+            pIAEARecordType->v = localMomentum.y();
+        if (pIAEARecordType->iw > 0)
+            pIAEARecordType->w = fabs(localMomentum.z()) / localMomentum.z();
 
         // G4double charge = aTrack->GetDefinition()->GetPDGCharge();
 
-        if (pIAEARecordType->iweight > 0) pIAEARecordType->weight = w;
+        if (pIAEARecordType->iweight > 0)
+            pIAEARecordType->weight = w;
 
         // pIAEARecordType->IsNewHistory = 0;  // not yet used
 
         pIAEARecordType->write_particle();
 
         pIAEAheader->update_counters(pIAEARecordType);
-
-    } else {
+    }
+    else
+    {
         mFile->fill();
     }
     mIsFirstStep = false;
 
-
     // Info will be stored so we marked the particle as killed
     if (mKillParticleFlag)
         step->GetTrack()->SetTrackStatus(fStopAndKill);
-
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::SaveData() {
+void GatePhaseSpaceActor::SaveData()
+{
     GateVActor::SaveData();
 
-    if (mFileType == "iaeaFile") {
+    if (mFileType == "iaeaFile")
+    {
         pIAEAheader->orig_histories = mNevent;
         G4String IAEAHeaderExt = ".IAEAheader";
 
@@ -737,14 +845,18 @@ void GatePhaseSpaceActor::SaveData() {
         G4String IAEAFileName = " ";
         IAEAFileName = G4String(removeExtension(mSaveFilename));
         pIAEAheader->fheader = open_file(const_cast<char *>(IAEAFileName.c_str()),
-                                         const_cast<char *>(IAEAHeaderExt.c_str()), (char *) "wb");
+                                         const_cast<char *>(IAEAHeaderExt.c_str()), (char *)"wb");
 
-        if (pIAEAheader->write_header() != OK) GateError("Phase space header not written.");
+        if (pIAEAheader->write_header() != OK)
+            GateError("Phase space header not written.");
 
         fclose(pIAEAheader->fheader);
         fclose(pIAEARecordType->p_file);
-    } else {
-        if (!this->mOverWriteFilesFlag) {
+    }
+    else
+    {
+        if (!this->mOverWriteFilesFlag)
+        {
             // Write and close only whe we know that mFile will be recreated next run
             mFile->write();
             mFile->close();
@@ -753,9 +865,9 @@ void GatePhaseSpaceActor::SaveData() {
 }
 // --------------------------------------------------------------------
 
-
 // --------------------------------------------------------------------
-void GatePhaseSpaceActor::ResetData() {
+void GatePhaseSpaceActor::ResetData()
+{
     GateError("Can't reset phase space");
 }
 // --------------------------------------------------------------------

--- a/source/digits_hits/src/GatePhaseSpaceActorMessenger.cc
+++ b/source/digits_hits/src/GatePhaseSpaceActorMessenger.cc
@@ -8,7 +8,6 @@
 
 #include "GatePhaseSpaceActorMessenger.hh"
 
-
 #include "G4UIcmdWithABool.hh"
 #include "G4UIcmdWithoutParameter.hh"
 #include "G4UIcmdWithADoubleAndUnit.hh"
@@ -17,18 +16,19 @@
 #include "G4UIcmdWith3VectorAndUnit.hh"
 #include "GatePhaseSpaceActor.hh"
 
-
 //-----------------------------------------------------------------------------
 GatePhaseSpaceActorMessenger::GatePhaseSpaceActorMessenger(GatePhaseSpaceActor *sensor)
-        : GateActorMessenger(sensor), pActor(sensor) {
+    : GateActorMessenger(sensor), pActor(sensor)
+{
     BuildCommands(baseName + sensor->GetObjectName());
 }
 //-----------------------------------------------------------------------------
 
-
 //-----------------------------------------------------------------------------
-GatePhaseSpaceActorMessenger::~GatePhaseSpaceActorMessenger() {
+GatePhaseSpaceActorMessenger::~GatePhaseSpaceActorMessenger()
+{
     delete pEnableChargeCmd;
+    delete pEnableAtomicNumberCmd;
     delete pEnableElectronicDEDXCmd;
     delete pEnableTotalDEDXCmd;
     delete pEnableMassCmd;
@@ -69,9 +69,9 @@ GatePhaseSpaceActorMessenger::~GatePhaseSpaceActorMessenger() {
 }
 //-----------------------------------------------------------------------------
 
-
 //-----------------------------------------------------------------------------
-void GatePhaseSpaceActorMessenger::BuildCommands(G4String base) {
+void GatePhaseSpaceActorMessenger::BuildCommands(G4String base)
+{
     G4String guidance;
     G4String bb;
 
@@ -80,6 +80,12 @@ void GatePhaseSpaceActorMessenger::BuildCommands(G4String base) {
     guidance = "Save electric charge of particles in the phase space file.";
     pEnableChargeCmd->SetGuidance(guidance);
     pEnableChargeCmd->SetParameterName("State", false);
+
+    bb = base + "/enableAtomicNumber";
+    pEnableAtomicNumberCmd = new G4UIcmdWithABool(bb, this);
+    guidance = "Save atomic number of particles in the phase space file.";
+    pEnableAtomicNumberCmd->SetGuidance(guidance);
+    pEnableAtomicNumberCmd->SetParameterName("State", false);
 
     bb = base + "/enableElectronicDEDX";
     pEnableElectronicDEDXCmd = new G4UIcmdWithABool(bb, this);
@@ -208,7 +214,7 @@ void GatePhaseSpaceActorMessenger::BuildCommands(G4String base) {
     bb = base + "/setMaxFileSize";
     pMaxSizeCmd = new G4UIcmdWithADoubleAndUnit(bb, this);
     guidance = G4String(
-            "Set maximum size of the phase space file. When the file reaches the maximum size, a new file is automatically created.");
+        "Set maximum size of the phase space file. When the file reaches the maximum size, a new file is automatically created.");
     pMaxSizeCmd->SetGuidance(guidance);
     pMaxSizeCmd->SetParameterName("Size", false);
     pMaxSizeCmd->SetUnitCategory("Memory size");
@@ -302,60 +308,83 @@ void GatePhaseSpaceActorMessenger::BuildCommands(G4String base) {
     guidance = "Kill particle once stored.";
     pEnableKillCmd->SetGuidance(guidance);
     pEnableKillCmd->SetParameterName("State", false);
-
 }
 //-----------------------------------------------------------------------------
 
-
 //-----------------------------------------------------------------------------
-void GatePhaseSpaceActorMessenger::SetNewValue(G4UIcommand *command, G4String param) {
-    if (command == pEnableChargeCmd) pActor->SetIsChargeEnabled(pEnableChargeCmd->GetNewBoolValue(param));
+void GatePhaseSpaceActorMessenger::SetNewValue(G4UIcommand *command, G4String param)
+{
+    if (command == pEnableChargeCmd)
+        pActor->SetIsChargeEnabled(pEnableChargeCmd->GetNewBoolValue(param));
+    if (command == pEnableAtomicNumberCmd)
+        pActor->SetIsAtomicNumberEnabled(pEnableAtomicNumberCmd->GetNewBoolValue(param));
     if (command == pEnableElectronicDEDXCmd)
         pActor->SetIsElectronicDEDXEnabled(pEnableElectronicDEDXCmd->GetNewBoolValue(param));
-    if (command == pEnableTotalDEDXCmd) pActor->SetIsTotalDEDXEnabled(pEnableTotalDEDXCmd->GetNewBoolValue(param));
-    if (command == pEnableEkineCmd) pActor->SetIsEkineEnabled(pEnableEkineCmd->GetNewBoolValue(param));
-    if (command == pEnablePositionXCmd) pActor->SetIsXPositionEnabled(pEnablePositionXCmd->GetNewBoolValue(param));
-    if (command == pEnableDirectionXCmd) pActor->SetIsXDirectionEnabled(pEnableDirectionXCmd->GetNewBoolValue(param));
-    if (command == pEnablePositionYCmd) pActor->SetIsYPositionEnabled(pEnablePositionYCmd->GetNewBoolValue(param));
-    if (command == pEnableDirectionYCmd) pActor->SetIsYDirectionEnabled(pEnableDirectionYCmd->GetNewBoolValue(param));
-    if (command == pEnablePositionZCmd) pActor->SetIsZPositionEnabled(pEnablePositionZCmd->GetNewBoolValue(param));
-    if (command == pEnableDirectionZCmd) pActor->SetIsZDirectionEnabled(pEnableDirectionZCmd->GetNewBoolValue(param));
+    if (command == pEnableTotalDEDXCmd)
+        pActor->SetIsTotalDEDXEnabled(pEnableTotalDEDXCmd->GetNewBoolValue(param));
+    if (command == pEnableEkineCmd)
+        pActor->SetIsEkineEnabled(pEnableEkineCmd->GetNewBoolValue(param));
+    if (command == pEnablePositionXCmd)
+        pActor->SetIsXPositionEnabled(pEnablePositionXCmd->GetNewBoolValue(param));
+    if (command == pEnableDirectionXCmd)
+        pActor->SetIsXDirectionEnabled(pEnableDirectionXCmd->GetNewBoolValue(param));
+    if (command == pEnablePositionYCmd)
+        pActor->SetIsYPositionEnabled(pEnablePositionYCmd->GetNewBoolValue(param));
+    if (command == pEnableDirectionYCmd)
+        pActor->SetIsYDirectionEnabled(pEnableDirectionYCmd->GetNewBoolValue(param));
+    if (command == pEnablePositionZCmd)
+        pActor->SetIsZPositionEnabled(pEnablePositionZCmd->GetNewBoolValue(param));
+    if (command == pEnableDirectionZCmd)
+        pActor->SetIsZDirectionEnabled(pEnableDirectionZCmd->GetNewBoolValue(param));
     if (command == pEnableProdProcessCmd)
         pActor->SetIsProdProcessEnabled(pEnableProdProcessCmd->GetNewBoolValue(param));
-    if (command == pEnableProdVolumeCmd) pActor->SetIsProdVolumeEnabled(pEnableProdVolumeCmd->GetNewBoolValue(param));
+    if (command == pEnableProdVolumeCmd)
+        pActor->SetIsProdVolumeEnabled(pEnableProdVolumeCmd->GetNewBoolValue(param));
     if (command == pEnableParticleNameCmd)
         pActor->SetIsParticleNameEnabled(pEnableParticleNameCmd->GetNewBoolValue(param));
-    if (command == pEnableWeightCmd) pActor->SetIsWeightEnabled(pEnableWeightCmd->GetNewBoolValue(param));
-    if (command == pEnableTimeCmd) pActor->SetIsTimeEnabled(pEnableTimeCmd->GetNewBoolValue(param));
+    if (command == pEnableWeightCmd)
+        pActor->SetIsWeightEnabled(pEnableWeightCmd->GetNewBoolValue(param));
+    if (command == pEnableTimeCmd)
+        pActor->SetIsTimeEnabled(pEnableTimeCmd->GetNewBoolValue(param));
     if (command == pEnableTimeFromBeginOfEventCmd)
         pActor->SetIsTimeFromBeginOfEventEnabled(pEnableTimeFromBeginOfEventCmd->GetNewBoolValue(param));
-    if (command == pEnableTrackLengthCmd) pActor->SetTrackLengthEnabled(pEnableTrackLengthCmd->GetNewBoolValue(param));
-    if (command == pEnableMassCmd) pActor->SetIsMassEnabled(pEnableMassCmd->GetNewBoolValue(param));
+    if (command == pEnableTrackLengthCmd)
+        pActor->SetTrackLengthEnabled(pEnableTrackLengthCmd->GetNewBoolValue(param));
+    if (command == pEnableMassCmd)
+        pActor->SetIsMassEnabled(pEnableMassCmd->GetNewBoolValue(param));
     if (command == pCoordinateInVolumeFrameCmd)
         pActor->SetUseVolumeFrame(pCoordinateInVolumeFrameCmd->GetNewBoolValue(param));
     if (command == pInOrOutGoingParticlesCmd)
         pActor->SetStoreOutgoingParticles(pInOrOutGoingParticlesCmd->GetNewBoolValue(param));
-    if (command == pEnableStoreAllStepCmd) pActor->SetIsAllStep(pEnableStoreAllStepCmd->GetNewBoolValue(param));
-    if (command == pEnableSecCmd) pActor->SetIsSecStored(pEnableSecCmd->GetNewBoolValue(param));
+    if (command == pEnableStoreAllStepCmd)
+        pActor->SetIsAllStep(pEnableStoreAllStepCmd->GetNewBoolValue(param));
+    if (command == pEnableSecCmd)
+        pActor->SetIsSecStored(pEnableSecCmd->GetNewBoolValue(param));
     if (command == pSaveEveryNEventsCmd || command == pSaveEveryNSecondsCmd)
         GateError(
-                "saveEveryNEvents and saveEveryNSeconds commands are not available with phase space actor. But you can use the setMaxFileSize command.");
-    if (command == pMaxSizeCmd) pActor->SetMaxFileSize(pMaxSizeCmd->GetNewDoubleValue(param));
+            "saveEveryNEvents and saveEveryNSeconds commands are not available with phase space actor. But you can use the setMaxFileSize command.");
+    if (command == pMaxSizeCmd)
+        pActor->SetMaxFileSize(pMaxSizeCmd->GetNewDoubleValue(param));
     if (command == bEnablePrimaryEnergyCmd)
         pActor->SetIsPrimaryEnergyEnabled(bEnablePrimaryEnergyCmd->GetNewBoolValue(param));
     if (command == bEnableEmissionPointCmd)
         pActor->SetIsEmissionPointEnabled(bEnableEmissionPointCmd->GetNewBoolValue(param));
-    if (command == bCoordinateFrameCmd) {
+    if (command == bCoordinateFrameCmd)
+    {
         pActor->SetCoordFrame(param);
         pActor->SetEnableCoordFrame();
     };
-    if (command == bEnableLocalTimeCmd) pActor->SetIsLocalTimeEnabled(bEnableLocalTimeCmd->GetNewBoolValue(param));
-    if (command == bSpotIDFromSourceCmd) {
+    if (command == bEnableLocalTimeCmd)
+        pActor->SetIsLocalTimeEnabled(bEnableLocalTimeCmd->GetNewBoolValue(param));
+    if (command == bSpotIDFromSourceCmd)
+    {
         pActor->SetSpotIDFromSource(param);
         pActor->SetIsSpotIDEnabled();
     };
-    if (command == bEnablePDGCodeCmd) pActor->SetEnablePDGCode(bEnablePDGCodeCmd->GetNewBoolValue(param));
-    if (command == bEnableCompactCmd) pActor->SetEnabledCompact(bEnableCompactCmd->GetNewBoolValue(param));
+    if (command == bEnablePDGCodeCmd)
+        pActor->SetEnablePDGCode(bEnablePDGCodeCmd->GetNewBoolValue(param));
+    if (command == bEnableCompactCmd)
+        pActor->SetEnabledCompact(bEnableCompactCmd->GetNewBoolValue(param));
     if (command == pEnableNuclearFlagCmd)
         pActor->SetIsNuclearFlagEnabled(pEnableNuclearFlagCmd->GetNewBoolValue(param));
     if (command == bEnableSphereProjection)
@@ -370,13 +399,15 @@ void GatePhaseSpaceActorMessenger::SetNewValue(G4UIcommand *command, G4String pa
     if (command == bSetTranslationAlongDirectionLength)
         pActor->SetTranslationAlongDirectionLength(bSetTranslationAlongDirectionLength->GetNewDoubleValue(param));
 
-    if (command == pEnableTOutCmd) pActor->SetIsTOutEnabled(pEnableTOutCmd->GetNewBoolValue(param));
-    if (command == pEnableTProdCmd) pActor->SetIsTProdEnabled(pEnableTProdCmd->GetNewBoolValue(param));
-    if (command == pUseMaskCmd) pActor->SetMaskFilename(param);
-    if (command == pEnableKillCmd) pActor->SetKillParticleFlag(pEnableKillCmd->GetNewBoolValue(param));
+    if (command == pEnableTOutCmd)
+        pActor->SetIsTOutEnabled(pEnableTOutCmd->GetNewBoolValue(param));
+    if (command == pEnableTProdCmd)
+        pActor->SetIsTProdEnabled(pEnableTProdCmd->GetNewBoolValue(param));
+    if (command == pUseMaskCmd)
+        pActor->SetMaskFilename(param);
+    if (command == pEnableKillCmd)
+        pActor->SetKillParticleFlag(pEnableKillCmd->GetNewBoolValue(param));
 
     GateActorMessenger::SetNewValue(command, param);
 }
 //-----------------------------------------------------------------------------
-
-

--- a/source/physics/include/GateSourcePhaseSpace.hh
+++ b/source/physics/include/GateSourcePhaseSpace.hh
@@ -6,7 +6,6 @@
   See LICENSE.md for further details
   ----------------------*/
 
-
 #ifndef GATEPHASESPACESOURCE_HH
 #define GATEPHASESPACESOURCE_HH
 
@@ -30,6 +29,7 @@
 #include "G4ThreeVector.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTable.hh"
+#include "G4IonTable.hh"
 #include "G4PrimaryVertex.hh"
 #include "G4ParticleMomentum.hh"
 #include <iomanip>
@@ -45,7 +45,8 @@
 struct iaea_record_type;
 struct iaea_header_type;
 
-class GateSourcePhaseSpace : public GateVSource {
+class GateSourcePhaseSpace : public GateVSource
+{
 public:
     GateSourcePhaseSpace(G4String name);
 
@@ -100,7 +101,8 @@ public:
 
     void SetPositionInWorldFrame(bool t) { mPositionInWorldFrame = t; }
 
-    void SetUseRegularSymmetry() {
+    void SetUseRegularSymmetry()
+    {
         if (mUseRandomSymmetry)
             GateError("You cannot use random and regular symmetry for phase space source");
         mUseRegularSymmetry = true;
@@ -108,7 +110,8 @@ public:
 
     bool GetUseRegularSymmetry() const { return mUseRegularSymmetry; }
 
-    void SetUseRandomSymmetry() {
+    void SetUseRandomSymmetry()
+    {
         if (mUseRegularSymmetry)
             GateError("You cannot use random and regular symmetry for phase space source");
         mUseRandomSymmetry = true;
@@ -117,6 +120,8 @@ public:
     bool GetUseRandomSymmetry() const { return mUseRandomSymmetry; }
 
     void SetParticleType(G4String &name) { mParticleTypeNameGivenByUser = name; }
+
+    void SetParticlePDGCode(G4int code) { mPDGCodeGivenByUser = code; }
 
     void SetUseNbOfParticleAsIntensity(bool b) { mUseNbOfParticleAsIntensity = b; }
 
@@ -196,6 +201,8 @@ protected:
     float w1;
     float w2;
 
+    G4int mPDGCode;
+    G4int mPDGCodeGivenByUser;
     char particleName[64];
     G4String mParticleTypeNameGivenByUser;
     double mParticleTime;
@@ -285,8 +292,6 @@ protected:
     torch::jit::script::Module mPTmodule;
     torch::Tensor mPTzer;
 #endif
-
 };
 
 #endif
-

--- a/source/physics/include/GateSourcePhaseSpaceMessenger.hh
+++ b/source/physics/include/GateSourcePhaseSpaceMessenger.hh
@@ -40,28 +40,30 @@ class G4UIcmdWith3VectorAndUnit;
 class G4UIcmdWithoutParameter;
 
 //----------------------------------------------------------------------------------------
-class GateSourcePhaseSpaceMessenger : public GateVSourceMessenger {
+class GateSourcePhaseSpaceMessenger : public GateVSourceMessenger
+{
 public:
-    GateSourcePhaseSpaceMessenger(GateSourcePhaseSpace *source);
+  GateSourcePhaseSpaceMessenger(GateSourcePhaseSpace *source);
 
-    ~GateSourcePhaseSpaceMessenger();
+  ~GateSourcePhaseSpaceMessenger();
 
-    void SetNewValue(G4UIcommand *, G4String);
+  void SetNewValue(G4UIcommand *, G4String);
 
 private:
-    GateSourcePhaseSpace *pSource;
-    G4UIcmdWithAString *AddFileCmd;
-    G4UIcmdWithAString *setParticleTypeCmd;
-    G4UIcmdWithoutParameter *RelativeVolumeCmd;
-    G4UIcmdWithoutParameter *RegularSymmetryCmd;
-    G4UIcmdWithoutParameter *RandomSymmetryCmd;
-    G4UIcmdWithABool *setUseNbParticleAsIntensityCmd;
-    G4UIcmdWithABool *ignoreWeightCmd;
-    G4UIcmdWithABool *RelativeTimeCmd;
-    G4UIcmdWithABool *IgnoreTimeCmd;
-    G4UIcmdWithADouble *setStartIdCmd;
-    G4UIcmdWithAnInteger *setPytorchBatchSizeCmd;
-    G4UIcmdWithAString *setPytorchParamsCmd;
+  GateSourcePhaseSpace *pSource;
+  G4UIcmdWithAString *AddFileCmd;
+  G4UIcmdWithAString *setParticleTypeCmd;
+  G4UIcmdWithoutParameter *RelativeVolumeCmd;
+  G4UIcmdWithoutParameter *RegularSymmetryCmd;
+  G4UIcmdWithoutParameter *RandomSymmetryCmd;
+  G4UIcmdWithABool *setUseNbParticleAsIntensityCmd;
+  G4UIcmdWithABool *ignoreWeightCmd;
+  G4UIcmdWithABool *RelativeTimeCmd;
+  G4UIcmdWithABool *IgnoreTimeCmd;
+  G4UIcmdWithADouble *setStartIdCmd;
+  G4UIcmdWithAnInteger *setPytorchBatchSizeCmd;
+  G4UIcmdWithAnInteger *setParticlePDGCodeCmd;
+  G4UIcmdWithAString *setPytorchParamsCmd;
 };
 //----------------------------------------------------------------------------------------
 

--- a/source/physics/src/GateSourcePhaseSpaceMessenger.cc
+++ b/source/physics/src/GateSourcePhaseSpaceMessenger.cc
@@ -25,7 +25,8 @@
 
 //----------------------------------------------------------------------------------------
 GateSourcePhaseSpaceMessenger::GateSourcePhaseSpaceMessenger(GateSourcePhaseSpace *source)
-    : GateVSourceMessenger(source), pSource(source) {
+    : GateVSourceMessenger(source), pSource(source)
+{
     G4String cmdName;
 
     cmdName = GetDirectoryName() + "addPhaseSpaceFile";
@@ -58,6 +59,11 @@ GateSourcePhaseSpaceMessenger::GateSourcePhaseSpaceMessenger(GateSourcePhaseSpac
     setParticleTypeCmd->SetGuidance("set the particle type (if not given in the PhS)");
     setParticleTypeCmd->SetParameterName("Particle Type", false);
 
+    cmdName = GetDirectoryName() + "setParticlePDGCode";
+    setParticlePDGCodeCmd = new G4UIcmdWithAnInteger(cmdName, this);
+    setParticlePDGCodeCmd->SetGuidance("set the particle type as PDGCode (if not given in the PhS)");
+    setParticlePDGCodeCmd->SetParameterName("Particle PDGCode", false);
+
     cmdName = GetDirectoryName() + "useNbOfParticleAsIntensity";
     setUseNbParticleAsIntensityCmd = new G4UIcmdWithABool(cmdName, this);
     setUseNbParticleAsIntensityCmd->SetGuidance("use the nb of particle in the PhS as source intensity");
@@ -78,18 +84,18 @@ GateSourcePhaseSpaceMessenger::GateSourcePhaseSpaceMessenger(GateSourcePhaseSpac
     setPytorchParamsCmd = new G4UIcmdWithAString(cmdName, this);
     setPytorchParamsCmd->SetGuidance("set the json file associated with the .pt PHSP");
     setPytorchParamsCmd->SetParameterName("Filename", false);
-
 }
 //----------------------------------------------------------------------------------------
 
-
 //----------------------------------------------------------------------------------------
-GateSourcePhaseSpaceMessenger::~GateSourcePhaseSpaceMessenger() {
+GateSourcePhaseSpaceMessenger::~GateSourcePhaseSpaceMessenger()
+{
     delete AddFileCmd;
     delete RelativeVolumeCmd;
     delete RegularSymmetryCmd;
     delete RandomSymmetryCmd;
     delete setParticleTypeCmd;
+    delete setParticlePDGCodeCmd;
     delete setUseNbParticleAsIntensityCmd;
     delete setStartIdCmd;
     delete setPytorchBatchSizeCmd;
@@ -100,25 +106,36 @@ GateSourcePhaseSpaceMessenger::~GateSourcePhaseSpaceMessenger() {
 }
 //----------------------------------------------------------------------------------------
 
-
 //----------------------------------------------------------------------------------------
-void GateSourcePhaseSpaceMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
+void GateSourcePhaseSpaceMessenger::SetNewValue(G4UIcommand *command, G4String newValue)
+{
     GateVSourceMessenger::SetNewValue(command, newValue);
-    if (command == AddFileCmd) pSource->AddFile(newValue);
-    if (command == RelativeVolumeCmd) pSource->SetPositionInWorldFrame(true);
-    if (command == RegularSymmetryCmd) pSource->SetUseRegularSymmetry();
-    if (command == RandomSymmetryCmd) pSource->SetUseRandomSymmetry();
-    if (command == setParticleTypeCmd) pSource->SetParticleType(newValue);
-    if (command == RelativeTimeCmd) pSource->SetRelativeTimeFlag(RelativeTimeCmd->GetNewBoolValue(newValue));
-    if (command == IgnoreTimeCmd) pSource->SetIgnoreTimeFlag(IgnoreTimeCmd->GetNewBoolValue(newValue));
+    if (command == AddFileCmd)
+        pSource->AddFile(newValue);
+    if (command == RelativeVolumeCmd)
+        pSource->SetPositionInWorldFrame(true);
+    if (command == RegularSymmetryCmd)
+        pSource->SetUseRegularSymmetry();
+    if (command == RandomSymmetryCmd)
+        pSource->SetUseRandomSymmetry();
+    if (command == setParticleTypeCmd)
+        pSource->SetParticleType(newValue);
+    if (command == setParticlePDGCodeCmd)
+        pSource->SetParticlePDGCode(setParticlePDGCodeCmd->GetNewIntValue(newValue));
+    if (command == RelativeTimeCmd)
+        pSource->SetRelativeTimeFlag(RelativeTimeCmd->GetNewBoolValue(newValue));
+    if (command == IgnoreTimeCmd)
+        pSource->SetIgnoreTimeFlag(IgnoreTimeCmd->GetNewBoolValue(newValue));
     if (command == setUseNbParticleAsIntensityCmd)
         pSource->SetUseNbOfParticleAsIntensity(setUseNbParticleAsIntensityCmd->GetNewBoolValue(newValue));
-    if (command == ignoreWeightCmd) pSource->SetIgnoreWeight(ignoreWeightCmd->GetNewBoolValue(newValue));
-    if (command == setStartIdCmd) pSource->SetStartingParticleId(setStartIdCmd->GetNewDoubleValue(newValue));
+    if (command == ignoreWeightCmd)
+        pSource->SetIgnoreWeight(ignoreWeightCmd->GetNewBoolValue(newValue));
+    if (command == setStartIdCmd)
+        pSource->SetStartingParticleId(setStartIdCmd->GetNewDoubleValue(newValue));
     if (command == setPytorchBatchSizeCmd)
         pSource->SetPytorchBatchSize(setPytorchBatchSizeCmd->GetNewIntValue(newValue));
-    if (command == setPytorchParamsCmd) pSource->SetPytorchParams(newValue);
-
+    if (command == setPytorchParamsCmd)
+        pSource->SetPytorchParams(newValue);
 }
 //----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I added support for ions in phase space source.
If the phase space contains PDGcode, the particles and now also ions are identified and used.
ions still don't work using the G4 name.

In the phase space actor I added Charge. 
So far the command enableCharge added the AtomicNumber. But this is not exactly the charge, for example for electrons the AtomicNumber is 0. 
I modified enableCharge to store the PDGchare as Charge in the phase space.
I added enableAtomicNumber to store the Atomic Number in the phase space. 