### PR TITLE
Adding another link to getting started with ROOT

### DIFF
--- a/docs/data_output_management.rst
+++ b/docs/data_output_management.rst
@@ -329,7 +329,7 @@ to look at vectors in 3D.
 * processName: The process by which the particle ended its path in the sensitive detector (e.g.: Transportation (“T”), Optical Absorption(“O”), Comptonscatter(”C”), PhotoElectric(“P”), RaleighScattering(“R”)).  You might be interested in distinguishing between particles that are detected at the detector(“T”) and those that were absorbed(“O”). A particle that undergoes Comptonscatter(“C”) is counted as two hits when it splits up. 
 
 
-(for more information http://www-root.fnal.gov/root/GettingStarted/GettingStarted.htm)
+(for more information see https://usermanual.wiki/Document/ROOTmanualforGATEusers.1287112941/view or http://www-root.fnal.gov/root/GettingStarted/GettingStarted.htm)
 
 How to merge Root files?
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A user in the mailing proposed a document that is made for GATE user. I believe it should either be linked or hosted with the GATE documentation since ROOT is one of the main output format. Also, the previous link seems to require a login. It might be the same document, but a link without additional login seems better.