### PR TITLE
Document spatial resolution history in ROOT output

### DIFF
--- a/docs/digitizer_and_detector_modeling.rst
+++ b/docs/digitizer_and_detector_modeling.rst
@@ -581,6 +581,11 @@ BEWARE : The file for 2D Distribution  should be structured such that:
   15 9.42 6.53 3.15 6.32 9.71
   30 9.42 7.45 6.25 7.32 9.74
 
+**IMPORTANT!** It is possible to keep the history of the spatial resolution for each Singles and Coincidences. It is availble for the moment only in ROOT output with a command:: 
+
+  /gate/output/root/SpRes2DStdDevOutput 1
+
+
 Energy Framing
 ^^^^^^^^^^^^^^
 *Previously Thresholder and Upholder*

--- a/docs/digitizer_and_detector_modeling.rst
+++ b/docs/digitizer_and_detector_modeling.rst
@@ -581,7 +581,7 @@ BEWARE : The file for 2D Distribution  should be structured such that:
   15 9.42 6.53 3.15 6.32 9.71
   30 9.42 7.45 6.25 7.32 9.74
 
-**IMPORTANT!** It is possible to keep the history of the spatial resolution for each Singles and Coincidences. It is availble for the moment only in ROOT output with a command:: 
+**IMPORTANT!** It is possible to keep the history of the spatial resolution for each Singles and Coincidences. It is availble for the moment only in ROOT output (:ref:`data_output_management.html#root-output`) with a command:: 
 
   /gate/output/root/SpRes2DStdDevOutput 1
 


### PR DESCRIPTION
Added note about keeping history of spatial resolution for Singles and Coincidences in ROOT output.