### PR TITLE
Update GateMiscFunctions.cc to prevent premature movements when using placements lists

### DIFF
--- a/source/general/src/GateMiscFunctions.cc
+++ b/source/general/src/GateMiscFunctions.cc
@@ -637,11 +637,9 @@ int GetIndexFromTime(std::vector<double> & mTimeList, double aTime) {
     i++;
   }
 
-  // Take the closest value in the time list
+  // Return the preceding (last) time update before aTime
   if(i > 0) {
-    if(fabs(mTimeList[i-1]-aTime) <= fabs(mTimeList[i]-aTime)) {
-      i--;
-    }
+    i--;
   }
 
   if ((i < 0) && (aTime < mTimeList[0])) {


### PR DESCRIPTION
When using movements with the list of placements in a text file, for a given time the geometry is now updated according to the highest preceding (past) time index defined in the list rather than the closest time (index), which may lead to (premature) movements occur earlier than the desired (list declared) time.

Question raised here https://listserv.in2p3.fr/cgi-bin/wa?A2=ind2212&L=OPENGATE-DEV-L&X=C617C8E29EB97C0CB9&Y=pmcorreia%40ua.pt&P=1302