### PR TITLE
make sure energy resolution has a initial value

### DIFF
--- a/source/digits_hits/src/GateEnergyResolution.cc
+++ b/source/digits_hits/src/GateEnergyResolution.cc
@@ -95,7 +95,7 @@ void GateEnergyResolution::Digitize()
 
 	GateDigi* inputDigi;
 
-	G4double reso;
+	G4double reso = 0;
 
   if (IDC)
      {


### PR DESCRIPTION
Energy resolution digitizer may malfunction and generate bizzare energy value under certain circumstances. It all due to the fact that if resolution is set to 0, then the function will use a unitialized auto variable `reso`. Gate does not forbid a zero input of resolution, therefore it should guarantee to generate a correct value