### PR TITLE
Delete dangling digits throughout the code

### DIFF
--- a/source/digits_hits/include/GatePileup.hh
+++ b/source/digits_hits/include/GatePileup.hh
@@ -83,6 +83,7 @@ protected:
   G4double m_Pileup;
   std::vector< GateDigi* >* m_waiting;
   G4bool m_firstEvent;
+  GateDigiCollection* m_tempDigiCollection;
 
 
 private:

--- a/source/digits_hits/src/GateAdderComptPhotIdeal.cc
+++ b/source/digits_hits/src/GateAdderComptPhotIdeal.cc
@@ -114,6 +114,7 @@ void GateAdderComptPhotIdeal::Digitize()
     			}
     		else
     		{
+    			delete m_outputDigi;
     			if(inputDigi->GetPostStepProcess()!="Transportation")
     				m_flgEvtRej=1;
     		}
@@ -241,6 +242,7 @@ void GateAdderComptPhotIdeal::Digitize()
 
 
     	    }
+    	    delete m_outputDigi;
     	}
 
 
@@ -248,6 +250,10 @@ void GateAdderComptPhotIdeal::Digitize()
 
 
     	}
+#ifdef GATE_USE_OPTICAL
+    else
+        delete m_outputDigi;
+#endif
 	  } //loop  over input digits
     } //IDC
   else

--- a/source/digits_hits/src/GateCCSinglesFileReader.cc
+++ b/source/digits_hits/src/GateCCSinglesFileReader.cc
@@ -146,6 +146,7 @@ G4int GateCCSinglesFileReader::PrepareNextEvent( )
         GateDigi* aSingleDigi=m_singleBuffer.CreateSingle();
          // OK GND 2022 TODO: uncomment for CC when no pulse list
         // pList->push_back(&aSingleDigi->GetPulse());
+        delete aSingleDigi;
 
       // Load the next set of Singles-data into the root-Singles structure
       LoadSinglesData();

--- a/source/digits_hits/src/GateDigitizerInitializationModule.cc
+++ b/source/digits_hits/src/GateDigitizerInitializationModule.cc
@@ -132,6 +132,7 @@ void GateDigitizerInitializationModule::Digitize()
     		        	G4cout << "[GateDigitizerInitializationModule::Digitize]: \n"
     		  	       << "\tprocessed " << *(*inHC)[i] << Gateendl
     		  	       << "\tcreated new Digi:\n"
+    		  	       << Digi << Gateendl
     		  	       << *Digi << Gateendl;
 */
     		  m_outputDigiCollection->insert(Digi);

--- a/source/digits_hits/src/GateEfficiency.cc
+++ b/source/digits_hits/src/GateEfficiency.cc
@@ -169,6 +169,8 @@ void GateEfficiency::Digitize()
 		   {
 			   m_OutputDigiCollection->insert(m_outputDigi);
 		   }
+          else
+              delete m_outputDigi;
 
 
 	  }

--- a/source/digits_hits/src/GateEnergyFraming.cc
+++ b/source/digits_hits/src/GateEnergyFraming.cc
@@ -120,7 +120,6 @@ void GateEnergyFraming::Digitize()
 				  G4cout << "[GateEnergyFraming::Digitize]Ignored digi with energy above uphold:\n"
 				  << *inputDigi << Gateendl << Gateendl ;
 				  
-			  else
 			  	delete m_outputDigi;	  
 		      }
 

--- a/source/digits_hits/src/GateMultipleRejection.cc
+++ b/source/digits_hits/src/GateMultipleRejection.cc
@@ -101,22 +101,26 @@ void GateMultipleRejection::Digitize()
 		  {
 			if(m_multipleDef==kvolumeID)
 			{
-				if ( std::find(m_VolumeIDs.begin(), m_VolumeIDs.end(), currentVolumeID) != m_VolumeIDs.end() )
+				if ( std::find(m_VolumeIDs.begin(), m_VolumeIDs.end(), currentVolumeID) != m_VolumeIDs.end() ) {
+				    delete m_outputDigi;
 					return;
+				}
 				else
 					m_OutputDigiCollection->insert(m_outputDigi);
 			}
 			else
 			{
+				delete m_outputDigi;
 				if (std::find(m_VolumeNames.begin(), m_VolumeNames.end(), currentVolumeName) != m_VolumeNames.end() )
 					return;
-
 			}
 		  }
 		else
 			{
 				if (n_digi==1) //save if only one digi
 					m_OutputDigiCollection->insert(m_outputDigi);
+				else
+					delete m_outputDigi;
 
 			}
 

--- a/source/digits_hits/src/GateNoise.cc
+++ b/source/digits_hits/src/GateNoise.cc
@@ -116,10 +116,9 @@ void GateNoise::Digitize()
 		    	//      G4cout<< Gateendl;
 		    	digi->SetOutputVolumeID(outputVol);
 
-		    	GateVolumeID* volID = system->MakeVolumeID(outputVol);
-		    	digi->SetVolumeID(*volID);
-		    	digi->SetGlobalPos(system->ComputeObjectCenter(volID));
-		    	delete volID;
+		    	GateVolumeID volID = system->MakeVolumeID(outputVol);
+		    	digi->SetVolumeID(volID);
+		    	digi->SetGlobalPos(system->ComputeObjectCenter(&volID));
 
 		    	digi->SetEventID(-2);
 
@@ -145,6 +144,9 @@ void GateNoise::Digitize()
 			m_OutputDigiCollection->insert(new GateDigi(*inputDigi));
 
 		   	  } //loop  over input digits
+				  for (const GateDigi* d : m_createdDigis) {
+				          delete d;
+				            }
     } //IDC
   else
     {
@@ -161,13 +163,12 @@ void GateNoise::Digitize()
 G4double GateNoise::ComputeStartTime(GateDigiCollection* IDC)
 {
 
-  	GateDigi* digi = new GateDigi();
+  	GateDigi* digi = NULL; //= new GateDigi();
 
   	std::vector< GateDigi* >* IDCVector = IDC->GetVector ();
   	std::vector<GateDigi*>::iterator iter;
 
   	G4double startTime = DBL_MAX;
-  	digi=0;
   	for (iter = IDCVector->begin(); iter < IDCVector->end() ; ++iter) {
   		if ( (*iter)->GetTime() < startTime ){
   			startTime  = (*iter)->GetTime();

--- a/source/digits_hits/src/GatePileup.cc
+++ b/source/digits_hits/src/GatePileup.cc
@@ -54,15 +54,15 @@ GatePileup::GatePileup(GateSinglesDigitizer *digitizer, G4String name)
 	collectionName.push_back(colName);
 	m_Messenger = new GatePileupMessenger(this);
 
-	GateDigiCollection* tempDigiCollection = new GateDigiCollection(GetName(), m_digitizer-> GetOutputName()); // to create the Digi Collection
-	m_waiting = tempDigiCollection->GetVector ();
+	m_tempDigiCollection = new GateDigiCollection(GetName(), m_digitizer-> GetOutputName()); // to create the Digi Collection
+	m_waiting = m_tempDigiCollection->GetVector ();
 }
 
 
 GatePileup::~GatePileup()
 {
   delete m_Messenger;
-
+  delete m_tempDigiCollection;
 }
 
 

--- a/source/geometry/include/GateVSystem.hh
+++ b/source/geometry/include/GateVSystem.hh
@@ -219,7 +219,7 @@ class GateVSystem : public GateClockDependent
     size_t ComputeIdFromVolID(const GateOutputVolumeID& volID,std::vector<G4bool>& enableList) const;
     //G4ThreeVector ComputeObjectCenter(const std::vector<G4int>& numList) const;
     G4ThreeVector ComputeObjectCenter(const GateVolumeID* volID) const;
-    GateVolumeID* MakeVolumeID(const std::vector<G4int>& numList) const;
+    GateVolumeID MakeVolumeID(const std::vector<G4int>& numList) const;
   public:
     typedef std::vector< GateSystemComponent* > compList_t;
     compList_t* MakeComponentListAtLevel(G4int level) const;

--- a/source/geometry/include/GateVolumeID.hh
+++ b/source/geometry/include/GateVolumeID.hh
@@ -76,7 +76,7 @@ class GateVolumeSelector
       - Transfer a position from a volume's reference frame into another volume's reference frame
       - Return a "daughterID" for each level
 */      
-class GateVolumeID : public std::vector<GateVolumeSelector>
+class GateVolumeID
 {
   public:
 
@@ -90,6 +90,18 @@ class GateVolumeID : public std::vector<GateVolumeSelector>
     GateVolumeID(G4int *daughterID, size_t arraySize);
 
     virtual inline ~GateVolumeID() {}
+
+  public: // vector interface
+    inline size_t size() const { return storage.size(); }
+    inline std::vector<GateVolumeSelector>::iterator begin() { return storage.begin(); }
+    inline std::vector<GateVolumeSelector>::const_iterator begin() const { return storage.begin(); }
+    inline std::vector<GateVolumeSelector>::iterator insert( std::vector<GateVolumeSelector>::iterator position, const GateVolumeSelector& val) {
+        return storage.insert(position, val);
+    }
+    inline GateVolumeSelector& operator[] (size_t n) { return storage[n]; }
+    inline const GateVolumeSelector& operator[] (size_t n) const { return storage[n]; }
+    inline friend bool operator==(const GateVolumeID& lhs, const GateVolumeID& rhs) { return lhs.storage == rhs.storage; }
+    inline void push_back (const GateVolumeSelector& val) { storage.push_back(val); }
 
   public:
     inline G4bool IsValid() const     { return size()!=0; }   	    //!< Returns true for a valid (i.e. not empty) volumeID
@@ -184,10 +196,12 @@ class GateVolumeID : public std::vector<GateVolumeSelector>
 
     //! Printing methods
     friend std::ostream& operator<<(std::ostream&, const GateVolumeID& volumeID);    
+
+  protected:
+    std::vector<GateVolumeSelector> storage;
 };
 
 inline GateVolumeID::GateVolumeID()
- : std::vector<GateVolumeSelector>()
 {}
 
 

--- a/source/geometry/src/GateVSystem.cc
+++ b/source/geometry/src/GateVSystem.cc
@@ -451,14 +451,14 @@ size_t GateVSystem::ComputeIdFromVolID(const GateOutputVolumeID& volID,std::vect
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-GateVolumeID* GateVSystem::MakeVolumeID(const std::vector<G4int>& numList) const
+GateVolumeID GateVSystem::MakeVolumeID(const std::vector<G4int>& numList) const
 {
   GateSystemComponent* comp = GetBaseComponent();
   if (!comp) return 0;
   G4VPhysicalVolume *vol=comp->GetPhysicalVolume(0), *last_vol=vol;
-  GateVolumeID* ans = new GateVolumeID;
-  ans->push_back( GateVolumeSelector(GateDetectorConstruction::GetGateDetectorConstruction()->GetWorldVolume()));
-  if (vol) ans->push_back( GateVolumeSelector(vol)); else return ans;
+  GateVolumeID ans;
+  ans.push_back( GateVolumeSelector(GateDetectorConstruction::GetGateDetectorConstruction()->GetWorldVolume()));
+  if (vol) ans.push_back( GateVolumeSelector(vol)); else return ans;
    
   for (size_t i=1;i<numList.size();++i){
     if (comp->GetChildNumber()<1) break;
@@ -484,14 +484,14 @@ GateVolumeID* GateVSystem::MakeVolumeID(const std::vector<G4int>& numList) const
           for (unsigned int ii=0;ii<logical->GetNoDaughters();++ii){
             last_vol=logical->GetDaughter(ii);
             if (last_vol->GetLogicalVolume()->IsAncestor(vol)) {
-              ans->push_back(last_vol);
+              ans.push_back(last_vol);
               pb=false;
               break;
             }
           }
           if (pb) return ans; // no last_vol child is ancestor of vol...
         } else {
-          ans->push_back(vol);
+          ans.push_back(vol);
           last_vol=vol;
           break;
         }


### PR DESCRIPTION
- Dodałem delete tam gdzie digit był tworzony a następnie nie jest zapisywany w DigitCollection
- Gdzie się dało zamieniłem na alokowanie zmiennych na stosie
- Przepisałem GateVolumeID tak by używał kompozycji, oryginalnie dziedziczył po std::vector co nie jest dobrą praktyką skoro std::vector nie ma wirtualnego destruktora. Ponieważ był memory leak miałem podejrzenie że może gdzieś ktoś trzyma wskaźnik jako typ `*std::vector` i to generuje problemy. W efekcie nic się nie zmieniło. Myślę że można założyć że nie jest tu używany polimorfizm, więc się nie upieram żeby zostawić tą zmianę.