### PR TITLE
Update Generate-9.3.sh

### DIFF
--- a/source/docker/Generate-9.3.sh
+++ b/source/docker/Generate-9.3.sh
@@ -3,7 +3,7 @@
 #Variables to modify
 Repository=opengatecollaboration
 ROOT_Version=v6-24-06
-CLHEP_Version=2.4.5.1
+CLHEP_Version=2.4.6.0
 Geant4_Version=11.1.1
 Gate_Version=9.3
 


### PR DESCRIPTION
Geant complains about CLHEP 2.4.5.1. It ask specifically for version 2.4.6.0