### PR TITLE
Add mixmaxrng

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -627,7 +627,7 @@ time duration, the last line of your program has to be **exit**.
 As a Monte Carlo tool, GATE needs a random generator. The CLHEP libraries
 provide various ones. Four different random engines are currently available in
 GATE, Ranlux64, James Random, MixMaxRng (default random engine in Geant4), and Mersenne Twister. The default random
-engine in GATE is Mersenne Twister, but this can be changed easily using::
+engine in GATE is James Random, but this can be changed easily using::
 
   /gate/random/setEngineName aName    (where aName can be: Ranlux64, JamesRandom, MixMaxRng, or MersenneTwister)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -625,11 +625,11 @@ If you want to exit from the Gate program when the simulation time exceed the
 time duration, the last line of your program has to be **exit**.
 
 As a Monte Carlo tool, GATE needs a random generator. The CLHEP libraries
-provide various ones. Three different random engines are currently available in
-GATE, the Ranlux64, the James Random and the Mersenne Twister. The default one
-is the Mersenne Twister, but this can be changed easily using::
+provide various ones. Four different random engines are currently available in
+GATE, Ranlux64, James Random, MixMaxRng (default random engine in Geant4), and Mersenne Twister. The default random
+engine in GATE is Mersenne Twister, but this can be changed easily using::
 
-  /gate/random/setEngineName aName    (where aName can be: Ranlux64, JamesRandom, or MersenneTwister)
+  /gate/random/setEngineName aName    (where aName can be: Ranlux64, JamesRandom, MixMaxRng, or MersenneTwister)
 
 **NB** Several users have reported artifacts in PET data when using the Ranlux64
 generator. These users have said that the artifacts are not present in data

--- a/source/general/src/GateRandomEngine.cc
+++ b/source/general/src/GateRandomEngine.cc
@@ -11,6 +11,7 @@
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Random/RandomEngine.h"
 #include "CLHEP/Random/JamesRandom.h"
+#include "CLHEP/Random/MixMaxRng.h"
 #include "CLHEP/Random/MTwistEngine.h"
 #include "CLHEP/Random/Ranlux64Engine.h"
 #include <ctime>
@@ -72,6 +73,10 @@ void GateRandomEngine::SetRandomEngine(const G4String& aName) {
   else if (aName=="MersenneTwister") {
     delete theRandomEngine;
     theRandomEngine = new CLHEP::MTwistEngine();
+  }
+  else if (aName=="MixMaxRng") {
+      delete theRandomEngine;
+      theRandomEngine = new CLHEP::MixMaxRng();
   }
   else {
 		G4String msg = "Unknown random engine '"+aName+"'. Computation aborted !!!\n";


### PR DESCRIPTION
Add MixMaxRng as an option to the list of random engines. MixMaxRng is the default Geant4 RNG since version 10.4. Note that the default GATE RNG (JamesRandom) is not changed.