### PR TITLE
Fix spatial resolution digitizer reqiuring all levels of geometry being defined

### DIFF
--- a/source/digits_hits/src/GateSpatialResolution.cc
+++ b/source/digits_hits/src/GateSpatialResolution.cc
@@ -100,10 +100,11 @@ void GateSpatialResolution::Digitize()
 	if (m_system==NULL) G4Exception( "GateSpatialResolution::Digitize", "Digitize", FatalException,
 				 "Failed to get the system corresponding to that digitizer. Abort.\n");
 
-	if (!m_system->CheckIfAllLevelsAreDefined())
+	if (!m_system->CheckIfEnoughLevelsAreDefined())
 	{
-		 GateError( " *** ERROR*** GateSpatialResolution::Digitize. Not all required geometry levels and sublevels for this system are defined. "
-				 "(Ex.: for cylindricalPET, the required levels are: rsector, module, submodule, crystal). Please, add them to your geometry macro in /gate/systems/cylindricalPET/XXX/attach    YYY. Abort.\n");
+		 GateError( " *** ERROR*** GateSpatialResolution::Digitize. Not all defined geometry levels has their mother levels defined."
+				 "(Ex.: for cylindricalPET, the levels are: rsector, module, submodule, crystal). If you have defined submodule, you have to have resector and module defined as well."
+				 "Please, add them to your geometry macro in /gate/systems/cylindricalPET/XXX/attach    YYY. Abort.\n");
 	}
 
 	m_systemDepth = m_system->GetTreeDepth();

--- a/source/geometry/include/GateVSystem.hh
+++ b/source/geometry/include/GateVSystem.hh
@@ -174,6 +174,10 @@ class GateVSystem : public GateClockDependent
     //! Checks if all levels are defined in the system (need by readout and spatial resolution)
     G4bool CheckIfAllLevelsAreDefined();
 
+    // Checks if all the ancestors of the lowest defined level are also defined. 
+    // For spatial reslution to work with some undefined low levels.
+    G4bool CheckIfEnoughLevelsAreDefined();
+
     //! Generate the output-volumeID based on the information stored in the volumeID
     virtual GateOutputVolumeID ComputeOutputVolumeID(const GateVolumeID& aVolumeID);
 

--- a/source/geometry/src/GateVSystem.cc
+++ b/source/geometry/src/GateVSystem.cc
@@ -352,6 +352,26 @@ G4bool GateVSystem::CheckIfAllLevelsAreDefined()
 }
 //-----------------------------------------------------------------------------
 
+G4bool GateVSystem::CheckIfEnoughLevelsAreDefined()
+{
+    G4int systemDepth=this->GetTreeDepth();
+    G4bool has_undefined_high_level = false;
+    for (G4int i=1;i<systemDepth-1;i++)
+    {
+    	GateSystemComponent* comp0= (this->MakeComponentListAtLevel(i))[0][0];
+    	//G4cout<< comp0->GetObjectName()<<G4endl;
+
+    	if (!comp0->GetCreator())
+      {
+        if (!has_undefined_high_level)
+          has_undefined_high_level = true;
+      }
+      else if (has_undefined_high_level)
+        return false;
+    }
+
+  return true;
+}
 
 //-----------------------------------------------------------------------------
 GateVSystem::compList_t* GateVSystem::MakeComponentListAtLevel(G4int level) const

--- a/source/geometry/src/GateVSystem.cc
+++ b/source/geometry/src/GateVSystem.cc
@@ -358,18 +358,19 @@ G4bool GateVSystem::CheckIfEnoughLevelsAreDefined()
     G4bool has_undefined_high_level = false;
     for (G4int i=1;i<systemDepth-1;i++)
     {
-    	GateSystemComponent* comp0= (this->MakeComponentListAtLevel(i))[0][0];
+      auto compList = this->MakeComponentListAtLevel(i);
+    	GateSystemComponent* comp0= compList[0][0];
     	if (!comp0->GetCreator())
       {
         if (!has_undefined_high_level)
           has_undefined_high_level = true;
-        delete comp0;
       }
       else if (has_undefined_high_level)
       {
-        delete comp0;
+        delete compList;
         return false;
       }
+      delete compList;
     }
 
   return true;

--- a/source/geometry/src/GateVSystem.cc
+++ b/source/geometry/src/GateVSystem.cc
@@ -359,15 +359,17 @@ G4bool GateVSystem::CheckIfEnoughLevelsAreDefined()
     for (G4int i=1;i<systemDepth-1;i++)
     {
     	GateSystemComponent* comp0= (this->MakeComponentListAtLevel(i))[0][0];
-    	//G4cout<< comp0->GetObjectName()<<G4endl;
-
     	if (!comp0->GetCreator())
       {
         if (!has_undefined_high_level)
           has_undefined_high_level = true;
+        delete comp0;
       }
       else if (has_undefined_high_level)
+      {
+        delete comp0;
         return false;
+      }
     }
 
   return true;


### PR DESCRIPTION
Fix spatial resolution digitizer reqiuring all levels of geometry being defined. Now it only requires all defined geometry has their mother defined.

based on discuss in issue #608 