### PR TITLE
Update GateDigitizerInitializationModule.cc

### DIFF
--- a/source/digits_hits/src/GateDigitizerInitializationModule.cc
+++ b/source/digits_hits/src/GateDigitizerInitializationModule.cc
@@ -77,6 +77,7 @@ void GateDigitizerInitializationModule::Digitize()
     	 if((*inHC)[i]->GetEdep() !=0 )
     	  {
     		  GateDigi* Digi = new GateDigi();
+    		  Digi->SetMother( (*inHC)[i] );
     		  Digi->SetRunID( (*inHC)[i]->GetRunID() );
     		  Digi->SetEventID( (*inHC)[i]->GetEventID() );
     		  Digi->SetTrackID( (*inHC)[i]->GetTrackID() );


### PR DESCRIPTION
fix singles (or other digis) not output correct systemID to npy file (probably not to other format either) due to mother hit not set